### PR TITLE
HAI-181 added dockerfile-local for docker-compose to use

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,0 +1,12 @@
+FROM node:12-alpine as staticbuilder
+ADD --chown=node:node . /builder/
+WORKDIR /builder
+RUN yarn && yarn cache clean --force
+RUN yarn build
+
+FROM registry.redhat.io/rhel8/nginx-116
+EXPOSE 8000
+COPY --from=staticbuilder ./builder/build /usr/share/nginx/html
+COPY --from=staticbuilder ./builder/nginx/nginx.conf /etc/nginx/nginx.conf
+WORKDIR /usr/share/nginx/html
+CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]


### PR DESCRIPTION
In this branch, a local dockerfile was added in order to build the site in a container such that it can be used in docker-compose in the future.

To test (without docker-compose):

1. Login to RedHat customer portal 
`docker login registry.redhat.io 
`
(If you do not have an account, you can create it at https://access.redhat.com/)
Note the username you need to use in docker login is not your email, there is a
username, you can find out in your profile in customer portal)
2. Build the image
`docker build -t haitaton-ui -f Dockerfile-local .`
3. Run the image
`docker run -d -p 8000:8000 -t haitaton-ui`
4. Go to localhost:8000 

(Note: This is just to test the dockerfile, the upcoming backend pr will add
docker-compose file as well. If you want to test that, pull the HAI-181 branch
from backend repo alongside with this one and check the backend readme for instructions)