### PR TITLE
Hai 722 - staattiset sivupalkin indeksitiedot asemoituna

### DIFF
--- a/src/domain/map/components/HankeSidebar/HankeIndexes.module.scss
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.module.scss
@@ -1,0 +1,22 @@
+.indexContainer {
+  display: flex;
+  align-items: center;
+  padding: 1.2rem 0.25rem;
+
+  &__titlesContainer {
+    flex-direction: column;
+    flex-grow: 1;
+  }
+
+  &__statusContainer {
+    padding-left: 1.5rem;
+    width: 64px;
+    text-align: center;
+  }
+}
+
+.indexes {
+  .indexContainer:nth-child(odd) {
+    background-color: var(--color-black-5);
+  }
+}

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.module.scss
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.module.scss
@@ -8,10 +8,10 @@
     flex-grow: 1;
   }
 
-  &__statusContainer {
-    padding-left: 1.5rem;
-    width: 64px;
+  &__number {
+    width: 34px;
     text-align: center;
+    margin-right: 8px;
   }
 }
 

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.test.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { cleanup } from '@testing-library/react';
+import HankeIndexes from './HankeIndexes';
+import { render } from '../../../../testUtils/render';
+import hankeList from '../../../mocks/hankeList';
+
+afterEach(cleanup);
+
+describe('HankeSidebar', () => {
+  test('Should be display data correctly', async () => {
+    const { findByText, getByTestId } = render(
+      <HankeIndexes hankeTunnus={hankeList[0].hankeTunnus} />
+    );
+    expect(findByText('Liikennehaittaindeksi')).toBeTruthy();
+    expect(getByTestId('sidebar-liikennehaittaindeksi')).toHaveTextContent('4');
+  });
+});

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.test.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.test.tsx
@@ -2,15 +2,18 @@ import React from 'react';
 import { cleanup } from '@testing-library/react';
 import HankeIndexes from './HankeIndexes';
 import { render } from '../../../../testUtils/render';
-import hankeList from '../../../mocks/hankeList';
+import hankeIndexData from '../../../mocks/hankeIndexData';
 
 afterEach(cleanup);
 
 describe('HankeSidebar', () => {
   test('Should be display data correctly', async () => {
-    const { findByText } = render(<HankeIndexes hankeTunnus={hankeList[0].hankeTunnus} />);
+    const { findByText, getByTestId } = render(<HankeIndexes hankeIndexData={hankeIndexData} />);
     expect(findByText('Liikennehaittaindeksi')).toBeTruthy();
-    // TODO: refactor tests once indexes implementation complete
-    // expect(getByTestId('sidebar-liikennehaittaindeksi')).toHaveTextContent('4');
+    expect(getByTestId('test-liikennehaittaIndeksi')).toHaveTextContent('4');
+    expect(findByText('Pyöräilyn pääreitti')).toBeTruthy();
+    expect(getByTestId('test-pyorailyIndeksi')).toHaveTextContent('3');
+    expect(findByText('Merkittävät joukkoliikennereitit')).toBeTruthy();
+    expect(getByTestId('test-joukkoliikenneIndeksi')).toHaveTextContent('1');
   });
 });

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.test.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.test.tsx
@@ -8,10 +8,9 @@ afterEach(cleanup);
 
 describe('HankeSidebar', () => {
   test('Should be display data correctly', async () => {
-    const { findByText, getByTestId } = render(
-      <HankeIndexes hankeTunnus={hankeList[0].hankeTunnus} />
-    );
+    const { findByText } = render(<HankeIndexes hankeTunnus={hankeList[0].hankeTunnus} />);
     expect(findByText('Liikennehaittaindeksi')).toBeTruthy();
-    expect(getByTestId('sidebar-liikennehaittaindeksi')).toHaveTextContent('4');
+    // TODO: refactor tests once indexes implementation complete
+    // expect(getByTestId('sidebar-liikennehaittaindeksi')).toHaveTextContent('4');
   });
 });

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
@@ -7,14 +7,16 @@ import {
 } from '../../../common/utils/liikennehaittaindeksi';
 import Text from '../../../../common/components/text/Text';
 import styles from './HankeIndexes.module.scss';
+import { HankeIndexData } from '../../../types/hanke';
 
 type IndexProps = {
   title: string;
   content?: string;
   index: number;
+  testId: string;
 };
 
-const IndexSection: React.FC<IndexProps> = ({ title, content, index }) =>
+const IndexSection: React.FC<IndexProps> = ({ title, content, index, testId }) =>
   title && title !== '' && index ? (
     <>
       <div className={styles.indexContainer}>
@@ -35,41 +37,48 @@ const IndexSection: React.FC<IndexProps> = ({ title, content, index }) =>
             color: getStatusByIndex(index) === LIIKENNEHAITTA_STATUS.YELLOW ? 'black' : 'white',
           }}
         >
-          <div>{index}</div>
+          <div data-testid={testId}>{index}</div>
         </div>
       </div>
     </>
   ) : null;
 
 type Props = {
-  hankeTunnus: string; // FIXME
+  hankeIndexData: HankeIndexData;
 };
 
