### PR TITLE
Hai 582 - Geometriaa klikkaamalla selaimen osoitteeseen päivittyy hankeTunnus

### DIFF
--- a/src/common/components/map/interactions/FeatureClick.tsx
+++ b/src/common/components/map/interactions/FeatureClick.tsx
@@ -20,6 +20,8 @@ const HankeClick: React.FC = () => {
               history.push({
                 search: `?hanke=${hankeTunnus}`,
               });
+              const extent = feature.getGeometry()?.getExtent();
+              if (extent) map?.getView().fit(extent, { padding: [150, 100, 100, 300] });
               return true;
             });
           }

--- a/src/common/components/map/interactions/HankeClick.tsx
+++ b/src/common/components/map/interactions/HankeClick.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useContext } from 'react';
+import { MapBrowserEvent } from 'ol';
+import OLVectorLayer from 'ol/layer/Vector';
+import { useHistory } from 'react-router-dom';
+import MapContext from '../MapContext';
+import { MapInstance } from '../types';
+
+const HankeClick: React.FC = () => {
+  const { map } = useContext(MapContext);
+
+  const history = useHistory();
+
+  const selectHanke = (mapInstance: MapInstance, evt: MapBrowserEvent<UIEvent>) => {
+    mapInstance?.getLayers().forEach((BaseLayer) => {
+      if (BaseLayer instanceof OLVectorLayer) {
+        BaseLayer.getFeatures(evt.pixel).then((features) => {
+          if (features.length > 0) {
+            features.some((feature) => {
+              const hankeTunnus = feature.get('hankeTunnus');
+              history.push({
+                search: `?hanke=${hankeTunnus}`,
+              });
+              return true;
+            });
+          }
+        });
+      }
+    });
+  };
+
+  useEffect(() => {
+    if (map)
+      map.on('click', (evt) => {
+        selectHanke(map, evt);
+      });
+  }, [map]);
+
+  return null;
+};
+
+export default HankeClick;

--- a/src/domain/map/HankeMap.tsx
+++ b/src/domain/map/HankeMap.tsx
@@ -16,6 +16,7 @@ import { useMapDataLayers } from './hooks/useMapLayers';
 import { useDateRangeFilter } from './hooks/useDateRangeFilter';
 import { MapTileLayerId } from './types';
 import { HankeData } from '../types/hanke';
+import HankeClick from '../../common/components/map/interactions/HankeClick';
 
 type Props = {
   projectsData: HankeData[];
@@ -78,6 +79,7 @@ const HankeMap: React.FC<Props> = ({ projectsData }) => {
         <Map zoom={zoom} mapClassName={styles.mapContainer__inner}>
           {mapTileLayers.ortokartta.visible && <Ortokartta />}
           {mapTileLayers.kantakartta.visible && <Kantakartta />}
+          <HankeClick />
 
           <VectorLayer
             source={hankeSources.current.features}

--- a/src/domain/map/HankeMap.tsx
+++ b/src/domain/map/HankeMap.tsx
@@ -16,7 +16,7 @@ import { useMapDataLayers } from './hooks/useMapLayers';
 import { useDateRangeFilter } from './hooks/useDateRangeFilter';
 import { MapTileLayerId } from './types';
 import { HankeData } from '../types/hanke';
-import HankeClick from '../../common/components/map/interactions/HankeClick';
+import FeatureClick from '../../common/components/map/interactions/FeatureClick';
 
 type Props = {
   projectsData: HankeData[];
@@ -79,7 +79,7 @@ const HankeMap: React.FC<Props> = ({ projectsData }) => {
         <Map zoom={zoom} mapClassName={styles.mapContainer__inner}>
           {mapTileLayers.ortokartta.visible && <Ortokartta />}
           {mapTileLayers.kantakartta.visible && <Kantakartta />}
-          <HankeClick />
+          <FeatureClick />
 
           <VectorLayer
             source={hankeSources.current.features}


### PR DESCRIPTION
Kun geometriaa klikataan hankekartalla selaimen URI-queryparametri "hanke" muutetaan vastaamaan polygonista löytynyttä "hankeTunnus" arvoa.

Tämä on rajapinta hankkeen tarkempien tietojen sivupaneelin avaamiselle.