### PR TITLE
HAI-21 old Dockerfile --> Dockerfile-dev. New Dockerfile and ci.yml t…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
       - run: yarn test
       - run: yarn lint
       - run: yarn type-check
+      - name: Upload application files for Docker build job
+        if: ${{ github.ref == 'refs/heads/dev' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: haitaton-ui-build
+          path: build
+          retention-days: 1
   e2e:
     runs-on: ubuntu-16.04
     steps:
@@ -31,13 +38,45 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/dev' }}
     steps:
-      - name: Check out the repo
+      -
+        name: Check out the repo
         uses: actions/checkout@v2
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+      -
+        name: Download application files
+        uses: actions/download-artifact@v2
         with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: docker.pkg.github.com
-          repository: city-of-helsinki/haitaton-ui/haitaton-ui-image
-          tag_with_ref: true
+          name: haitaton-ui-build
+      -
+        name: List files after checkout
+        shell: bash
+        run: |
+          ls -ltra
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to OpenShift Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.RHSA_USERNAME }}
+          password: ${{ secrets.RHSA_TOKEN }}
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.CR_OWNER }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/city-of-helsinki/haitaton/haitaton-ui:latest
+            ghcr.io/city-of-helsinki/haitaton/haitaton-ui:dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,62 +1,7 @@
-# ===============================================
-FROM helsinkitest/node:12-slim as staticbuilder
-# ===============================================
-
-# Offical image has npm log verbosity as info. More info - https://github.com/nodejs/docker-node#verbosity
-ENV NPM_CONFIG_LOGLEVEL warn
-
-# set our node environment, either development or production
-# defaults to production, compose overrides this to development on build and run
-ARG NODE_ENV=production
-ENV NODE_ENV $NODE_ENV
-
-# Yarn
-ENV YARN_VERSION 1.19.1
-RUN yarn policies set-version $YARN_VERSION
-
-USER root
-RUN apt-install.sh build-essential
-
-# Use non-root user
-USER appuser
-
-# Install dependencies
-COPY --chown=appuser:appuser package.json yarn.lock /app/
-RUN yarn && yarn cache clean --force
-
-USER root
-RUN apt-cleanup.sh build-essential
-
-# Copy all files
-COPY --chown=appuser:appuser . .
-
-# Build application
-RUN yarn build
-
-# =============================
-FROM nginx:1.19 as production
-# =============================
-
-# Copy static build
-COPY --from=staticbuilder --chown=nginx:nginx /app/build /usr/share/nginx/html
-
-# Copy nginx config
+FROM registry.redhat.io/rhel8/nginx-116
+COPY ./build /usr/share/nginx/html
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
-
-# Env-script and .env file
 WORKDIR /usr/share/nginx/html
-# COPY ./scripts/env.sh .
 COPY .env .
-
-# Add bash
-RUN apt-get update
-RUN apt-get install bash
-
-# Make script executable
-# RUN chmod +x env.sh
-
-USER nginx
-
 CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]
-
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.redhat.io/rhel8/nginx-116
+EXPOSE 8000
 COPY ./build /usr/share/nginx/html
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 WORKDIR /usr/share/nginx/html
 COPY .env .
 CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]
-EXPOSE 8000

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,62 @@
+# ===============================================
+FROM helsinkitest/node:12-slim as staticbuilder
+# ===============================================
+
+# Offical image has npm log verbosity as info. More info - https://github.com/nodejs/docker-node#verbosity
+ENV NPM_CONFIG_LOGLEVEL warn
+
+# set our node environment, either development or production
+# defaults to production, compose overrides this to development on build and run
+ARG NODE_ENV=production
+ENV NODE_ENV $NODE_ENV
+
+# Yarn
+ENV YARN_VERSION 1.19.1
+RUN yarn policies set-version $YARN_VERSION
+
+USER root
+RUN apt-install.sh build-essential
+
+# Use non-root user
+USER appuser
+
+# Install dependencies
+COPY --chown=appuser:appuser package.json yarn.lock /app/
+RUN yarn && yarn cache clean --force
+
+USER root
+RUN apt-cleanup.sh build-essential
+
+# Copy all files
+COPY --chown=appuser:appuser . .
+
+# Build application
+RUN yarn build
+
+# =============================
+FROM nginx:1.19 as production
+# =============================
+
+# Copy static build
+COPY --from=staticbuilder --chown=nginx:nginx /app/build /usr/share/nginx/html
+
+# Copy nginx config
+COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
+
+# Env-script and .env file
+WORKDIR /usr/share/nginx/html
+# COPY ./scripts/env.sh .
+COPY .env .
+
+# Add bash
+RUN apt-get update
+RUN apt-get install bash
+
+# Make script executable
+# RUN chmod +x env.sh
+
+USER nginx
+
+CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]
+
+EXPOSE 8000

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,3 @@
-user  nginx;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;


### PR DESCRIPTION
…o use the once builded application and Red Hat base image and GitHub Container Registry

NOTICE! I am not sure whether the ci.yml builds the application quite the same way as the old Dockerfile did (renamed it to Dockerfile-dev now for keeping it still there) - maybe it needs some adjustments. Also, I am not 100% sure actions/upload-artifact@v2 works correctly and copies build folder so that it can be downloaded in docker-build-step. This might need more than one iteration in order to get it right...