-const HankeIndexes: React.FC<Props> = ({ hankeTunnus }) => {
+const HankeIndexes: React.FC<Props> = ({ hankeIndexData }) => {
   const { t } = useTranslation();
 
   return (
     <div className={styles.indexes}>
-      <h1>{hankeTunnus}</h1>
+      <IndexSection
+        title={t('hankeIndexes:liikennehaittaindeksi')}
+        index={hankeIndexData.liikennehaittaIndeksi.indeksi}
+        testId="test-liikennehaittaIndeksi"
+      />
 
-      <IndexSection title={t('hankeIndexes:liikennehaittaindeksi')} index={4} />
-
+      {/*
+ ks of now the backend did not respond with an index value for ruuhkautuminen
       <IndexSection
         title={t('hankeIndexes:ruuhkautuminen')}
         content={`${t('hankeIndexes:kiertoreittitarve')}: ${t('hankeIndexes:todennakoinen')}`}
         index={3.7}
       />
+*/}
 
       <IndexSection
         title={t('hankeIndexes:pyorailynPaareitti')}
-        content={`${t('hankeIndexes:kiertoreittitarve')}: ${t('hankeIndexes:eiTarvetta')}`}
-        index={1}
+        content={`${t('hankeIndexes:kiertoreittitarve')}: `}
+        index={hankeIndexData.pyorailyIndeksi}
+        testId="test-pyorailyIndeksi"
       />
 
       <IndexSection
         title={t('hankeIndexes:merkittavatJoukkoliikennereitit')}
-        content={`${t('hankeIndexes:kiertoreittitarve')}: ${t('hankeIndexes:merkittava')}`}
-        index={4}
+        content={`${t('hankeIndexes:kiertoreittitarve')}: `}
+        index={hankeIndexData.joukkoliikenneIndeksi}
+        testId="test-joukkoliikenneIndeksi"
       />
     </div>
   );

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
@@ -16,32 +16,29 @@ type IndexProps = {
   testId: string;
 };
 
-const IndexSection: React.FC<IndexProps> = ({ title, content, index, testId }) =>
-  title && title !== '' && index ? (
-    <>
-      <div className={styles.indexContainer}>
-        <div className={styles.indexContainer__titlesContainer}>
-          <Text tag="h3" styleAs={content ? 'h6' : 'h5'} weight="bold">
-            {title}
-          </Text>
-          {content && (
-            <Text tag="p" styleAs="body-m">
-              {content}
-            </Text>
-          )}
-        </div>
-        <div
-          className={styles.indexContainer__number}
-          style={{
-            backgroundColor: getColorByStatus(getStatusByIndex(index)),
-            color: getStatusByIndex(index) === LIIKENNEHAITTA_STATUS.YELLOW ? 'black' : 'white',
-          }}
-        >
-          <div data-testid={testId}>{index}</div>
-        </div>
-      </div>
-    </>
-  ) : null;
+const IndexSection: React.FC<IndexProps> = ({ title, content, index, testId }) => (
+  <div className={styles.indexContainer}>
+    <div className={styles.indexContainer__titlesContainer}>
+      <Text tag="h3" styleAs={content ? 'h6' : 'h5'} weight="bold">
+        {title}
+      </Text>
+      {content && (
+        <Text tag="p" styleAs="body-m">
+          {content}
+        </Text>
+      )}
+    </div>
+    <div
+      className={styles.indexContainer__number}
+      style={{
+        backgroundColor: getColorByStatus(getStatusByIndex(index)),
+        color: getStatusByIndex(index) === LIIKENNEHAITTA_STATUS.YELLOW ? 'black' : 'white',
+      }}
+    >
+      <div data-testid={testId}>{index}</div>
+    </div>
+  </div>
+);
 
 type Props = {
   hankeIndexData: HankeIndexData;

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
@@ -55,15 +55,6 @@ const HankeIndexes: React.FC<Props> = ({ hankeIndexData }) => {
         testId="test-liikennehaittaIndeksi"
       />
 
-      {/*
- ks of now the backend did not respond with an index value for ruuhkautuminen
-      <IndexSection
-        title={t('hankeIndexes:ruuhkautuminen')}
-        content={`${t('hankeIndexes:kiertoreittitarve')}: ${t('hankeIndexes:todennakoinen')}`}
-        index={3.7}
-      />
-*/}
-
       <IndexSection
         title={t('hankeIndexes:pyorailynPaareitti')}
         content={`${t('hankeIndexes:kiertoreittitarve')}: `}
@@ -77,6 +68,15 @@ const HankeIndexes: React.FC<Props> = ({ hankeIndexData }) => {
         index={hankeIndexData.joukkoliikenneIndeksi}
         testId="test-joukkoliikenneIndeksi"
       />
+
+      {/* Ruuhkautuminen is not yet a part of the response
+      <IndexSection
+        title={t('hankeIndexes:ruuhkautuminen')}
+        content={`${t('hankeIndexes:kiertoreittitarve')}: ${t('hankeIndexes:merkittava')}`}
+        index={2}
+        testId="test-ruuhkautumisIndeksi"
+      />
+      */}
     </div>
   );
 };

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
@@ -1,55 +1,66 @@
 import React from 'react';
 import { StatusLabel } from 'hds-react';
+import { useTranslation } from 'react-i18next';
 import Text from '../../../../common/components/text/Text';
 import styles from './HankeIndexes.module.scss';
+
+type IndexProps = {
+  title: string;
+  content?: string;
+  index: number;
+};
+
+const IndexSection: React.FC<IndexProps> = ({ title, content, index }) =>
+  title && title !== '' && index ? (
+    <>
+      <div className={styles.indexContainer}>
+        <div className={styles.indexContainer__titlesContainer}>
+          <Text tag="h3" styleAs={content ? 'h6' : 'h5'} weight="bold">
+            {title}
+          </Text>
+          {content && (
+            <Text tag="p" styleAs="body-m">
+              {content}
+            </Text>
+          )}
+        </div>
+        <div className={styles.indexContainer__statusContainer}>
+          <StatusLabel type="alert">{index}</StatusLabel>
+        </div>
+      </div>
+    </>
+  ) : null;
 
 type Props = {
   hankeTunnus: string; // FIXME
 };
 
 const HankeIndexes: React.FC<Props> = ({ hankeTunnus }) => {
+  const { t } = useTranslation();
+
   return (
     <div className={styles.indexes}>
       <h1>{hankeTunnus}</h1>
-      <div className={styles.indexContainer}>
-        <div className={styles.indexContainer__titlesContainer}>
-          <Text tag="h3" styleAs="h5" weight="bold">
-            Liikennehaittaindeksi
-          </Text>
-        </div>
-        <div
-          className={styles.indexContainer__statusContainer}
-          data-testid="sidebar-liikennehaittaindeksi"
-        >
-          <StatusLabel type="error">4</StatusLabel>
-        </div>
-      </div>
-      <div className={styles.indexContainer}>
-        <div className={styles.indexContainer__titlesContainer}>
-          <Text tag="h3" styleAs="h6" weight="bold">
-            Ruuhkautuminen
-          </Text>
-          <Text tag="p" styleAs="body-m">
-            Kiertoreittitarve: todennäköinen
-          </Text>
-        </div>
-        <div className={styles.indexContainer__statusContainer}>
-          <StatusLabel type="alert">2.7</StatusLabel>
-        </div>
-      </div>
-      <div className={styles.indexContainer}>
-        <div className={styles.indexContainer__titlesContainer}>
-          <Text tag="h3" styleAs="h6" weight="bold">
-            Pyöräilyn pääreitti
-          </Text>
-          <Text tag="p" styleAs="body-m">
-            Kiertoreittitarve: ei tarvetta
-          </Text>
-        </div>
-        <div className={styles.indexContainer__statusContainer}>
-          <StatusLabel type="success">1</StatusLabel>
-        </div>
-      </div>
+
+      <IndexSection title={t('hankeIndexes:liikennehaittaindeksi')} index={4} />
+
+      <IndexSection
+        title={t('hankeIndexes:ruuhkautuminen')}
+        content={`${t('hankeIndexes:kiertoreittitarve')}: ${t('hankeIndexes:todennakoinen')}`}
+        index={2.7}
+      />
+
+      <IndexSection
+        title={t('hankeIndexes:pyorailynPaareitti')}
+        content={`${t('hankeIndexes:kiertoreittitarve')}: ${t('hankeIndexes:eiTarvetta')}`}
+        index={1}
+      />
+
+      <IndexSection
+        title={t('hankeIndexes:merkittavatJoukkoliikennereitit')}
+        content={`${t('hankeIndexes:kiertoreittitarve')}: ${t('hankeIndexes:merkittava')}`}
+        index={4}
+      />
     </div>
   );
 };

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { StatusLabel } from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import {
+  LIIKENNEHAITTA_STATUS,
+  getStatusByIndex,
+  getColorByStatus,
+} from '../../../common/utils/liikennehaittaindeksi';
 import Text from '../../../../common/components/text/Text';
 import styles from './HankeIndexes.module.scss';
 
@@ -24,8 +28,14 @@ const IndexSection: React.FC<IndexProps> = ({ title, content, index }) =>
             </Text>
           )}
         </div>
-        <div className={styles.indexContainer__statusContainer}>
-          <StatusLabel type="alert">{index}</StatusLabel>
+        <div
+          className={styles.indexContainer__number}
+          style={{
+            backgroundColor: getColorByStatus(getStatusByIndex(index)),
+            color: getStatusByIndex(index) === LIIKENNEHAITTA_STATUS.YELLOW ? 'black' : 'white',
+          }}
+        >
+          <div>{index}</div>
         </div>
       </div>
     </>
@@ -47,7 +57,7 @@ const HankeIndexes: React.FC<Props> = ({ hankeTunnus }) => {
       <IndexSection
         title={t('hankeIndexes:ruuhkautuminen')}
         content={`${t('hankeIndexes:kiertoreittitarve')}: ${t('hankeIndexes:todennakoinen')}`}
-        index={2.7}
+        index={3.7}
       />
 
       <IndexSection

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { StatusLabel } from 'hds-react';
+import Text from '../../../../common/components/text/Text';
+import styles from './HankeIndexes.module.scss';
+
+type Props = {
+  hankeTunnus: string; // FIXME
+};
+
+const HankeIndexes: React.FC<Props> = ({ hankeTunnus }) => {
+  return (
+    <div className={styles.indexes}>
+      <h1>{hankeTunnus}</h1>
+      <div className={styles.indexContainer}>
+        <div className={styles.indexContainer__titlesContainer}>
+          <Text tag="h3" styleAs="h5" weight="bold">
+            Liikennehaittaindeksi
+          </Text>
+        </div>
+        <div
+          className={styles.indexContainer__statusContainer}
+          data-testid="sidebar-liikennehaittaindeksi"
+        >
+          <StatusLabel type="error">4</StatusLabel>
+        </div>
+      </div>
+      <div className={styles.indexContainer}>
+        <div className={styles.indexContainer__titlesContainer}>
+          <Text tag="h3" styleAs="h6" weight="bold">
+            Ruuhkautuminen
+          </Text>
+          <Text tag="p" styleAs="body-m">
+            Kiertoreittitarve: todennäköinen
+          </Text>
+        </div>
+        <div className={styles.indexContainer__statusContainer}>
+          <StatusLabel type="alert">2.7</StatusLabel>
+        </div>
+      </div>
+      <div className={styles.indexContainer}>
+        <div className={styles.indexContainer__titlesContainer}>
+          <Text tag="h3" styleAs="h6" weight="bold">
+            Pyöräilyn pääreitti
+          </Text>
+          <Text tag="p" styleAs="body-m">
+            Kiertoreittitarve: ei tarvetta
+          </Text>
+        </div>
+        <div className={styles.indexContainer__statusContainer}>
+          <StatusLabel type="success">1</StatusLabel>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HankeIndexes;

--- a/src/domain/map/components/HankeSidebar/HankeIndexesContainer.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexesContainer.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useQuery } from 'react-query';
+import { HankeIndexData } from '../../../types/hanke';
+import api from '../../../api/api';
+import HankeIndexes from './HankeIndexes';
+
+const getHankeIndexes = async (hankeTunnus: string | null) => {
+  const response = await api.get<HankeIndexData>(`/hankkeet/${hankeTunnus}/tormaystarkastelu`);
+  return response;
+};
+
+const useGetHanke = (hankeTunnus: string | null) =>
+  useQuery(['hankeIndexes', hankeTunnus], () => getHankeIndexes(hankeTunnus), {
+    enabled: !!hankeTunnus,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+
+type Props = {
+  hankeTunnus: string;
+};
+
+const HankeIndexesContainer: React.FC<Props> = ({ hankeTunnus }) => {
+  const { isLoading, isError, data } = useGetHanke(hankeTunnus);
+
+  if (!data || !data.data || isLoading || isError) {
+    return null;
+  }
+
+  return <HankeIndexes hankeIndexData={data.data} />;
+};
+
+export default HankeIndexesContainer;

--- a/src/domain/map/components/HankeSidebar/HankeIndexesContainer.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexesContainer.tsx
@@ -5,8 +5,7 @@ import api from '../../../api/api';
 import HankeIndexes from './HankeIndexes';
 
 const getHankeIndexes = async (hankeTunnus: string | null) => {
-  const response = await api.get<HankeIndexData>(`/hankkeet/${hankeTunnus}/tormaystarkastelu`);
-  return response;
+  return api.get<HankeIndexData>(`/hankkeet/${hankeTunnus}/tormaystarkastelu`);
 };
 
 const useGetHanke = (hankeTunnus: string | null) =>

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
@@ -3,6 +3,11 @@
     border-top: 1px solid var(--color-black-20);
     max-width: 320px;
     top: 72px !important;
+
+    hr {
+      margin-top: 36px;
+      border-top: 1px solid var(--color-black-20);
+    }
   }
 
   &__closeButton {
@@ -20,18 +25,21 @@
   &__indexContainer {
     display: flex;
     align-items: center;
-    padding: 5px;
-    margin-top: 1.5rem;
+    padding: 1.2rem 0.25rem;
 
     &__titlesContainer {
       flex-direction: column;
       flex-grow: 1;
     }
 
-    &__numberContainer {
+    &__statusContainer {
       padding-left: 1.5rem;
       width: 64px;
       text-align: center;
     }
+  }
+
+  &__indexContainer:nth-child(even) {
+    background-color: var(--color-black-5);
   }
 }

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
@@ -20,31 +20,18 @@
   &__indexContainer {
     display: flex;
     align-items: center;
-    background-color: rgb(255, 30, 143);
     padding: 5px;
 
     &__titlesContainer {
       flex-direction: column;
       flex-grow: 1;
-      background-color: rgb(34, 128, 221);
-
-      div {
-        background-color: #f1f1f1;
-        margin: 10px;
-        text-align: start;
-        font-size: 30px;
-      }
+      margin-top: 1.5rem;
     }
 
     &__numberContainer {
-      background-color: rgb(150, 255, 30);
-
-      div {
-        background-color: #f1f1f1;
-        margin: 10px;
-        font-size: 30px;
-        width: 48px;
-      }
+      margin: 12px;
+      width: 62px;
+      font-size: large;
     }
   }
 }

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
@@ -16,4 +16,35 @@
     margin-top: 24px;
     margin-left: 5px;
   }
+
+  &__indexContainer {
+    display: flex;
+    align-items: center;
+    background-color: rgb(255, 30, 143);
+    padding: 5px;
+
+    &__titlesContainer {
+      flex-direction: column;
+      flex-grow: 1;
+      background-color: rgb(34, 128, 221);
+
+      div {
+        background-color: #f1f1f1;
+        margin: 10px;
+        text-align: start;
+        font-size: 30px;
+      }
+    }
+
+    &__numberContainer {
+      background-color: rgb(150, 255, 30);
+
+      div {
+        background-color: #f1f1f1;
+        margin: 10px;
+        font-size: 30px;
+        width: 48px;
+      }
+    }
+  }
 }

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
@@ -21,25 +21,4 @@
     margin-top: 24px;
     margin-left: 5px;
   }
-
-  &__indexContainer {
-    display: flex;
-    align-items: center;
-    padding: 1.2rem 0.25rem;
-
-    &__titlesContainer {
-      flex-direction: column;
-      flex-grow: 1;
-    }
-
-    &__statusContainer {
-      padding-left: 1.5rem;
-      width: 64px;
-      text-align: center;
-    }
-  }
-
-  &__indexContainer:nth-child(even) {
-    background-color: var(--color-black-5);
-  }
 }

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
@@ -21,17 +21,17 @@
     display: flex;
     align-items: center;
     padding: 5px;
