### PR TITLE
HAI-629: Use access_token in request headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "npm run react-spring-issue-1078",
     "start": "PORT=3001 react-scripts start",
     "build": "react-scripts build",
-    "serve": "ws --spa index.html -d build -p 3001",
+    "serve": "REACT_APP_ENV=e2e ws --spa index.html -d build -p 3001 --rewrite '/api/(.*) -> http://localhost:3000/api/$1'",
     "build-and-serve": "yarn run build && yarn run serve",
     "test": "DEBUG_PRINT_LIMIT=50000 react-scripts test --env=jest-environment-jsdom-sixteen",
     "testCI": "CI=true react-scripts test --env=jest-environment-jsdom-sixteen",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "npm run react-spring-issue-1078",
     "start": "PORT=3001 react-scripts start",
     "build": "react-scripts build",
-    "serve": "ws --spa index.html -d build -p 3001 --rewrite '/api/(.*) -> http://localhost:3000/api/$1'",
+    "serve": "ws --spa index.html -d build -p 3001",
     "build-and-serve": "yarn run build && yarn run serve",
     "test": "DEBUG_PRINT_LIMIT=50000 react-scripts test --env=jest-environment-jsdom-sixteen",
     "testCI": "CI=true react-scripts test --env=jest-environment-jsdom-sixteen",
@@ -18,7 +18,7 @@
     "ts-check:cypress": "tsc --noEmit --project ./cypress/tsconfig.json",
     "lint": "yarn ts-check:cypress && yarn ts-check && eslint --ext js,ts,tsx src cypress",
     "lint:css": "stylelint 'src/**/*.scss'",
-    "e2e": "start-server-and-test start :3001 cypress-run-chrome",
+    "e2e": "REACT_APP_ENV=e2e start-server-and-test start :3001 cypress-run-chrome",
     "cypress-run-chrome": "cypress run --browser chrome",
     "cypress-run-chrome-headless": "cypress run --headless --browser chrome"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "npm run react-spring-issue-1078",
     "start": "PORT=3001 react-scripts start",
     "build": "react-scripts build",
-    "serve": "REACT_APP_ENV=e2e ws --spa index.html -d build -p 3001 --rewrite '/api/(.*) -> http://localhost:3000/api/$1'",
+    "serve": "ws --spa index.html -d build -p 3001 --rewrite '/api/(.*) -> http://localhost:3000/api/$1'",
     "build-and-serve": "yarn run build && yarn run serve",
     "test": "DEBUG_PRINT_LIMIT=50000 react-scripts test --env=jest-environment-jsdom-sixteen",
     "testCI": "CI=true react-scripts test --env=jest-environment-jsdom-sixteen",
@@ -18,7 +18,7 @@
     "ts-check:cypress": "tsc --noEmit --project ./cypress/tsconfig.json",
     "lint": "yarn ts-check:cypress && yarn ts-check && eslint --ext js,ts,tsx src cypress",
     "lint:css": "stylelint 'src/**/*.scss'",
-    "e2e": "REACT_APP_ENV=e2e start-server-and-test start :3001 cypress-run-chrome",
+    "e2e": "start-server-and-test start :3001 cypress-run-chrome",
     "cypress-run-chrome": "cypress run --browser chrome",
     "cypress-run-chrome-headless": "cypress run --headless --browser chrome"
   },

--- a/src/common/components/app/Layout.tsx
+++ b/src/common/components/app/Layout.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import Header from '../header/Header';
 import Footer from '../footer/Footer';
 import ConfirmationDialog from '../confirmationDialog/ConfirmationDialog';

--- a/src/common/routes/AppRoutes.tsx
+++ b/src/common/routes/AppRoutes.tsx
@@ -5,9 +5,26 @@ import useLocale from '../hooks/useLocale';
 import Login from '../../domain/auth/components/Login';
 import OidcCallback from '../../domain/auth/components/OidcCallback';
 import { LOGIN_CALLBACK_PATH, LOGIN_PATH } from '../../domain/auth/constants';
