### PR TITLE
HAI-723: Värin selvitys liikennehaittaindeksin perusteella

### DIFF
--- a/src/common/components/map/layers/VectorLayer.tsx
+++ b/src/common/components/map/layers/VectorLayer.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect } from 'react';
 import { Vector as VectorSource } from 'ol/source';
-import { Style } from 'ol/style';
+import { StyleLike } from 'ol/style/Style';
 import OLVectorLayer from 'ol/layer/Vector';
 import MapContext from '../MapContext';
 
@@ -8,7 +8,7 @@ type Props = {
   source: VectorSource;
   className: string;
   zIndex?: number;
-  style?: Style;
+  style?: StyleLike;
 };
 
 const VectorLayer: React.FC<Props> = ({ source, className, zIndex = 0, style = undefined }) => {

--- a/src/domain/common/utils/liikennehaittaindeksi.test.ts
+++ b/src/domain/common/utils/liikennehaittaindeksi.test.ts
@@ -1,0 +1,47 @@
+import {
+  getStatusByIndex,
+  getColorByStatus,
+  LIIKENNEHAITTA_STATUS,
+  INDEX_RED,
+  INDEX_BLUE,
+  INDEX_GREEN,
+  INDEX_YELLOW,
+} from './liikennehaittaindeksi';
+
+describe('Liikennehaittaindeksi utils', () => {
+  test('status and color with null should be blue', async () => {
+    const status = getStatusByIndex(null);
+    expect(status).toBe(LIIKENNEHAITTA_STATUS.BLUE);
+    expect(getColorByStatus(status)).toBe(INDEX_BLUE);
+  });
+
+  test('status and color with 0 should be green', async () => {
+    const status = getStatusByIndex(0);
+    expect(status).toBe(LIIKENNEHAITTA_STATUS.GREEN);
+    expect(getColorByStatus(status)).toBe(INDEX_GREEN);
+  });
+
+  test('status and color with 2.9 should be green', async () => {
+    const status = getStatusByIndex(2.9);
+    expect(status).toBe(LIIKENNEHAITTA_STATUS.GREEN);
+    expect(getColorByStatus(status)).toBe(INDEX_GREEN);
+  });
+
+  test('status and color with 3 should be yellow', async () => {
+    const status = getStatusByIndex(3);
+    expect(status).toBe(LIIKENNEHAITTA_STATUS.YELLOW);
+    expect(getColorByStatus(status)).toBe(INDEX_YELLOW);
+  });
+
+  test('status and color with 4 should be red', async () => {
+    const status = getStatusByIndex(4);
+    expect(status).toBe(LIIKENNEHAITTA_STATUS.RED);
+    expect(getColorByStatus(status)).toBe(INDEX_RED);
+  });
+
+  test('status and color with 6 should be red', async () => {
+    const status = getStatusByIndex(6);
+    expect(status).toBe(LIIKENNEHAITTA_STATUS.RED);
+    expect(getColorByStatus(status)).toBe(INDEX_RED);
+  });
+});

--- a/src/domain/common/utils/liikennehaittaindeksi.ts
+++ b/src/domain/common/utils/liikennehaittaindeksi.ts
@@ -1,0 +1,40 @@
+import { $enum } from 'ts-enum-util';
+
+/*
+Note: RGBA values doesnt work with openlayers?
+
+const opacity = '0.1';
+export const INDEX_RED = `rgba(196, 18, 62, ${opacity})`;
+export const INDEX_YELLOW = `rgba(255, 218, 7, ${opacity})`;
+export const INDEX_GREEN = `#rgba(0, 146, 70, ${opacity})`;
+export const INDEX_BLUE = `rgba(36, 114, 198, ${opacity})`;
+*/
+
+type TormaysIndex = null | number;
+
+export const INDEX_RED = '#c4123e';
+export const INDEX_YELLOW = '#ffda07';
+export const INDEX_GREEN = '#009246';
+export const INDEX_BLUE = '#2472c6';
+
+export enum LIIKENNEHAITTA_STATUS {
+  BLUE = 'BLUE',
+  GREEN = 'GREEN',
+  YELLOW = 'YELLOW',
+  RED = 'RED',
+}
+
+export const getStatusByIndex = (index: TormaysIndex) => {
+  if (index === null) return LIIKENNEHAITTA_STATUS.BLUE;
+  if (index < 3) return LIIKENNEHAITTA_STATUS.GREEN;
+  if (index < 4) return LIIKENNEHAITTA_STATUS.YELLOW;
+  return LIIKENNEHAITTA_STATUS.RED;
+};
+
+export const getColorByStatus = (status: LIIKENNEHAITTA_STATUS) =>
+  $enum.mapValue(status).with({
+    [LIIKENNEHAITTA_STATUS.BLUE]: INDEX_BLUE,
+    [LIIKENNEHAITTA_STATUS.GREEN]: INDEX_GREEN,
+    [LIIKENNEHAITTA_STATUS.YELLOW]: INDEX_YELLOW,
+    [LIIKENNEHAITTA_STATUS.RED]: INDEX_RED,
+  });

--- a/src/domain/map/components/Layers/HankeLayer.tsx
+++ b/src/domain/map/components/Layers/HankeLayer.tsx
@@ -1,6 +1,5 @@
 import React, { useRef, useEffect, useMemo } from 'react';
 import { useQuery } from 'react-query';
-import { Fill, Stroke, Style } from 'ol/style';
 import { Vector as VectorSource } from 'ol/source';
 import GeoJSON from 'ol/format/GeoJSON';
 import VectorLayer from '../../../../common/components/map/layers/VectorLayer';
@@ -8,22 +7,8 @@ import { byAllHankeFilters } from '../../utils';
 import { useDateRangeFilter } from '../../hooks/useDateRangeFilter';
 import { HankeData } from '../../../types/hanke';
 import api from '../../../api/api';
-
+import { styleFunction } from '../../utils/geometryStyle';
 import CenterProjectOnMap from '../interations/CenterProjectOnMap';
-
-// Temporary reference style implementation. Actual colors
-// are chosen based on törmäysanalyysi
-const geometryStyle = {
-  Blue: new Style({
-    stroke: new Stroke({
-      color: 'black',
-      width: 1,
-    }),
-    fill: new Fill({
-      color: 'rgba(36, 114, 198, 1)',
-    }),
-  }),
-};
 
 const getProjectsWithGeometry = async () => {
   const response = await api.get<HankeData[]>('/hankkeet', {
@@ -76,7 +61,7 @@ const HankeLayer = () => {
         source={hankeSource.current}
         zIndex={100}
         className="hankeGeometryLayer"
-        style={geometryStyle.Blue}
+        style={styleFunction}
       />
     </>
   );

--- a/src/domain/map/components/Layers/Kantakartta.tsx
+++ b/src/domain/map/components/Layers/Kantakartta.tsx
@@ -18,6 +18,7 @@ const Kantakartta = () => (
           TRANSPARENT: 'false',
         },
         projection,
+        cacheSize: 1000,
         imageSmoothing: false,
         hidpi: false,
         serverType: 'geoserver',

--- a/src/domain/map/utils/geometryStyle.ts
+++ b/src/domain/map/utils/geometryStyle.ts
@@ -1,0 +1,50 @@
+import Feature from 'ol/Feature';
+import { $enum } from 'ts-enum-util';
+import { Fill, Style } from 'ol/style';
+import {
+  getStatusByIndex,
+  getColorByStatus,
+  LIIKENNEHAITTA_STATUS,
+} from '../../common/utils/liikennehaittaindeksi';
+
+const STYLES = {
+  [LIIKENNEHAITTA_STATUS.BLUE]: new Style({
+    fill: new Fill({
+      color: getColorByStatus(LIIKENNEHAITTA_STATUS.BLUE),
+    }),
+  }),
+  [LIIKENNEHAITTA_STATUS.GREEN]: new Style({
+    fill: new Fill({
+      color: getColorByStatus(LIIKENNEHAITTA_STATUS.GREEN),
+    }),
+  }),
+  [LIIKENNEHAITTA_STATUS.YELLOW]: new Style({
+    fill: new Fill({
+      color: getColorByStatus(LIIKENNEHAITTA_STATUS.YELLOW),
+    }),
+  }),
+  [LIIKENNEHAITTA_STATUS.RED]: new Style({
+    fill: new Fill({
+      color: getColorByStatus(LIIKENNEHAITTA_STATUS.RED),
+    }),
+  }),
+};
+
+export const getStyleByStatus = (status: LIIKENNEHAITTA_STATUS): Style =>
+  $enum.mapValue(status).with({
+    [LIIKENNEHAITTA_STATUS.BLUE]: STYLES[LIIKENNEHAITTA_STATUS.BLUE],
+    [LIIKENNEHAITTA_STATUS.GREEN]: STYLES[LIIKENNEHAITTA_STATUS.GREEN],
+    [LIIKENNEHAITTA_STATUS.YELLOW]: STYLES[LIIKENNEHAITTA_STATUS.YELLOW],
+    [LIIKENNEHAITTA_STATUS.RED]: STYLES[LIIKENNEHAITTA_STATUS.RED],
+  });
+
+// Performance tips: https://github.com/openlayers/openlayers/issues/8392
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const styleFunction: any = (feature: Feature) => {
+  const hankeTunnus = feature.get('hankeTunnus');
+  // eslint-disable-next-line
+  const fakeIndex = hankeTunnus ? parseInt(hankeTunnus.slice(hankeTunnus.length - 1)) : null; // last number of hankeTunnus
+  const status = getStatusByIndex(fakeIndex);
+
+  return getStyleByStatus(status);
+};


### PR DESCRIPTION
# Haitaton-ui pull-request

Kyseessä on

- [ ] Bugikorjaus
- [ ] Uusi toiminnallisuus (ei muuta olemassaolevaa toteutusta)
- [x] Uusi toiminnallisuus (muuttaa jo olemassaolevaa toteutusta)

## Kuvaus mitä pull-request toteuttaa / korjaa

Funktiot väri-statuksen selvittämiseksi liikennehaittaindeksin perusteella ja värin selvittäminen väri-statuksen perusteella. Tein esimerkin styleFunktiosta jota voi käyttää (ja käytin) hanke-geometrioiden tyylittelemiseksi.

## Checklist:

- [x] Muuttujat ovat kuvaavasti nimettyjä eikä koodi sisällä kirjoitusvirheitä
- [x] Muutokseni eivät aiheuta uusia virheitä consoleen
- [x] Olen toteuttanut Jest-testit toiminnallisuuden testaukseen