+    margin-top: 1.5rem;
 
     &__titlesContainer {
       flex-direction: column;
       flex-grow: 1;
-      margin-top: 1.5rem;
     }
 
     &__numberContainer {
-      margin: 12px;
-      width: 62px;
-      font-size: large;
+      padding-left: 1.5rem;
+      width: 64px;
+      text-align: center;
     }
   }
 }

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
@@ -96,53 +96,46 @@ const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
               {t('hankeSidebar:editHanke')}
             </Button>
           </Link>
+          <hr />
 
-          <table>
-            <tbody>
-              <tr>
-                <div className={styles.hankeSidebar__indexContainer}>
-                  <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
-                    <Text tag="h3" styleAs="h5" weight="bold">
-                      Liikennehaittaindeksi
-                    </Text>
-                  </div>
-                  <div className={styles.hankeSidebar__indexContainer__numberContainer}>
-                    <StatusLabel type="error">4</StatusLabel>
-                  </div>
-                </div>
-              </tr>
-              <tr>
-                <div className={styles.hankeSidebar__indexContainer}>
-                  <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
-                    <Text tag="h3" styleAs="h6" weight="bold">
-                      Ruuhkautuminen
-                    </Text>
-                    <Text tag="p" styleAs="body-m">
-                      Kiertoreittitarve: todennäköinen
-                    </Text>
-                  </div>
-                  <div className={styles.hankeSidebar__indexContainer__numberContainer}>
-                    <StatusLabel type="alert">2.7</StatusLabel>
-                  </div>
-                </div>
-              </tr>
-              <tr>
-                <div className={styles.hankeSidebar__indexContainer}>
-                  <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
-                    <Text tag="h3" styleAs="h6" weight="bold">
-                      Pyöräilyn pääreitti
-                    </Text>
-                    <Text tag="p" styleAs="body-m">
-                      Kiertoreittitarve: ei tarvetta
-                    </Text>
-                  </div>
-                  <div className={styles.hankeSidebar__indexContainer__numberContainer}>
-                    <StatusLabel type="success">1</StatusLabel>
-                  </div>
-                </div>
-              </tr>
-            </tbody>
-          </table>
+          <div className={styles.hankeSidebar__indexes}>
+            <div className={styles.hankeSidebar__indexContainer}>
+              <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
+                <Text tag="h3" styleAs="h5" weight="bold">
+                  Liikennehaittaindeksi
+                </Text>
+              </div>
+              <div className={styles.hankeSidebar__indexContainer__statusContainer}>
+                <StatusLabel type="error">4</StatusLabel>
+              </div>
+            </div>
+            <div className={styles.hankeSidebar__indexContainer}>
+              <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
+                <Text tag="h3" styleAs="h6" weight="bold">
+                  Ruuhkautuminen
+                </Text>
+                <Text tag="p" styleAs="body-m">
+                  Kiertoreittitarve: todennäköinen
+                </Text>
+              </div>
+              <div className={styles.hankeSidebar__indexContainer__statusContainer}>
+                <StatusLabel type="alert">2.7</StatusLabel>
+              </div>
+            </div>
+            <div className={styles.hankeSidebar__indexContainer}>
+              <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
+                <Text tag="h3" styleAs="h6" weight="bold">
+                  Pyöräilyn pääreitti
+                </Text>
+                <Text tag="p" styleAs="body-m">
+                  Kiertoreittitarve: ei tarvetta
+                </Text>
+              </div>
+              <div className={styles.hankeSidebar__indexContainer__statusContainer}>
+                <StatusLabel type="success">1</StatusLabel>
+              </div>
+            </div>
+          </div>
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
@@ -96,6 +96,16 @@ const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
               {t('hankeSidebar:editHanke')}
             </Button>
           </Link>