+import useAuth from '../../domain/auth/useAuth';
 import LocaleRoutes from './LocaleRoutes';
 
 const localeParam = `:locale(${Object.values(LANGUAGES).join('|')})`;
+
+type Props = {
+  path: string;
+  component: React.ElementType;
+};
+
+const PrivateRoute: React.FC<Props> = ({ component: Component, ...rest }) => {
+  const { isAuthenticated } = useAuth();
+
+  return (
+    <Route
+      {...rest}
+      render={(props) => (isAuthenticated ? <Component {...props} /> : <p>Kirjaudu sisään</p>)}
+    />
+  );
+};
 
 const AppRoutes: React.FC = () => {
   const currentLocale = useLocale();
@@ -17,7 +34,7 @@ const AppRoutes: React.FC = () => {
       <Redirect exact path="/" to={`/${currentLocale}`} />
       <Route exact path={LOGIN_PATH} component={Login} />
       <Route exact path={LOGIN_CALLBACK_PATH} component={OidcCallback} />
-      <Route path={`/${localeParam}`} component={LocaleRoutes} />
+      <PrivateRoute path={`/${localeParam}`} component={LocaleRoutes} />
       <Route render={() => <Redirect to={`/${currentLocale}`} />} />
     </Switch>
   );

--- a/src/common/routes/AppRoutes.tsx
+++ b/src/common/routes/AppRoutes.tsx
@@ -21,7 +21,12 @@ const PrivateRoute: React.FC<Props> = ({ component: Component, ...rest }) => {
   return (
     <Route
       {...rest}
-      render={(props) => (isAuthenticated ? <Component {...props} /> : <p>Kirjaudu sisään</p>)}
+      render={(props) => (
+        <div>
+          {!isAuthenticated && <p>Kirjaudu sisään</p>}
+          <Component {...props} />
+        </div>
+      )}
     />
   );
 };

--- a/src/domain/api/api.ts
+++ b/src/domain/api/api.ts
@@ -1,10 +1,24 @@
-import axios, { AxiosInstance, AxiosResponse, AxiosError } from 'axios';
+import axios, { AxiosInstance, AxiosResponse, AxiosRequestConfig, AxiosError } from 'axios';
+import { LOCALSTORAGE_OIDC_KEY } from '../auth/constants';
 
 const api: AxiosInstance = axios.create({
   baseURL: '/api',
 });
 
 api.defaults.headers.post['Content-Type'] = 'application/json';
+
+api.interceptors.request.use(
+  (config: AxiosRequestConfig) => {
+    const oidcStorage = localStorage.getItem(LOCALSTORAGE_OIDC_KEY);
+    if (oidcStorage) {
+      const token = JSON.parse(oidcStorage).access_token;
+      // eslint-disable-next-line no-param-reassign
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error: AxiosError) => Promise.reject(error)
+);
 
 api.interceptors.response.use(
   // eslint-disable-next-line

--- a/src/domain/auth/authService.ts
+++ b/src/domain/auth/authService.ts
@@ -1,5 +1,5 @@
 import { UserManager, User, UserManagerSettings, Log, WebStorageStateStore } from 'oidc-client';
-import { LOGIN_CALLBACK_PATH } from './constants';
+import { LOGIN_CALLBACK_PATH, LOCALSTORAGE_OIDC_KEY } from './constants';
 
 const { origin } = window.location;
 
@@ -56,8 +56,7 @@ export class AuthService {
 
   // eslint-disable-next-line
   public isAuthenticated(): boolean {
-    const userKey = `oidc.user:${process.env.REACT_APP_OIDC_AUTHORITY}:${process.env.REACT_APP_OIDC_CLIENT_ID}`;
-    const oidcStorage = localStorage.getItem(userKey);
+    const oidcStorage = localStorage.getItem(LOCALSTORAGE_OIDC_KEY);
 
     return !!oidcStorage && !!JSON.parse(oidcStorage).access_token;
   }

--- a/src/domain/auth/constants.ts
+++ b/src/domain/auth/constants.ts
@@ -1,2 +1,4 @@
 export const LOGIN_PATH = '/login';
 export const LOGIN_CALLBACK_PATH = '/login_callback';
+
+export const LOCALSTORAGE_OIDC_KEY = `oidc.user:${process.env.REACT_APP_OIDC_AUTHORITY}:${process.env.REACT_APP_OIDC_CLIENT_ID}`;

--- a/src/domain/auth/useAuth.ts
+++ b/src/domain/auth/useAuth.ts
@@ -23,19 +23,23 @@ export interface Profile {
 /* eslint-enable  */
 
 interface AuthState {
-  profile: Profile | null;
+  profile: Partial<Profile> | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   error: Error | null;
 }
 
 function useProfile(): AuthState {
-  const [profile, setProfile] = React.useState<Profile | null>(null);
+  // Temporary hack to bybass auth in e2e tests
+  const [profile, setProfile] = React.useState<Partial<Profile> | null>(
+    process.env.REACT_APP_ENV === 'e2e' ? {} : null
+  );
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [error, setError] = React.useState<Error | null>(null);
 
   React.useEffect(() => {
-    let ignore = false;
+    // Temporary hack to bybass auth in e2e tests
+    let ignore = process.env.REACT_APP_ENV === 'e2e';
 
     function getUser() {
       setIsLoading(true);

--- a/src/domain/auth/useAuth.ts
+++ b/src/domain/auth/useAuth.ts
@@ -1,0 +1,83 @@
+import React from 'react';
+import authService from './authService';
+
+/* eslint-disable camelcase */
+export interface Profile {
+  acr: string;
+  auth_time: number;
+  authorities: 'ROLE_offline_access' | 'ROLE_uma_authorization' | 'ROLE_haitaton-user';
+  azp: 'haitaton-ui';
+  email: string;
+  email_verified: boolean;
+  family_name: string;
+  given_name: string;
+  jti: '64dc4fd9-56e3-40ed-8358-ccfa32bb2036';
+  name: string;
+  preferred_username: string;
+  s_hash: string;
+  session_state: string;
+  sub: string;
+  typ: 'ID';
+  user_name: string;
+}
+/* eslint-enable  */
+
+interface AuthState {
+  profile: Profile | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+function useProfile(): AuthState {
+  const [profile, setProfile] = React.useState<Profile | null>(null);
+  const [isLoading, setIsLoading] = React.useState<boolean>(false);
+  const [error, setError] = React.useState<Error | null>(null);
+
+  React.useEffect(() => {
+    let ignore = false;
+
+    function getUser() {
+      setIsLoading(true);
+
+      authService
+        .getUser()
+        .then((user) => {
+          if (ignore) {
+            return;
+          }
+
+          setProfile(user ? ((user.profile as unknown) as Profile) : null);
+        })
+        .catch(() => {
+          if (ignore) {
+            return;
+          }
+
+          setError(Error('User was not found'));
+        })
+        .finally(() => {
+          if (ignore) {
+            return;
+          }
+
+          setIsLoading(false);
+        });
+    }
+
+    getUser();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  return {
+    profile,
+    isAuthenticated: !!profile,
+    isLoading,
+    error,
+  };
+}
+
+export default useProfile;

--- a/src/domain/auth/useAuth.ts
+++ b/src/domain/auth/useAuth.ts
@@ -30,16 +30,12 @@ interface AuthState {
 }
 
 function useProfile(): AuthState {
-  // Temporary hack to bybass auth in e2e tests
-  const [profile, setProfile] = React.useState<Partial<Profile> | null>(
-    process.env.REACT_APP_ENV === 'e2e' ? {} : null
-  );
+  const [profile, setProfile] = React.useState<Partial<Profile> | null>(null);
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [error, setError] = React.useState<Error | null>(null);
 
   React.useEffect(() => {
-    // Temporary hack to bybass auth in e2e tests
-    let ignore = process.env.REACT_APP_ENV === 'e2e';
+    let ignore = false;
 
     function getUser() {
       setIsLoading(true);

--- a/src/domain/hanke/edit/Form2.tsx
+++ b/src/domain/hanke/edit/Form2.tsx
@@ -7,7 +7,7 @@ import { TextInput } from 'hds-react';
 import { CONTACT_FORMFIELD, FormProps, HankeDataFormState, Organization } from './types';
 import { HANKE_CONTACT_TYPE } from '../../types/hanke';
 
-import api from '../../../common/utils/api';
+import api from '../../api/api';
 import { getInputErrorText } from '../../../common/utils/form';
 import H2 from '../../../common/components/text/H2';
 import H3 from '../../../common/components/text/H3';

--- a/src/domain/hanke/edit/FormContainer.tsx
+++ b/src/domain/hanke/edit/FormContainer.tsx
@@ -12,7 +12,7 @@ import { actions, hankeDataDraft } from './reducer';
 import { SaveFormArguments } from './types';
 import { convertHankeDataToFormState } from './utils';
 
-import api from '../../../common/utils/api';
+import api from '../../api/api';
 
 const getHanke = async (hankeTunnus?: string) => {
   const { data } = await api.get<HankeDataDraft>(`/hankkeet/${hankeTunnus}`);

--- a/src/domain/hanke/edit/thunks.ts
+++ b/src/domain/hanke/edit/thunks.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import api from '../../../common/utils/api';
+import api from '../../api/api';
 import { HankeDataFormState } from './types';
 import { HANKE_SAVETYPE_KEY } from '../../types/hanke';
 import { saveGeometryData } from '../../map/thunks';

--- a/src/domain/hanke/list/HankeListContainer.tsx
+++ b/src/domain/hanke/list/HankeListContainer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useQuery } from 'react-query';
 import HankeListComponent from './HankeListComponent';
-import api from '../../../common/utils/api';
+import api from '../../api/api';
 import { HankeDataDraft } from '../../types/hanke';
 
 const getHankkeet = async () => {

--- a/src/domain/map/HankeDrawerContainer.tsx
+++ b/src/domain/map/HankeDrawerContainer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
-import api from '../../common/utils/api';
+import api from '../api/api';
 import { HankeGeometria } from '../types/hanke';
 import HankeDrawer from './HankeDrawer';
 

--- a/src/domain/map/HankeMapContainer.tsx
+++ b/src/domain/map/HankeMapContainer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useQuery } from 'react-query';
 import { HankeData } from '../types/hanke';
-import api from '../../common/utils/api';
+import api from '../api/api';
 import HankeMapComponent from './HankeMapComponent';
 
 const getProjectsWithGeometry = async () => {

--- a/src/domain/map/thunks.ts
+++ b/src/domain/map/thunks.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { ReducerState, HankeGeometryApiRequestData, HankeGeometryApiResponseData } from './types';
-import api from '../../common/utils/api';
+import api from '../api/api';
 
 type SaveGeometryArguments = {
   hankeTunnus: string;

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -16,7 +16,7 @@ module.exports = function (app) {
   app.use(
     '/auth',
     createProxyMiddleware({
-      target: 'http://localhost:3001',
+      target: 'http://localhost:3030',
       changeOrigin: true,
     })
   );


### PR DESCRIPTION
Tämä on kevyt toteutus jossa on tehty vain pakolliset asiat kirjautumisen ja API-kutsujen testaamiseksi. Puuttuu ainakin vielä tokenin uudistaminen, tallentaminen turvallisesti ja testit.