### PR TITLE
Hai 647 - Hankkeiden geometriadatat yhdelle VectorLayerille

### DIFF
--- a/src/domain/map/HankeMapComponent.tsx
+++ b/src/domain/map/HankeMapComponent.tsx
@@ -18,8 +18,6 @@ import { MapDataLayerKey, MapTileLayerId } from './types';
 import { HankeData } from '../types/hanke';
 
 type Props = {
-  loadingProjects: boolean;
-  loadingProjectsError: boolean;
   projectsData: HankeData[];
 };
 
@@ -37,11 +35,7 @@ const geometryStyle = {
   }),
 };
 
-const HankeMapComponent: React.FC<Props> = ({
-  loadingProjects,
-  loadingProjectsError,
-  projectsData,
-}) => {
+const HankeMapComponent: React.FC<Props> = ({ projectsData }) => {
   const { dataLayers, mapTileLayers, toggleDataLayer, toggleMapTileLayer } = useMapDataLayers();
   const {
     hankeFilterStartDate,

--- a/src/domain/map/HankeMapComponent.tsx
+++ b/src/domain/map/HankeMapComponent.tsx
@@ -21,7 +21,7 @@ import { HankeData } from '../types/hanke';
 type Props = {
   loadingProjects: boolean;
   loadingProjectsError: boolean;
-  projectsData: AxiosResponse<HankeData[]> | undefined;
+  projectsData: HankeData[] | undefined;
 };
 
 // Temporary reference style implementation. Actual colors
@@ -54,8 +54,8 @@ const HankeMapComponent: React.FC<Props> = ({
   const [zoom] = useState(9); // TODO: also take zoom into consideration
 
   const hankkeetFilteredByAll =
-    (!loadingProjects || loadingProjectsError) && projectsData && Array.isArray(projectsData.data)
-      ? projectsData.data.filter(
+    (!loadingProjects || loadingProjectsError) && projectsData && Array.isArray(projectsData)
+      ? projectsData.filter(
           byAllHankeFilters({ startDate: hankeFilterStartDate, endDate: hankeFilterEndDate })
         )
       : [];

--- a/src/domain/map/HankeMapContainer.tsx
+++ b/src/domain/map/HankeMapContainer.tsx
@@ -17,12 +17,13 @@ const useProjectsWithGeometry = () => useQuery(['projectsWithGeometry'], getProj
 
 const HankeMapContainer: React.FC = () => {
   const { isLoading, isError, data } = useProjectsWithGeometry();
+  const projectsData = data ? data.data : [];
 
   return (
     <HankeMapComponent
       loadingProjects={isLoading}
       loadingProjectsError={isError}
-      projectsData={data}
+      projectsData={projectsData}
     />
   );
 };

--- a/src/domain/map/HankeMapContainer.tsx
+++ b/src/domain/map/HankeMapContainer.tsx
@@ -16,16 +16,10 @@ const getProjectsWithGeometry = async () => {
 const useProjectsWithGeometry = () => useQuery(['projectsWithGeometry'], getProjectsWithGeometry);
 
 const HankeMapContainer: React.FC = () => {
-  const { isLoading, isError, data } = useProjectsWithGeometry();
+  const { data } = useProjectsWithGeometry();
   const projectsData = data ? data.data : [];
 
-  return (
-    <HankeMapComponent
-      loadingProjects={isLoading}
-      loadingProjectsError={isError}
-      projectsData={projectsData}
-    />
-  );
+  return <HankeMapComponent projectsData={projectsData} />;
 };
 
 export default HankeMapContainer;

--- a/src/domain/map/Map.test.tsx
+++ b/src/domain/map/Map.test.tsx
@@ -11,7 +11,7 @@ describe('Map tile layers can be controlled by layercontrol and share the same s
   test('Map tile layer toggled control changes when clicked', async () => {
     render(
       <Provider store={store}>
-        <HankeMapComponent loadingProjects={false} loadingProjectsError={false} projectsData={[]} />
+        <HankeMapComponent projectsData={[]} />
       </Provider>
     );
 
@@ -43,7 +43,7 @@ describe('Map tile layers can be controlled by layercontrol and share the same s
 
     const { getByTestId } = render(
       <Provider store={store}>
-        <HankeMapComponent loadingProjects={false} loadingProjectsError={false} projectsData={[]} />
+        <HankeMapComponent projectsData={[]} />
       </Provider>
     );
 

--- a/src/domain/map/Map.test.tsx
+++ b/src/domain/map/Map.test.tsx
@@ -11,11 +11,7 @@ describe('Map tile layers can be controlled by layercontrol and share the same s
   test('Map tile layer toggled control changes when clicked', async () => {
     render(
       <Provider store={store}>
-        <HankeMapComponent
-          loadingProjects={false}
-          loadingProjectsError={false}
-          projectsData={undefined}
-        />
+        <HankeMapComponent loadingProjects={false} loadingProjectsError={false} projectsData={[]} />
       </Provider>
     );
 
@@ -47,11 +43,7 @@ describe('Map tile layers can be controlled by layercontrol and share the same s
 
     const { getByTestId } = render(
       <Provider store={store}>
-        <HankeMapComponent
-          loadingProjects={false}
-          loadingProjectsError={false}
-          projectsData={undefined}
-        />
+        <HankeMapComponent loadingProjects={false} loadingProjectsError={false} projectsData={[]} />
       </Provider>
     );
 


### PR DESCRIPTION
Hankkeiden geometriadatat refaktoroidaan yhdelle VectorLayerille hankkeen klikkausta varten.

Muuten jouduttaisiin looppaamaan kaikkien Mapin vectorLayerit lävitse ja kysellä jokaiselta vectorLayeriltä osuiko pikseli johonkin sen Layerin geometriaan. Nyt pelkästään kysytään sitä yhdeltä Layeriltä kuten kuuluisikin.