+
+          <div className={styles.hankeSidebar__indexContainer}>
+            <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
+              <div>1</div>
+              <div>2</div>
+            </div>
+            <div className={styles.hankeSidebar__indexContainer__numberContainer}>
+              <div>1</div>
+            </div>
+          </div>
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
@@ -97,19 +97,52 @@ const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
             </Button>
           </Link>
 
-          <div className={styles.hankeSidebar__indexContainer}>
-            <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
-              <Text tag="h3" styleAs="h6" weight="bold">
-                Ruuhkautuminen
-              </Text>
-              <Text tag="p" styleAs="body-m">
-                Kiertoreittitarve: todennäköinen
-              </Text>
-            </div>
-            <div className={styles.hankeSidebar__indexContainer__numberContainer}>
-              <StatusLabel type="info">2.7</StatusLabel>
-            </div>
-          </div>
+          <table>
+            <tbody>
+              <tr>
+                <div className={styles.hankeSidebar__indexContainer}>
+                  <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
+                    <Text tag="h3" styleAs="h5" weight="bold">
+                      Liikennehaittaindeksi
+                    </Text>
+                  </div>
+                  <div className={styles.hankeSidebar__indexContainer__numberContainer}>
+                    <StatusLabel type="error">4</StatusLabel>
+                  </div>
+                </div>
+              </tr>
+              <tr>
+                <div className={styles.hankeSidebar__indexContainer}>
+                  <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
+                    <Text tag="h3" styleAs="h6" weight="bold">
+                      Ruuhkautuminen
+                    </Text>
+                    <Text tag="p" styleAs="body-m">
+                      Kiertoreittitarve: todennäköinen
+                    </Text>
+                  </div>
+                  <div className={styles.hankeSidebar__indexContainer__numberContainer}>
+                    <StatusLabel type="alert">2.7</StatusLabel>
+                  </div>
+                </div>
+              </tr>
+              <tr>
+                <div className={styles.hankeSidebar__indexContainer}>
+                  <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
+                    <Text tag="h3" styleAs="h6" weight="bold">
+                      Pyöräilyn pääreitti
+                    </Text>
+                    <Text tag="p" styleAs="body-m">
+                      Kiertoreittitarve: ei tarvetta
+                    </Text>
+                  </div>
+                  <div className={styles.hankeSidebar__indexContainer__numberContainer}>
+                    <StatusLabel type="success">1</StatusLabel>
+                  </div>
+                </div>
+              </tr>
+            </tbody>
+          </table>
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
@@ -8,7 +8,7 @@ import Text from '../../../../common/components/text/Text';
 import { formatToFinnishDate } from '../../../../common/utils/date';
 import { HankeData } from '../../../types/hanke';
 import styles from './HankeSidebar.module.scss';
