### PR TITLE
HAI-607: Korjaus yhteystietojen validointiin ja filtteröintiin

### DIFF
--- a/src/domain/hanke/edit/Form.test.tsx
+++ b/src/domain/hanke/edit/Form.test.tsx
@@ -75,6 +75,15 @@ describe('HankeForm', () => {
     fireEvent.change(getByTestId('omistajat-etunimi'), {
       target: { value: omistajaEtunimi },
     });
+    fireEvent.change(getByTestId('omistajat-sukunimi'), {
+      target: { value: omistajaEtunimi },
+    });
+    fireEvent.change(getByTestId('omistajat-email'), {
+      target: { value: 'pekka@omistaja.fi' },
+    });
+    fireEvent.change(getByTestId('omistajat-puhelinnumero'), {
+      target: { value: '0406664200' },
+    });
 
     getByTestId('forward').click(); // changes view to form3
     await waitFor(() => queryAllByText('Työmaan tiedot')[1]);

--- a/src/domain/hanke/edit/Form2.tsx
+++ b/src/domain/hanke/edit/Form2.tsx
@@ -5,7 +5,7 @@ import { $enum } from 'ts-enum-util';
 import { useTypedController } from '@hookform/strictly-typed';
 import { TextInput } from 'hds-react';
 import { CONTACT_FORMFIELD, FormProps, HankeDataFormState, Organization } from './types';
-import { HANKE_CONTACT_TYPE } from '../../types/hanke';
+import { HANKE_CONTACT_TYPE, HankeContactKey } from '../../types/hanke';
 import api from '../../api/api';
 import { getInputErrorText } from '../../../common/utils/form';
 import Text from '../../../common/components/text/Text';
@@ -19,6 +19,16 @@ const CONTACT_FIELDS = [
   CONTACT_FORMFIELD.PUHELINNUMERO,
   CONTACT_FORMFIELD.OSASTO,
 ];
+
+const REQUIRED: string[] = [
+  CONTACT_FORMFIELD.ETUNIMI,
+  CONTACT_FORMFIELD.SUKUNIMI,
+  CONTACT_FORMFIELD.EMAIL,
+  CONTACT_FORMFIELD.PUHELINNUMERO,
+];
+
+const isRequired = (type: HankeContactKey, field: string) =>
+  type === HANKE_CONTACT_TYPE.OMISTAJAT && REQUIRED.includes(field);
 
 const fetchOrganizations = async () => {
   const response = await api.get<Organization[]>('/organisaatiot');
@@ -57,6 +67,8 @@ const Form2: React.FC<FormProps> = ({ control, formData, errors, register }) => 
           <div className="formColumns">
             {CONTACT_FIELDS.map((contactField) => {
               const contactData = formData[contactType][contactIndex];
+              const asteriskIfRequired = isRequired(contactType, contactField) ? ' *' : '';
+
               return (
                 <React.Fragment key={contactField}>
                   <TypedController
@@ -65,7 +77,7 @@ const Form2: React.FC<FormProps> = ({ control, formData, errors, register }) => 
                     render={(props) => (
                       <TextInput
                         className="formItem"
-                        label={t(`hankeForm:labels:${contactField}`)}
+                        label={t(`hankeForm:labels:${contactField}`) + asteriskIfRequired}
                         id={`${contactType}-${contactField}`}
                         ref={register}
                         data-testid={`${contactType}-${contactField}`}

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -12,14 +12,20 @@ export const isRequiredByFormPage = (formPage: number) => (val: number, schema: 
 // https://github.com/jquense/yup/issues/176
 // https://github.com/jquense/yup/issues/952
 export const contactSchema = yup.object().shape({
-  // sukunimi: yup.string().max(100).when(['$formPage', 'etunimi', 'email'], {
-  sukunimi: yup.string().when(['etunimi', 'email'], {
-    is: true,
-    then: yup.string().required(),
-  }),
   etunimi: yup.string().nullable().max(100),
+  sukunimi: yup.string().nullable().max(100),
   email: yup.string().email().nullable().max(100),
   puhelinnumero: yup.string().nullable().max(20),
+  organisaatioId: yup.number().nullable(),
+  organisaatioNimi: yup.string().nullable(),
+  osasto: yup.string().nullable().max(200),
+});
+
+export const requiredContactSchema = yup.object().shape({
+  etunimi: yup.string().required().max(100),
+  sukunimi: yup.string().required(),
+  email: yup.string().email().required().max(100),
+  puhelinnumero: yup.string().required().max(20),
   organisaatioId: yup.number().nullable(),
   organisaatioNimi: yup.string().nullable(),
   osasto: yup.string().nullable().max(200),
@@ -52,7 +58,13 @@ export const hankeSchema = yup.object().shape({
     then: yup.string().required(),
   }),
   [FORMFIELD.KATUOSOITE]: yup.string().nullable().when('$formPage', isRequiredByFormPage(3)),
-  [FORMFIELD.OMISTAJAT]: yup.array().nullable().ensure().of(contactSchema),
+  [FORMFIELD.OMISTAJAT]: yup
+    .array()
+    .nullable()
+    // eslint-disable-next-line
+    .when('$formPage', (val: number, schema: any) =>
+      val === 2 ? schema.ensure().of(requiredContactSchema) : schema
+    ),
   [FORMFIELD.ARVIOIJAT]: yup.array().nullable().ensure().of(contactSchema),
   [FORMFIELD.TOTEUTTAJAT]: yup.array().nullable().ensure().of(contactSchema),
 });

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -9,8 +9,14 @@ export const today = startOfDay(new Date());
 export const isRequiredByFormPage = (formPage: number) => (val: number, schema: yup.MixedSchema) =>
   val === formPage ? schema.required() : schema;
 
+// https://github.com/jquense/yup/issues/176
+// https://github.com/jquense/yup/issues/952
 export const contactSchema = yup.object().shape({
-  sukunimi: yup.string().nullable().max(100),
+  // sukunimi: yup.string().max(100).when(['$formPage', 'etunimi', 'email'], {
+  sukunimi: yup.string().when(['etunimi', 'email'], {
+    is: true,
+    then: yup.string().required(),
+  }),
   etunimi: yup.string().nullable().max(100),
   email: yup.string().email().nullable().max(100),
   puhelinnumero: yup.string().nullable().max(20),

--- a/src/domain/hanke/edit/utils.ts
+++ b/src/domain/hanke/edit/utils.ts
@@ -1,8 +1,18 @@
 import { HankeContact, HankeDataDraft } from '../../types/hanke';
 import { FORMFIELD, HankeDataFormState } from './types';
 
-const isContactEmpty = ({ etunimi, sukunimi, email }: HankeContact) =>
-  etunimi === '' && sukunimi === '' && email === '';
+const isContactEmpty = ({
+  etunimi,
+  sukunimi,
+  email,
+  puhelinnumero,
+  organisaatioNimi,
+}: HankeContact) =>
+  etunimi === '' &&
+  sukunimi === '' &&
+  email === '' &&
+  puhelinnumero === '' &&
+  organisaatioNimi === '';
 
 // This is temporary solution for sending empty contacts to API
 export const filterEmptyContacts = (hankeData: HankeDataFormState): HankeDataFormState => ({


### PR DESCRIPTION
Yhteystieto filtteröidään pois kutsusta jos se on empty. eli mikään näistä ( etunimi, sukunimi, email, puhelinnumero, organisaatioNimi) ei ole syötetty. Tämä on meidän form-kirjaston takia koska se lisää tuon Contact-objektin väkisin tuohon array-fieldiin.

Omistaja-tyypin validointiin käytetää requiredContactSchemaa, eli pakollisia pakollisia tietoja ovat etunimi, sukunimi, email ja puhelinnumero.

