### PR TITLE
HAI-298: Hankkeen muokkaus-sivu

### DIFF
--- a/cypress/integration/editHankePage.spec.ts
+++ b/cypress/integration/editHankePage.spec.ts
@@ -23,6 +23,7 @@ context('EditHankePage', () => {
   });
 
   it('Editing hanke should fetch and populate form data', () => {
+    cy.get('[data-testid=save-draft-button]').should('be.disabled');
     cy.get('input[data-testid=nimi]').should('have.value', savedHanke.nimi);
     // Type something to make form dirty and enable save-draft-button
     cy.get('textarea[data-testid=kuvaus]')

--- a/cypress/integration/editHankePage.spec.ts
+++ b/cypress/integration/editHankePage.spec.ts
@@ -1,0 +1,34 @@
+/// <reference types="cypress" />
+
+const savedHanke = {
+  hankeTunnus: 'HAI-testi',
+  nimi: 'nimi',
+  kuvaus: 'kuvaus',
+  alkuPvm: '10.01.2032',
+  loppuPvm: '11.01.2032',
+  osoite: 'Mannerheimintie 22',
+  vaihe: 'OHJELMOINTI',
+};
+
+context('EditHankePage', () => {
+  beforeEach(() => {
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/api/hankkeet/HAI-testi',
+      },
+      savedHanke
+    );
+    cy.visit(`/fi/hanke/${savedHanke.hankeTunnus}`);
+  });
+
+  it('Editing hanke should fetch and populate form data', () => {
+    cy.get('input[data-testid=nimi]').should('have.value', savedHanke.nimi);
+    // Type something to make form dirty and enable save-draft-button
+    cy.get('textarea[data-testid=kuvaus]')
+      .clear()
+      .type('Uusi kuvaus')
+      .should('have.value', 'Uusi kuvaus');
+    cy.get('[data-testid=save-draft-button]').should('not.be.disabled');
+  });
+});