-import HankeIndexes from './HankeIndexes';
+import HankeIndexesContainer from './HankeIndexesContainer';
 import useLinkPath from '../../../../common/hooks/useLinkPath';
 import { ROUTES } from '../../../../common/types/route';
 
@@ -99,7 +99,7 @@ const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
           </Link>
           <hr />
 
-          <HankeIndexes hankeTunnus={hanke.hankeTunnus} />
+          <HankeIndexesContainer hankeTunnus={hanke.hankeTunnus} />
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Drawer, DrawerBody, DrawerContent } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 import { IconCross } from 'hds-react/icons';
-import { Button } from 'hds-react';
+import { Button, StatusLabel } from 'hds-react';
 import Text from '../../../../common/components/text/Text';
 import { formatToFinnishDate } from '../../../../common/utils/date';
 import { HankeData } from '../../../types/hanke';
@@ -99,11 +99,15 @@ const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
 
           <div className={styles.hankeSidebar__indexContainer}>
             <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
-              <div>1</div>
-              <div>2</div>
+              <Text tag="h3" styleAs="h6" weight="bold">
+                Ruuhkautuminen
+              </Text>
+              <Text tag="p" styleAs="body-m">
+                Kiertoreittitarve: todennäköinen
+              </Text>
             </div>
             <div className={styles.hankeSidebar__indexContainer__numberContainer}>
