### PR TITLE
Hai 584 - Sivupalkista voi klikata hankkeen muokkaussivulle

### DIFF
--- a/src/domain/hanke/edit/Form.test.tsx
+++ b/src/domain/hanke/edit/Form.test.tsx
@@ -52,7 +52,7 @@ describe('HankeForm', () => {
     fireEvent.change(getByLabelText('Hankkeen loppupäivä', { exact: false }), {
       target: { value: loppuPvm },
     });
-    queryAllByText('Hankeen Vaihe')[0].click();
+    queryAllByText('Hankkeen Vaihe')[0].click();
     queryAllByText('Ohjelmointi')[0].click();
     expect(handleIsDirtyChange).toHaveBeenCalledTimes(2);
     await waitFor(() => expect(getByTestId('forward')).not.toBeDisabled());
@@ -136,7 +136,7 @@ describe('HankeForm', () => {
       target: { value: loppuPvm },
     });
 
-    queryAllByText('Hankeen Vaihe')[0].click();
+    queryAllByText('Hankkeen Vaihe')[0].click();
     queryAllByText('Suunnittelu')[0].click();
 
     await waitFor(() => expect(getByTestId('forward')).toBeDisabled());
@@ -175,7 +175,7 @@ describe('HankeForm', () => {
       target: { value: loppuPvm },
     });
 
-    queryAllByText('Hankeen Vaihe')[0].click();
+    queryAllByText('Hankkeen Vaihe')[0].click();
     queryAllByText('Ohjelmointi')[0].click();
 
     await waitFor(() => expect(getByTestId('forward')).not.toBeDisabled());
@@ -253,7 +253,7 @@ describe('HankeForm', () => {
     fireEvent.change(getByLabelText('Hankkeen loppupäivä', { exact: false }), {
       target: { value: loppuPvm },
     });
-    queryAllByText('Hankeen Vaihe')[0].click();
+    queryAllByText('Hankkeen Vaihe')[0].click();
     queryAllByText('Ohjelmointi')[0].click();
 
     getByText('Tallenna luonnos').click();

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
@@ -11,4 +11,9 @@
     right: 0;
     padding: 5px;
   }
+
+  &__editButton {
+    margin-top: 24px;
+    margin-left: 5px;
+  }
 }

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Drawer, DrawerBody, DrawerContent } from '@chakra-ui/react';
+import { Link } from 'react-router-dom';
 import { IconCross } from 'hds-react/icons';
+import { Button } from 'hds-react';
 import Text from '../../../../common/components/text/Text';
 import { formatToFinnishDate } from '../../../../common/utils/date';
 import { HankeData } from '../../../types/hanke';
 import styles from './HankeSidebar.module.scss';
+import useLinkPath from '../../../../common/hooks/useLinkPath';
+import { ROUTES } from '../../../../common/types/route';
 
 type SectionProps = {
   title: string;
@@ -32,6 +36,8 @@ type Props = {
 
 const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
   const { t } = useTranslation();
+
+  const getEditHankePath = useLinkPath(ROUTES.EDIT_HANKE);
 
   return (
     <Drawer
@@ -81,6 +87,11 @@ const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
               .join(', ')}
           />
           <SidebarSection title={t('hankeForm:labels.kuvaus')} content={hanke.kuvaus} />
+          <Link to={getEditHankePath({ hankeTunnus: hanke.hankeTunnus })}>
+            <Button variant="secondary" className={styles.hankeSidebar__editButton}>
+              {t('hankeSidebar:editHanke')}
+            </Button>
+          </Link>
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -179,7 +179,7 @@
     "labels": {
       "hankeTunnus": "EN:Hankkeen tunnus",
       "nimi": "EN:Hankkeen nimi",
-      "vaihe": "EN:Hankeen Vaihe",
+      "vaihe": "EN:Hankkeen Vaihe",
       "kuvaus": "EN:Hankkeen kuvaus",
       "suunnitteluVaihe": "EN:Hankkeen suunnitteluvaihe",
       "alkuPvm": "EN:Hankkeen alkupäivä",
@@ -240,7 +240,8 @@
     }
   },
   "hankeSidebar": {
-    "closeButtonAriaLabel": "EN:Sulje hankevalikko"
+    "closeButtonAriaLabel": "EN:Sulje hankevalikko",
+    "editHanke": "EN: Muokkaa hankkeen tietoja"
   },
   "hankeList": {
     "pageHeader": "EN:Hankelista",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -178,7 +178,7 @@
     "labels": {
       "hankeTunnus": "Hankkeen tunnus",
       "nimi": "Hankkeen nimi",
-      "vaihe": "Hankeen Vaihe",
+      "vaihe": "Hankkeen Vaihe",
       "kuvaus": "Hankkeen kuvaus",
       "suunnitteluVaihe": "Hankkeen suunnitteluvaihe",
       "alkuPvm": "Hankkeen alkupäivä",
@@ -239,7 +239,8 @@
     }
   },
   "hankeSidebar": {
-    "closeButtonAriaLabel": "Sulje hankevalikko"
+    "closeButtonAriaLabel": "Sulje hankevalikko",
+    "editHanke": "Muokkaa hankkeen tietoja"
   },
   "hankeList": {
     "pageHeader": "Hankelista",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -178,7 +178,7 @@
     "labels": {
       "hankeTunnus": "SV:Hankkeen tunnus",
       "nimi": "SV:Hankkeen nimi",
-      "vaihe": "SV:Hankeen Vaihe",
+      "vaihe": "SV:Hankkeen Vaihe",
       "kuvaus": "SV:Hankkeen kuvaus",
       "suunnitteluVaihe": "SV:Hankkeen suunnitteluvaihe",
       "alkuPvm": "SV:Hankkeen alkupäivä",
@@ -239,7 +239,8 @@
     }
   },
   "hankeSidebar": {
-    "closeButtonAriaLabel": "SV:Sulje hankevalikko"
+    "closeButtonAriaLabel": "SV:Sulje hankevalikko",
+    "editHanke": "SV: Muokkaa hankkeen tietoja"
   },
   "hankeList": {
     "pageHeader": "SV:Hankelista",


### PR DESCRIPTION
Korjattu samalla pieni typo
Ohjataan hankkeen editointisivulle samalla tyylillä kuten hankeList -komponentista