--- a/cypress/integration/form.spec.ts
+++ b/cypress/integration/form.spec.ts
@@ -12,7 +12,7 @@ const osoite = 'Mannerheimintie 22';
 
 context('HankeForm', () => {
   beforeEach(() => {
-    cy.visit('/fi/form');
+    cy.visit('/fi/hanke/uusi');
   });
 
   it('Hanke form testing', () => {

--- a/src/common/components/header/Header.tsx
+++ b/src/common/components/header/Header.tsx
@@ -11,7 +11,7 @@ import './Header.styles.scss';
 
 const Header: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
-  const { HOME, MAP, PROJECTS, FORM } = useLocalizedRoutes();
+  const { HOME, MAP, PROJECTS, NEW_HANKE } = useLocalizedRoutes();
   const { i18n, t } = useTranslation();
   const isAuthenticated = authService.isAuthenticated();
 
@@ -54,7 +54,7 @@ const Header: React.FC = () => {
             {t('authentication:loginButton')}
           </NavLink>
         )}
-        <NavLink to={FORM.path} className="header__hankeLink" data-testid="hankeLink">
+        <NavLink to={NEW_HANKE.path} className="header__hankeLink" data-testid="hankeLink">
           <Locale id="header:hankeLink" />
         </NavLink>
       </Navigation.Row>

--- a/src/common/routes/LocaleRoutes.tsx
+++ b/src/common/routes/LocaleRoutes.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { Language } from '../types/language';
-import ProjectsPage from '../../pages/ProjectsPage';
+import HankeListPage from '../../pages/HankeListPage';
 import MapPage from '../../pages/MapPage';
-import ProjectPage from '../../pages/ProjectPage';
+import NewHankePage from '../../pages/NewHankePage';
+import EditHankePage from '../../pages/EditHankePage';
 import HomePage from '../../pages/HomePage';
 import {
   useLocalizedRoutes,
@@ -26,7 +27,7 @@ const LocaleRoutes: React.FC<Props> = ({
 }) => {
   const history = useHistory();
   const { i18n, t } = useTranslation();
-  const { HOME, FORM, PROJECTS, MAP } = useLocalizedRoutes();
+  const { HOME, NEW_HANKE, EDIT_HANKE, PROJECTS, MAP } = useLocalizedRoutes();
   const { language: currentLocale } = i18n;
 
   // Update language when route param changes
@@ -36,6 +37,8 @@ const LocaleRoutes: React.FC<Props> = ({
 
   // Redirect when user changes langauge
   React.useEffect(() => {
+    // return if nothing changed
+    if (currentLocale === localeParam) return;
     i18n.changeLanguage(currentLocale);
     const redirectPath = getRouteLocalization({
       t,
@@ -46,13 +49,14 @@ const LocaleRoutes: React.FC<Props> = ({
     });
 
     history.push(redirectPath);
-  }, [currentLocale]);
+  }, [currentLocale, localeParam]);
 
   return (
     <Switch>
       <Route exact path={HOME.path} component={HomePage} />
-      <Route exact path={FORM.path} component={ProjectPage} />
-      <Route exact path={PROJECTS.path} component={ProjectsPage} />
+      <Route exact path={NEW_HANKE.path} component={NewHankePage} />
+      <Route exact path={EDIT_HANKE.path} component={EditHankePage} />
+      <Route exact path={PROJECTS.path} component={HankeListPage} />
       <Route exact path={MAP.path} component={MapPage} />
     </Switch>
   );

--- a/src/common/types/route.ts
+++ b/src/common/types/route.ts
@@ -2,7 +2,8 @@ export enum ROUTES {
   PROJECTS = 'PROJECTS',
   HOME = 'HOME',
   MAP = 'MAP',
-  FORM = 'FORM',
+  NEW_HANKE = 'NEW_HANKE',
+  EDIT_HANKE = 'EDIT_HANKE',
 }
 
 export type Route = keyof typeof ROUTES;

--- a/src/domain/hanke/edit/FormContainer.tsx
+++ b/src/domain/hanke/edit/FormContainer.tsx
@@ -1,21 +1,48 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { useQuery } from 'react-query';
 import { actions as dialogActions } from '../../../common/components/confirmationDialog/reducer';
-import { HANKE_SAVETYPE } from '../../types/hanke';
+import { HANKE_SAVETYPE, HankeDataDraft } from '../../types/hanke';
 import { getHasFormChanged, getFormData, getShowNotification } from './selectors';
 import { saveForm } from './thunks';
 import { saveGeometryData } from '../../map/thunks';
 import HankeForm from './Form';
 import { actions, hankeDataDraft } from './reducer';
 import { SaveFormArguments } from './types';
+import { convertHankeDataToFormState } from './utils';
 
-const HankeFormContainer = () => {
+import api from '../../../common/utils/api';
+
+const getHanke = async (hankeTunnus?: string) => {
+  const { data } = await api.get<HankeDataDraft>(`/hankkeet/${hankeTunnus}`);
+  return data;
+};
+
+const useHanke = (hankeTunnus?: string) =>
+  useQuery<HankeDataDraft>(['hanke'], () => getHanke(hankeTunnus), {
+    enabled: !!hankeTunnus,
+  });
+
+type Props = {
+  hankeTunnus?: string;
+};
+
+const HankeFormContainer: React.FC<Props> = ({ hankeTunnus }) => {
   const dispatch = useDispatch();
   const history = useHistory();
   const hasFormChanged = useSelector(getHasFormChanged());
   const formData = useSelector(getFormData());
   const showNotification = useSelector(getShowNotification());
+
+  const { data: hankeData, isFetched } = useHanke(hankeTunnus);
+
+  useEffect(() => {
+    // Update fetched hankeData to redux
+    if (hankeTunnus && isFetched && hankeData) {
+      dispatch(actions.updateFormData(convertHankeDataToFormState(hankeData)));
+    }
+  }, [isFetched]);
 
   const handleSave = ({ data, formPage }: SaveFormArguments) => {
     dispatch(
@@ -27,8 +54,8 @@ const HankeFormContainer = () => {
     );
   };
 
-  const handleSaveGeometry = (hankeTunnus: string) => {
-    dispatch(saveGeometryData({ hankeTunnus }));
+  const handleSaveGeometry = (id: string) => {
+    dispatch(saveGeometryData({ hankeTunnus: id }));
   };
 
   const handleIsDirtyChange = (isDirty: boolean) => {

--- a/src/domain/hanke/edit/utils.ts
+++ b/src/domain/hanke/edit/utils.ts
@@ -1,4 +1,4 @@
-import { HankeContact } from '../../types/hanke';
+import { HankeContact, HankeDataDraft } from '../../types/hanke';
 import { FORMFIELD, HankeDataFormState } from './types';
 
 const isContactEmpty = ({ etunimi, sukunimi, email }: HankeContact) =>
@@ -11,4 +11,11 @@ export const filterEmptyContacts = (hankeData: HankeDataFormState): HankeDataFor
   [FORMFIELD.ARVIOIJAT]: hankeData[FORMFIELD.ARVIOIJAT]?.filter((v) => !isContactEmpty(v)) || [],
   [FORMFIELD.TOTEUTTAJAT]:
     hankeData[FORMFIELD.TOTEUTTAJAT]?.filter((v) => !isContactEmpty(v)) || [],
+});
+
+export const convertHankeDataToFormState = (hankeData: HankeDataDraft): HankeDataFormState => ({
+  ...hankeData,
+  omistajat: hankeData.omistajat ? hankeData.omistajat : [],
+  arvioijat: hankeData.arvioijat ? hankeData.arvioijat : [],
+  toteuttajat: hankeData.toteuttajat ? hankeData.toteuttajat : [],
 });

--- a/src/domain/hanke/list/HankeListComponent.tsx
+++ b/src/domain/hanke/list/HankeListComponent.tsx
@@ -17,7 +17,7 @@ type Props = {
 };
 
 const Projects: React.FC<Props> = ({ initialData }) => {
-  const { FORM } = useLocalizedRoutes();
+  const { NEW_HANKE } = useLocalizedRoutes();
 
   const { t } = useTranslation();
   const columns = React.useMemo(
@@ -57,7 +57,7 @@ const Projects: React.FC<Props> = ({ initialData }) => {
       <div className="hankelista__inner">
         <Table columns={columns} data={initialData || []} />
         <div className="hankelista__buttonWpr">
-          <NavLink data-testid="toFormLink" to={FORM.path} className="hankelista__hankeLink">
+          <NavLink data-testid="toFormLink" to={NEW_HANKE.path} className="hankelista__hankeLink">
             <Locale id="header:hankeLink" />
           </NavLink>
         </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -62,11 +62,18 @@
         "title": "EN::Haitaton 2.0 - Kartta"
       }
     },
-    "FORM": {
-      "path": "/form",
-      "headerLabel": "EN::Kaavake",
+    "NEW_HANKE": {
+      "path": "/hanke/new",
+      "headerLabel": "EN:Hanke",
       "meta": {
-        "title": "EN::Haitaton 2.0 - Kaavake"
+        "title": "EN:Haitaton 2.0 - Luo uusi hanke"
+      }
+    },
+    "EDIT_HANKE": {
+      "path": "/hanke/:hankeTunnus",
+      "headerLabel": "EN:Hanke",
+      "meta": {
+        "title": "EN:Haitaton 2.0 - Hankkeen muokkaus"
       }
     }
   },

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -62,11 +62,18 @@
         "title": "Haitaton 2.0 - Kartta"
       }
     },
-    "FORM": {
-      "path": "/form",
-      "headerLabel": "Kaavake",
+    "NEW_HANKE": {
+      "path": "/hanke/uusi",
+      "headerLabel": "Hanke",
       "meta": {
-        "title": "Haitaton 2.0 - Kaavake"
+        "title": "Haitaton 2.0 - Luo uusi hanke"
+      }
+    },
+    "EDIT_HANKE": {
+      "path": "/hanke/:hankeTunnus",
+      "headerLabel": "Hanke",
+      "meta": {
+        "title": "Haitaton 2.0 - Hankkeen muokkaus"
       }
     }
   },

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -62,11 +62,18 @@
         "title": "SV::Haitaton 2.0 - Kartta"
       }
     },
-    "FORM": {
-      "path": "/form",
-      "headerLabel": "SV::Kaavake",
+    "NEW_HANKE": {
+      "path": "/hanke/uusi",
+      "headerLabel": "SV:Hanke",
       "meta": {
-        "title": "SV::Haitaton 2.0 - Kaavake"
+        "title": "SV:Haitaton 2.0 - Luo uusi hanke"
+      }
+    },
+    "EDIT_HANKE": {
+      "path": "/hanke/:hankeTunnus",
+      "headerLabel": "SV:Hanke",
+      "meta": {
+        "title": "SV: Haitaton 2.0 - Hankkeen muokkaus"
       }
     }
   },

--- a/src/pages/EditHankePage.tsx
+++ b/src/pages/EditHankePage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import Container from '../common/components/container/Container';
+import PageMeta from './components/PageMeta';
+import { useLocalizedRoutes } from '../common/hooks/useLocalizedRoutes';
+import HankeFormContainer from '../domain/hanke/edit/FormContainer';
+
+interface Params {
+  hankeTunnus: string;
+}
+
+type Props = RouteComponentProps<Params>;
+
+const HankeFormPage: React.FC<Props> = ({
+  match: {
+    params: { hankeTunnus },
+  },
+}) => {
+  const { EDIT_HANKE } = useLocalizedRoutes();
+
+  return (
+    <Container>
+      <PageMeta routeData={EDIT_HANKE} />
+      <HankeFormContainer hankeTunnus={hankeTunnus} />
+    </Container>
+  );
+};
+
+export default HankeFormPage;

--- a/src/pages/HankeListPage.tsx
+++ b/src/pages/HankeListPage.tsx
@@ -4,17 +4,15 @@ import PageMeta from './components/PageMeta';
 import { useLocalizedRoutes } from '../common/hooks/useLocalizedRoutes';
 import HankeListContainer from '../domain/hanke/list/HankeListContainer';
 
-const ProjectListPage: React.FC = () => {
+const HankeListPage: React.FC = () => {
   const { PROJECTS } = useLocalizedRoutes();
 
   return (
-    <>
-      <Container>
-        <PageMeta routeData={PROJECTS} />
-        <HankeListContainer />
-      </Container>
-    </>
+    <Container>
+      <PageMeta routeData={PROJECTS} />
+      <HankeListContainer />
+    </Container>
   );
 };
 
-export default ProjectListPage;
+export default HankeListPage;

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -4,11 +4,11 @@ import PageMeta from './components/PageMeta';
 import HankeMap from '../domain/map/HankeMap';
 
 const MapPage: React.FC = () => {
-  const { FORM } = useLocalizedRoutes();
+  const { MAP } = useLocalizedRoutes();
 
   return (
     <>
-      <PageMeta routeData={FORM} />
+      <PageMeta routeData={MAP} />
       <HankeMap />
     </>
   );

--- a/src/pages/NewHankePage.tsx
+++ b/src/pages/NewHankePage.tsx
@@ -4,17 +4,15 @@ import PageMeta from './components/PageMeta';
 import { useLocalizedRoutes } from '../common/hooks/useLocalizedRoutes';
 import HankeFormContainer from '../domain/hanke/edit/FormContainer';
 
-const MapPage: React.FC = () => {
-  const { MAP } = useLocalizedRoutes();
+const NewHankePage: React.FC = () => {
+  const { NEW_HANKE } = useLocalizedRoutes();
 
   return (
-    <>
-      <Container>
-        <PageMeta routeData={MAP} />
-        <HankeFormContainer />
-      </Container>
-    </>
+    <Container>
+      <PageMeta routeData={NEW_HANKE} />
+      <HankeFormContainer />
+    </Container>
   );
 };
 
-export default MapPage;
+export default NewHankePage;


### PR DESCRIPTION
- Uusi sivu /fi/hanke/:hankeTunnus, eli testaamaan pääset syöttämällä tallennetun hankkeen hanketunnuksen urliin.
- Toteutuksessa hyödynnetään lähes täysin hankkeen luomiseen tarkoitettua koodia
- Käynnissä olevan hankkeen validointi menee hieman sekaisin, koska hankkeen alku -ja loppupäivät voivat olla ennen tätä päivää. Validointi ei ilmoita näistä, koska validointi laukaistaan vain onBlur-eventissä
- Piti tehdä konversio HankeDataDraft->HankeDataFormState koska HankeDataDraftissa yhteystietotyypit voivat olla arvoltaan undefined.