### PR TITLE
HAI-737: Indeksilaskennan varmistus

### DIFF
--- a/src/common/components/app/App.tsx
+++ b/src/common/components/app/App.tsx
@@ -6,6 +6,7 @@ import { ChakraProvider } from '@chakra-ui/react';
 import AppRoutes from '../../routes/AppRoutes';
 import Layout from './Layout';
 import { store } from '../../redux/store';
+import theme from './theme';
 import './app.scss';
 import '../../../assets/styles/reset.css';
 
@@ -21,7 +22,7 @@ const App: React.FC = () => (
   <Router>
     <Provider store={store}>
       <QueryClientProvider client={queryClient}>
-        <ChakraProvider>
+        <ChakraProvider theme={theme}>
           <Layout>
             <AppRoutes />
           </Layout>

--- a/src/common/components/app/app.scss
+++ b/src/common/components/app/app.scss
@@ -32,12 +32,6 @@ body {
   min-height: 100vh;
 }
 
-// https://github.com/chakra-ui/chakra-ui/issues/2893
-// Remove this when above issue is fixed
-.chakra-modal__content-container {
-  width: auto !important;
-}
-
 .chakra-modal__overlay {
   background: #333;
   opacity: 0.2;

--- a/src/common/components/app/theme.ts
+++ b/src/common/components/app/theme.ts
@@ -17,7 +17,7 @@ import { createBreakpoints } from '@chakra-ui/theme-tools';
   '5xl': '4.5rem',
 }; */
 
-export const breakpoints = createBreakpoints({
+const breakpoints = createBreakpoints({
   sm: '320px',
   md: '576px',
   lg: '768px',
@@ -27,6 +27,24 @@ export const breakpoints = createBreakpoints({
 
 const customTheme = extendTheme({
   breakpoints,
+  components: {
+    Drawer: {
+      variants: {
+        // https://github.com/chakra-ui/chakra-ui/issues/2399
+        alwaysOpen: {
+          // eslint-disable-next-line
+          // @ts-ignore, false positive
+          parts: ['dialog, dialogContainer'],
+          dialog: {
+            pointerEvents: 'auto',
+          },
+          dialogContainer: {
+            pointerEvents: 'none',
+          },
+        },
+      },
+    },
+  },
 });
 
 export default customTheme;

--- a/src/common/components/confirmationDialog/ConfirmationDialog.tsx
+++ b/src/common/components/confirmationDialog/ConfirmationDialog.tsx
@@ -2,22 +2,14 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-
-import {
-  AlertDialog,
-  AlertDialogBody,
-  AlertDialogFooter,
-  AlertDialogContent,
-  AlertDialogOverlay,
-} from '@chakra-ui/react';
 import { Button } from 'hds-react';
 import { getIsDialogOpen, getRedirectUrl } from './selectors';
 import { actions } from './reducer';
+import ConfirmationDialogUI from './ConfirmationDialogUI';
 
 import './Dialog.styles.scss';
 
 const ConfirmationDialog: React.FC = () => {
-  const cancelRef = React.useRef<HTMLButtonElement>(null);
   const isDialogOpenVal = useSelector(getIsDialogOpen());
   const redirectUrl = useSelector(getRedirectUrl());
   const dispatch = useDispatch();
@@ -26,35 +18,21 @@ const ConfirmationDialog: React.FC = () => {
   function onClose() {
     dispatch(actions.updateIsDialogOpen({ isDialogOpen: false, redirectUrl }));
   }
-  function cancel() {
-    dispatch(actions.updateIsDialogOpen({ isDialogOpen: false, redirectUrl }));
-  }
-  function exit() {
+  function closeAndRedirect() {
     dispatch(actions.updateIsDialogOpen({ isDialogOpen: false, redirectUrl }));
     history.push(redirectUrl);
   }
-  return (
-    <>
-      <AlertDialog
-        isOpen={isDialogOpenVal}
-        leastDestructiveRef={cancelRef}
-        onClose={() => onClose()}
-      >
-        <AlertDialogOverlay />
-        <AlertDialogContent>
-          <AlertDialogBody>{t('common:confirmationDialog:bodyText')}</AlertDialogBody>
 
-          <AlertDialogFooter>
-            <Button type="button" theme="coat" ref={cancelRef} onClick={() => cancel()}>
-              {t('common:confirmationDialog:cancelButton')}
-            </Button>
-            <Button type="button" theme="coat" variant="secondary" onClick={() => exit()}>
-              {t('common:confirmationDialog:exitButton')}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
+  return (
+    <ConfirmationDialogUI
+      handleClose={onClose}
+      body={t('common:confirmationDialog:bodyText')}
+      isOpen={isDialogOpenVal}
+    >
+      <Button type="button" theme="coat" variant="secondary" onClick={() => closeAndRedirect()}>
+        {t('common:confirmationDialog:exitButton')}
+      </Button>
+    </ConfirmationDialogUI>
   );
 };
 export default ConfirmationDialog;

--- a/src/common/components/confirmationDialog/ConfirmationDialogUI.tsx
+++ b/src/common/components/confirmationDialog/ConfirmationDialogUI.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogFooter,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  AlertDialogCloseButton,
+} from '@chakra-ui/react';
+import { Button } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import './Dialog.styles.scss';
+
+type Props = {
+  body: string;
+  children: React.ReactNode;
+  isOpen: boolean;
+  handleClose: () => void;
+};
+
+const ConfirmationDialog: React.FC<Props> = ({ body, children, isOpen, handleClose }) => {
+  const cancelRef = React.useRef<HTMLButtonElement>(null);
+  const { t } = useTranslation();
+
+  return (
+    <AlertDialog isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={handleClose} isCentered>
+      <AlertDialogOverlay />
+      <AlertDialogContent>
+        <AlertDialogCloseButton />
+        <AlertDialogBody>{body}</AlertDialogBody>
+        <AlertDialogFooter>
+          <Button
+            type="button"
+            theme="coat"
+            variant="secondary"
+            ref={cancelRef}
+            onClick={handleClose}
+          >
+            {t('common:confirmationDialog:cancelButton')}
+          </Button>
+          {children}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+export default ConfirmationDialog;

--- a/src/common/components/confirmationDialog/ConfirmationDialogUI.tsx
+++ b/src/common/components/confirmationDialog/ConfirmationDialogUI.tsx
@@ -32,7 +32,7 @@ const ConfirmationDialog: React.FC<Props> = ({ body, children, isOpen, handleClo
           <Button
             type="button"
             theme="coat"
-            variant="secondary"
+            variant="primary"
             ref={cancelRef}
             onClick={handleClose}
           >

--- a/src/domain/hanke/edit/Form.test.tsx
+++ b/src/domain/hanke/edit/Form.test.tsx
@@ -15,7 +15,6 @@ const alkuPvm = '24.03.2025';
 const loppuPvm = '25.03.2032';
 const haittaAlkuPvm = '01.04.2026';
 const haittaLoppuPvm = '01.03.2031';
-
 const omistajaEtunimi = 'Matti';
 const katuosoite = 'Pohjoinen Rautatiekatu 11 b 12';
 const hankeenKuvaus = 'Tässä on kuvaus';
@@ -43,13 +42,13 @@ describe('HankeForm', () => {
     const handleIsDirtyChange = jest.fn();
     const handleUnmount = jest.fn();
     const handleFormClose = jest.fn();
-    const handleSubmit = jest.fn();
+    const onCalculateIndexes = jest.fn();
 
     const { getByTestId, getByLabelText, queryAllByText } = render(
       <Form
         formData={formData}
         onSave={handleSave}
-        onSubmit={handleSubmit}
+        onCalculateIndexes={onCalculateIndexes}
         onSaveGeometry={handleSaveGeometry}
         onIsDirtyChange={handleIsDirtyChange}
         onUnmount={handleUnmount}
@@ -144,13 +143,13 @@ describe('HankeForm', () => {
     const handleIsDirtyChange = jest.fn();
     const handleUnmount = jest.fn();
     const handleFormClose = jest.fn();
-    const handleSubmit = jest.fn();
+    const onCalculateIndexes = jest.fn();
 
     const { getByTestId, getByLabelText, queryAllByText } = render(
       <Form
         formData={formData}
         onSave={handleSave}
-        onSubmit={handleSubmit}
+        onCalculateIndexes={onCalculateIndexes}
         onSaveGeometry={handleSaveGeometry}
         onIsDirtyChange={handleIsDirtyChange}
         onUnmount={handleUnmount}
@@ -185,13 +184,13 @@ describe('HankeForm', () => {
     const handleIsDirtyChange = jest.fn();
     const handleUnmount = jest.fn();
     const handleFormClose = jest.fn();
-    const handleSubmit = jest.fn();
+    const onCalculateIndexes = jest.fn();
 
     const { getByTestId, getByLabelText, queryAllByText, queryByText } = render(
       <Form
         formData={formData}
         onSave={handleSave}
-        onSubmit={handleSubmit}
+        onCalculateIndexes={onCalculateIndexes}
         onSaveGeometry={handleSaveGeometry}
         onIsDirtyChange={handleIsDirtyChange}
         onUnmount={handleUnmount}
@@ -265,7 +264,7 @@ describe('HankeForm', () => {
           [FORMFIELD.NIMI]: 'Lenkkeilijä Pekka',
         }}
         onSave={() => ({})}
-        onSubmit={() => ({})}
+        onCalculateIndexes={() => ({})}
         onSaveGeometry={() => ({})}
         onIsDirtyChange={() => ({})}
         onUnmount={() => ({})}
@@ -285,7 +284,7 @@ describe('HankeForm', () => {
           [FORMFIELD.ALKU_PVM]: '1999-03-15T00:00:00Z',
         }}
         onSave={() => ({})}
-        onSubmit={() => ({})}
+        onCalculateIndexes={() => ({})}
         onSaveGeometry={() => ({})}
         onIsDirtyChange={() => ({})}
         onUnmount={() => ({})}
@@ -307,7 +306,7 @@ describe('HankeForm', () => {
           },
         }}
         onSave={() => ({})}
-        onSubmit={() => ({})}
+        onCalculateIndexes={() => ({})}
         onSaveGeometry={() => ({})}
         onIsDirtyChange={() => ({})}
         onUnmount={() => ({})}

--- a/src/domain/hanke/edit/Form.tsx
+++ b/src/domain/hanke/edit/Form.tsx
@@ -50,14 +50,7 @@ const HankeForm: React.FC<Props> = ({
     },
   });
 
-  const {
-    /* handleSubmit, */ errors,
-    control,
-    register,
-    formState,
-    getValues,
-    reset,
-  } = formContext;
+  const { errors, control, register, formState, getValues, reset } = formContext;
 
   useEffect(() => {
     reset(formData);
@@ -106,11 +99,7 @@ const HankeForm: React.FC<Props> = ({
         <div className="hankeForm__formWpr">
           <StateIndicator formPage={formPage} />
           <div className="hankeForm__formWprRight">
-            <form
-              name="hanke"
-              // eslint-disable-next-line no-console
-              onSubmit={() => console.error('This should not happen.')}
-            >
+            <form name="hanke">
               <div className="closeFormWpr">
                 <button
                   type="button"

--- a/src/domain/hanke/edit/Form.tsx
+++ b/src/domain/hanke/edit/Form.tsx
@@ -19,7 +19,7 @@ import './Form.styles.scss';
 type Props = {
   formData: HankeDataFormState;
   onSave: (args: SaveFormArguments) => void;
-  onSubmit: (data: HankeDataFormState) => void;
+  onCalculateIndexes: (hankeTunnus: string) => void;
   onSaveGeometry: (hankeTunnus: string) => void;
   onIsDirtyChange: (isDirty: boolean) => void;
   onUnmount: () => void;
@@ -29,7 +29,7 @@ type Props = {
 const HankeForm: React.FC<Props> = ({
   formData,
   onSave,
-  onSubmit,
+  onCalculateIndexes,
   onSaveGeometry,
   onIsDirtyChange,
   onUnmount,
@@ -50,7 +50,14 @@ const HankeForm: React.FC<Props> = ({
     },
   });
 
-  const { handleSubmit, errors, control, register, formState, getValues, reset } = formContext;
+  const {
+    /* handleSubmit, */ errors,
+    control,
+    register,
+    formState,
+    getValues,
+    reset,
+  } = formContext;
 
   useEffect(() => {
     reset(formData);
@@ -99,7 +106,11 @@ const HankeForm: React.FC<Props> = ({
         <div className="hankeForm__formWpr">
           <StateIndicator formPage={formPage} />
           <div className="hankeForm__formWprRight">
-            <form name="hanke" onSubmit={handleSubmit(onSubmit)}>
+            <form
+              name="hanke"
+              // eslint-disable-next-line no-console
+              onSubmit={() => console.error('This should not happen.')}
+            >
               <div className="closeFormWpr">
                 <button
                   type="button"
@@ -129,6 +140,7 @@ const HankeForm: React.FC<Props> = ({
                 goBack={goBack}
                 goForward={goForward}
                 saveDraft={saveDraft}
+                onCalculateIndexes={onCalculateIndexes}
                 formPage={formPage}
               />
             </form>

--- a/src/domain/hanke/edit/FormButtons.tsx
+++ b/src/domain/hanke/edit/FormButtons.tsx
@@ -71,15 +71,17 @@ const FormButtons: React.FC<Props> = ({
         isOpen={isOpen}
         handleClose={() => setIsOpen(false)}
       >
-        <button
+        <Button
           type="button"
+          theme="coat"
+          variant="secondary"
           onClick={() => {
             onCalculateIndexes(hankeTunnus);
             setIsOpen(false);
           }}
         >
           {t('hankeForm:confirmIndexCalculationButton')}
-        </button>
+        </Button>
       </ConfirmationDialogUI>
       {formPage === 4 && (
         <Button

--- a/src/domain/hanke/edit/FormButtons.tsx
+++ b/src/domain/hanke/edit/FormButtons.tsx
@@ -1,24 +1,35 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Button } from 'hds-react';
 import { IconAngleLeft, IconAngleRight } from 'hds-react/icons';
 import { HankeTilat } from '../../types/hanke';
+import ConfirmationDialogUI from '../../../common/components/confirmationDialog/ConfirmationDialogUI';
 
 type Props = {
   goBack: () => void;
+  onCalculateIndexes: (hankeTunnus: string) => void;
   goForward: () => void;
   saveDraft: () => void;
   formPage: number;
 };
 
-const FormButtons: React.FC<Props> = ({ goBack, goForward, saveDraft, formPage }) => {
+const FormButtons: React.FC<Props> = ({
+  goBack,
+  goForward,
+  saveDraft,
+  formPage,
+  onCalculateIndexes,
+}) => {
   const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+
   const {
     watch,
     formState: { isValid, isDirty },
   } = useFormContext();
   const hankeTilat: HankeTilat | undefined = watch('tilat');
+  const hankeTunnus: string = watch('hankeTunnus');
 
   let previousButtonText = '';
   let nextButtonText = '';
@@ -55,6 +66,21 @@ const FormButtons: React.FC<Props> = ({ goBack, goForward, saveDraft, formPage }
 
   return (
     <div className="btnWpr">
+      <ConfirmationDialogUI
+        body={t('hankeForm:calculateIndexDialogBody')}
+        isOpen={isOpen}
+        handleClose={() => setIsOpen(false)}
+      >
+        <button
+          type="button"
+          onClick={() => {
+            onCalculateIndexes(hankeTunnus);
+            setIsOpen(false);
+          }}
+        >
+          {t('hankeForm:confirmIndexCalculationButton')}
+        </button>
+      </ConfirmationDialogUI>
       {formPage === 4 && (
         <Button
           className="btnWpr--next"
@@ -62,6 +88,10 @@ const FormButtons: React.FC<Props> = ({ goBack, goForward, saveDraft, formPage }
           iconRight={<IconAngleRight />}
           variant="secondary"
           data-testid="submitButton"
+          onClick={(e) => {
+            e.preventDefault();
+            setIsOpen(true);
+          }}
           disabled={
             !isValid ||
             !hankeTilat?.onTiedotLiikenneHaittaIndeksille ||

--- a/src/domain/hanke/edit/FormContainer.tsx
+++ b/src/domain/hanke/edit/FormContainer.tsx
@@ -9,7 +9,7 @@ import { saveForm, calculateIndex } from './thunks';
 import { saveGeometryData } from '../../map/thunks';
 import HankeForm from './Form';
 import { actions, hankeDataDraft } from './reducer';
-import { SaveFormArguments, HankeDataFormState } from './types';
+import { SaveFormArguments } from './types';
 import { convertHankeDataToFormState } from './utils';
 
 import api from '../../api/api';
@@ -54,7 +54,7 @@ const HankeFormContainer: React.FC<Props> = ({ hankeTunnus }) => {
   };
 
   // eslint-disable-next-line @typescript-eslint/no-shadow
-  const handleCalculateIndex = ({ hankeTunnus }: HankeDataFormState) => {
+  const handleCalculateIndex = (hankeTunnus: string) => {
     if (hankeTunnus) dispatch(calculateIndex(hankeTunnus));
   };
 
@@ -83,7 +83,7 @@ const HankeFormContainer: React.FC<Props> = ({ hankeTunnus }) => {
     <HankeForm
       formData={formData}
       onSave={handleSave}
-      onSubmit={handleCalculateIndex}
+      onCalculateIndexes={handleCalculateIndex}
       onSaveGeometry={handleSaveGeometry}
       onIsDirtyChange={handleIsDirtyChange}
       onUnmount={handleUnmount}

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
@@ -41,6 +41,7 @@ const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
 
   return (
     <Drawer
+      variant="alwaysOpen"
       placement="left"
       isOpen={isOpen}
       size="md"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -183,7 +183,8 @@
     "indexCalculationFailHeader": "EN:Törmäystarkastelun laskenta epäonnistui",
     "indexCalculationFailText": "EN:Tuntematon virhe",
     "closeAriaLabel": "EN:Poistu kaavakkeelta tallentamatta",
-
+    "calculateIndexDialogBody": "EN:Haitattoman Beta-versiossa indeksilaskentaa ei voi suorittaa uudelleen, haluatko varmasti laskea indeksit nyt, vai tarkistatko vielä hankkeen tietojen oikeellisuuden?",
+    "confirmIndexCalculationButton": "EN:Jatka indeksilaskentaan",
     "labels": {
       "hankeTunnus": "EN:Hankkeen tunnus",
       "nimi": "EN:Hankkeen nimi",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -183,7 +183,7 @@
     "indexCalculationFailHeader": "EN:Törmäystarkastelun laskenta epäonnistui",
     "indexCalculationFailText": "EN:Tuntematon virhe",
     "closeAriaLabel": "EN:Poistu kaavakkeelta tallentamatta",
-    "calculateIndexDialogBody": "EN:Haitattoman Beta-versiossa indeksilaskentaa ei voi suorittaa uudelleen, haluatko varmasti laskea indeksit nyt, vai tarkistatko vielä hankkeen tietojen oikeellisuuden?",
+    "calculateIndexDialogBody": "EN:Haitattoman Beta-versiossa hanketta ei voi muokata sen jälkeen kun sille on laskettu haittaindeksit. Ennen kuin lasket indeksit, kannattaa käydä katsomassa hankkeen tilannetta karttanäkymässä (ylävalikossa) ja tarvittaessa muokata hankkeen tietoja ennen indeksien laskentaa. Mikäli olet valmis indeksien laskentaan, voit laskea indeksit nyt, tai palata lomakkeelle ja muokata hankkeen tietoja. Hanke säilyy tallennuksen jälkeen hankelistalla ja karttanäkymässä.",
     "confirmIndexCalculationButton": "EN:Jatka indeksilaskentaan",
     "labels": {
       "hankeTunnus": "EN:Hankkeen tunnus",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -183,6 +183,8 @@
     "indexCalculationFailHeader": "Törmäystarkastelun laskenta epäonnistui",
     "indexCalculationFailText": "Tuntematon virhe",
     "closeAriaLabel": "Poistu kaavakkeelta tallentamatta",
+    "calculateIndexDialogBody": "Haitattoman Beta-versiossa indeksilaskentaa ei voi suorittaa uudelleen, haluatko varmasti laskea indeksit nyt, vai tarkistatko vielä hankkeen tietojen oikeellisuuden?",
+    "confirmIndexCalculationButton": "Jatka indeksilaskentaan",
     "labels": {
       "hankeTunnus": "Hankkeen tunnus",
       "nimi": "Hankkeen nimi",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -183,7 +183,7 @@
     "indexCalculationFailHeader": "Törmäystarkastelun laskenta epäonnistui",
     "indexCalculationFailText": "Tuntematon virhe",
     "closeAriaLabel": "Poistu kaavakkeelta tallentamatta",
-    "calculateIndexDialogBody": "Haitattoman Beta-versiossa indeksilaskentaa ei voi suorittaa uudelleen, haluatko varmasti laskea indeksit nyt, vai tarkistatko vielä hankkeen tietojen oikeellisuuden?",
+    "calculateIndexDialogBody": "Haitattoman Beta-versiossa hanketta ei voi muokata sen jälkeen kun sille on laskettu haittaindeksit. Ennen kuin lasket indeksit, kannattaa käydä katsomassa hankkeen tilannetta karttanäkymässä (ylävalikossa) ja tarvittaessa muokata hankkeen tietoja ennen indeksien laskentaa. Mikäli olet valmis indeksien laskentaan, voit laskea indeksit nyt, tai palata lomakkeelle ja muokata hankkeen tietoja. Hanke säilyy tallennuksen jälkeen hankelistalla ja karttanäkymässä.",
     "confirmIndexCalculationButton": "Jatka indeksilaskentaan",
     "labels": {
       "hankeTunnus": "Hankkeen tunnus",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -183,7 +183,7 @@
     "indexCalculationFailHeader": "SV:Törmäystarkastelun laskenta epäonnistui",
     "indexCalculationFailText": "SV:Tuntematon virhe",
     "closeAriaLabel": "SV:Poistu kaavakkeelta tallentamatta",
-    "calculateIndexDialogBody": "SV:Haitattoman Beta-versiossa indeksilaskentaa ei voi suorittaa uudelleen, haluatko varmasti laskea indeksit nyt, vai tarkistatko vielä hankkeen tietojen oikeellisuuden?",
+    "calculateIndexDialogBody": "SV:Haitattoman Beta-versiossa hanketta ei voi muokata sen jälkeen kun sille on laskettu haittaindeksit. Ennen kuin lasket indeksit, kannattaa käydä katsomassa hankkeen tilannetta karttanäkymässä (ylävalikossa) ja tarvittaessa muokata hankkeen tietoja ennen indeksien laskentaa. Mikäli olet valmis indeksien laskentaan, voit laskea indeksit nyt, tai palata lomakkeelle ja muokata hankkeen tietoja. Hanke säilyy tallennuksen jälkeen hankelistalla ja karttanäkymässä.",
     "confirmIndexCalculationButton": "SV:Jatka indeksilaskentaan",
     "labels": {
       "hankeTunnus": "SV:Hankkeen tunnus",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -183,6 +183,8 @@
     "indexCalculationFailHeader": "SV:Törmäystarkastelun laskenta epäonnistui",
     "indexCalculationFailText": "SV:Tuntematon virhe",
     "closeAriaLabel": "SV:Poistu kaavakkeelta tallentamatta",
+    "calculateIndexDialogBody": "SV:Haitattoman Beta-versiossa indeksilaskentaa ei voi suorittaa uudelleen, haluatko varmasti laskea indeksit nyt, vai tarkistatko vielä hankkeen tietojen oikeellisuuden?",
+    "confirmIndexCalculationButton": "SV:Jatka indeksilaskentaan",
     "labels": {
       "hankeTunnus": "SV:Hankkeen tunnus",
       "nimi": "SV:Hankkeen nimi",


### PR DESCRIPTION
# Haitaton-ui pull-request

Kyseessä on

- [x] Bugikorjaus
- [x] Uusi toiminnallisuus (ei muuta olemassaolevaa toteutusta)
- [x] Uusi toiminnallisuus (muuttaa jo olemassaolevaa toteutusta)

## Kuvaus mitä pull-request toteuttaa / korjaa

Lisää ennen indeksinlaskentaa dialogin, joka tarkentaa että indeksit voi laskea vain kerran.
Korjattu myös purkkaratkaisu joka poisti dialogin keskityksen: https://helsinkisolutionoffice.atlassian.net/browse/HAI-678
Pientä refaktorointia ConfirmationDialog-komponenttiin

## Checklist:

- [x] Muuttujat ovat kuvaavasti nimettyjä eikä koodi sisällä kirjoitusvirheitä
- [ ] Muutokseni eivät aiheuta uusia virheitä consoleen
- [ ] Olen toteuttanut Jest-testit toiminnallisuuden testaukseen