-              <div>1</div>
+              <StatusLabel type="info">2.7</StatusLabel>
             </div>
           </div>
         </DrawerBody>

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
@@ -3,11 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { Drawer, DrawerBody, DrawerContent } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 import { IconCross } from 'hds-react/icons';
-import { Button, StatusLabel } from 'hds-react';
+import { Button } from 'hds-react';
 import Text from '../../../../common/components/text/Text';
 import { formatToFinnishDate } from '../../../../common/utils/date';
 import { HankeData } from '../../../types/hanke';
 import styles from './HankeSidebar.module.scss';
+import HankeIndexes from './HankeIndexes';
 import useLinkPath from '../../../../common/hooks/useLinkPath';
 import { ROUTES } from '../../../../common/types/route';
 
@@ -98,44 +99,7 @@ const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
           </Link>
           <hr />
 
-          <div className={styles.hankeSidebar__indexes}>
-            <div className={styles.hankeSidebar__indexContainer}>
-              <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
-                <Text tag="h3" styleAs="h5" weight="bold">
-                  Liikennehaittaindeksi
-                </Text>
-              </div>
-              <div className={styles.hankeSidebar__indexContainer__statusContainer}>
-                <StatusLabel type="error">4</StatusLabel>
-              </div>
-            </div>
-            <div className={styles.hankeSidebar__indexContainer}>
-              <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
-                <Text tag="h3" styleAs="h6" weight="bold">
-                  Ruuhkautuminen
-                </Text>
-                <Text tag="p" styleAs="body-m">
-                  Kiertoreittitarve: todennäköinen
-                </Text>
-              </div>
-              <div className={styles.hankeSidebar__indexContainer__statusContainer}>
-                <StatusLabel type="alert">2.7</StatusLabel>
-              </div>
-            </div>
-            <div className={styles.hankeSidebar__indexContainer}>
-              <div className={styles.hankeSidebar__indexContainer__titlesContainer}>
-                <Text tag="h3" styleAs="h6" weight="bold">
-                  Pyöräilyn pääreitti
-                </Text>
-                <Text tag="p" styleAs="body-m">
-                  Kiertoreittitarve: ei tarvetta
-                </Text>
-              </div>
-              <div className={styles.hankeSidebar__indexContainer__statusContainer}>
-                <StatusLabel type="success">1</StatusLabel>
-              </div>
-            </div>
-          </div>
+          <HankeIndexes hankeTunnus={hanke.hankeTunnus} />
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/src/domain/mocks/hankeIndexData.ts
+++ b/src/domain/mocks/hankeIndexData.ts
@@ -1,0 +1,17 @@
+import { HankeIndexData, HANKE_INDEX_TYPE, HANKE_INDEX_STATE } from '../types/hanke';
+
+const hankeIndexData: HankeIndexData = {
+  hankeTunnus: 'HAI21-35',
+  hankeId: 62,
+  hankeGeometriatId: 52,
+  liikennehaittaIndeksi: {
+    indeksi: 4,
+    tyyppi: HANKE_INDEX_TYPE.PERUSINDEKSI,
+  },
+  perusIndeksi: 4,
+  pyorailyIndeksi: 3,
+  joukkoliikenneIndeksi: 1,
+  tila: HANKE_INDEX_STATE.VOIMASSA,
+};
+
+export default hankeIndexData;

