### PR TITLE
Add github workflow to publish docker image

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,19 @@
+name: Publish Docker image
+on:
+  push:
+    branches: main
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: City-of-Helsinki/haitaton-ui/haitaton-ui-image
+          tag_with_ref: true


### PR DESCRIPTION
Add workflow to publish docker image to Github Packages.
https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-docker-images