--- a/src/domain/mocks/hankeList.ts
+++ b/src/domain/mocks/hankeList.ts
@@ -72,6 +72,7 @@ const hankeList: HankeData[] = [
     meluHaitta: null,
     polyHaitta: null,
     tarinaHaitta: null,
+    liikennehaittaindeksi: null,
   },
   {
     id: 2,
@@ -135,6 +136,7 @@ const hankeList: HankeData[] = [
     meluHaitta: null,
     polyHaitta: null,
     tarinaHaitta: null,
+    liikennehaittaindeksi: null,
   },
 ];
 

--- a/src/domain/types/hanke.ts
+++ b/src/domain/types/hanke.ts
@@ -146,6 +146,21 @@ export type HankeTilat = {
   onAsiakasryhmia: boolean;
 };
 
+export enum HANKE_INDEX_TYPE {
+  PERUSINDEKSI = 'PERUSINDEKSI',
+}
+
+export type LiikenneHaittaIndeksi = {
+  indeksi: number;
+  tyyppi: HANKE_INDEX_TYPE.PERUSINDEKSI;
+};
+
+export enum HANKE_INDEX_STATE {
+  VOIMASSA = 'VOIMASSA',
+}
+
+export type HANKE_INDEX_STATE_KEY = keyof typeof HANKE_INDEX_STATE;
+
 export interface HankeData {
   id: number;
   hankeTunnus: string;
@@ -162,6 +177,7 @@ export interface HankeData {
   haittaLoppuPvm: Date | null;
   kaistaHaitta: HANKE_KAISTAHAITTA_KEY | null;
   kaistaPituusHaitta: HANKE_KAISTAPITUUSHAITTA_KEY | null;
+  liikennehaittaindeksi: LiikenneHaittaIndeksi | null;
   meluHaitta: HANKE_MELUHAITTA_KEY | null;
   polyHaitta: HANKE_POLYAITTA_KEY | null;
   tarinaHaitta: HANKE_TARINAHAITTA_KEY | null;
@@ -177,6 +193,17 @@ export interface HankeData {
   createdAt?: string;
   modifiedBy?: null | string;
   modifiedAt?: null | string;
+}
+
+export interface HankeIndexData {
+  hankeTunnus: string;
+  hankeId: number;
+  hankeGeometriatId: number;
+  liikennehaittaIndeksi: LiikenneHaittaIndeksi;
+  perusIndeksi: number;
+  pyorailyIndeksi: number;
+  joukkoliikenneIndeksi: number;
+  tila: HANKE_INDEX_STATE_KEY;
 }
 
 type DraftRequiredFields =

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -248,6 +248,15 @@
     "closeButtonAriaLabel": "EN:Sulje hankevalikko",
     "editHanke": "EN: Muokkaa hankkeen tietoja"
   },
+  "hankeIndexes": {
+    "liikennehaittaindeksi": "EN: Liikennehaittaindeksi",
+    "ruuhkautuminen": "EN: Ruuhkautuminen",
+    "pyorailynPaareitti": "EN: Pyöräilyn pääreitti",
+    "merkittavatJoukkoliikennereitit": "EN: Merkittävät joukkoliikennereitit",
+    "kiertoreittitarve": "EN: Kiertoreittitarve",
+    "todennakoinen": "EN: todennäköinen",
+    "eiTarvetta": "EN: ei tarvetta"
+  },
   "hankeList": {
     "pageHeader": "EN:Hankelista",
     "paginationHeader": "EN:Sivu",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -255,7 +255,8 @@
     "merkittavatJoukkoliikennereitit": "EN: Merkittävät joukkoliikennereitit",
     "kiertoreittitarve": "EN: Kiertoreittitarve",
     "todennakoinen": "EN: todennäköinen",
-    "eiTarvetta": "EN: ei tarvetta"
+    "eiTarvetta": "EN: ei tarvetta",
+    "merkittava": "EN: merkittävä"
   },
   "hankeList": {
     "pageHeader": "EN:Hankelista",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -247,6 +247,15 @@
     "closeButtonAriaLabel": "Sulje hankevalikko",
     "editHanke": "Muokkaa hankkeen tietoja"
   },
+  "hankeIndexes": {
+    "liikennehaittaindeksi": "Liikennehaittaindeksi",
+    "ruuhkautuminen": "Ruuhkautuminen",
+    "pyorailynPaareitti": "Pyöräilyn pääreitti",
+    "merkittavatJoukkoliikennereitit": "Merkittävät joukkoliikennereitit",
+    "kiertoreittitarve": "Kiertoreittitarve",
+    "todennakoinen": "todennäköinen",
+    "eiTarvetta": "ei tarvetta"
+  },
   "hankeList": {
     "pageHeader": "Hankelista",
     "paginationHeader": "Sivu",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -254,7 +254,8 @@
     "merkittavatJoukkoliikennereitit": "Merkittävät joukkoliikennereitit",
     "kiertoreittitarve": "Kiertoreittitarve",
     "todennakoinen": "todennäköinen",
-    "eiTarvetta": "ei tarvetta"
+    "eiTarvetta": "ei tarvetta",
+    "merkittava": "merkittävä"
   },
   "hankeList": {
     "pageHeader": "Hankelista",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -247,6 +247,15 @@
     "closeButtonAriaLabel": "SV:Sulje hankevalikko",
     "editHanke": "SV: Muokkaa hankkeen tietoja"
   },
+  "hankeIndexes": {
+    "liikennehaittaindeksi": "SV: Liikennehaittaindeksi",
+    "ruuhkautuminen": "SV: Ruuhkautuminen",
+    "pyorailynPaareitti": "SV: Pyöräilyn pääreitti",
+    "merkittavatJoukkoliikennereitit": "SV: Merkittävät joukkoliikennereitit",
+    "kiertoreittitarve": "SV: Kiertoreittitarve",
+    "todennakoinen": "SV: todennäköinen",
+    "eiTarvetta": "SV: ei tarvetta"
+  },
   "hankeList": {
     "pageHeader": "SV:Hankelista",
     "paginationHeader": "SV:Sivu",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -254,7 +254,8 @@
     "merkittavatJoukkoliikennereitit": "SV: Merkittävät joukkoliikennereitit",
     "kiertoreittitarve": "SV: Kiertoreittitarve",
     "todennakoinen": "SV: todennäköinen",
-    "eiTarvetta": "SV: ei tarvetta"
+    "eiTarvetta": "SV: ei tarvetta",
+    "merkittava": "SV: merkittävä"
   },
   "hankeList": {
     "pageHeader": "SV:Hankelista",


### PR DESCRIPTION
# Haitaton-ui pull-request

Kyseessä on

- [ ] Bugikorjaus
- [x] Uusi toiminnallisuus (ei muuta olemassaolevaa toteutusta)
- [ ] Uusi toiminnallisuus (muuttaa jo olemassaolevaa toteutusta)

## Kuvaus mitä pull-request toteuttaa / korjaa
Toteutetaan UI-designin mukainen toteutus hankkeen ali-indekseistä sivupalkkiin -- käyttäen staattista dataa vielä tässä vaiheessa. Seuraavissa askeleissa data haetaan ja poimitaan dynaamisesta backendiltä.

PR avattu tukemaan keskustelua toteutuksesta.


TODO: 
1. Tyylittele taulun joka toinen rivi eri värillä
2. indeksin stylelabel tulee olla yhtä leveä jokaiselle indeksinumerolle