### PR TITLE
HAI-900: Indeksien värien selitys kartalle

### DIFF
--- a/src/common/components/app/layout.styles.scss
+++ b/src/common/components/app/layout.styles.scss
@@ -1,6 +1,6 @@
 .pageContainer {
   position: relative;
   padding-bottom: 60px;
-  min-height: calc(100vh - 75px); // Header 75px
+  min-height: calc(100vh - 72px); // Header 72px
   margin: auto;
 }

--- a/src/domain/common/utils/liikennehaittaindeksi.ts
+++ b/src/domain/common/utils/liikennehaittaindeksi.ts
@@ -18,10 +18,10 @@ export const INDEX_GREEN = '#009246';
 export const INDEX_BLUE = '#2472c6';
 
 export enum LIIKENNEHAITTA_STATUS {
-  BLUE = 'BLUE',
-  GREEN = 'GREEN',
-  YELLOW = 'YELLOW',
   RED = 'RED',
+  YELLOW = 'YELLOW',
+  GREEN = 'GREEN',
+  BLUE = 'BLUE',
 }
 
 export const getStatusByIndex = (index: TormaysIndex) => {

--- a/src/domain/map/HankeMap.tsx
+++ b/src/domain/map/HankeMap.tsx
@@ -14,6 +14,7 @@ import { MapTileLayerId } from './types';
 import FeatureClick from '../../common/components/map/interactions/FeatureClick';
 import GeometryHover from '../../common/components/map/interactions/hover/GeometryHover';
 import HankeHoverBox from './components/HankeHover/HankeHoverBox';
+import MapGuide from './components/MapGuide/MapGuide';
 import HankkeetProvider from './HankkeetProvider';
 
 const HankeMap: React.FC = () => {
@@ -36,6 +37,7 @@ const HankeMap: React.FC = () => {
       >
         <h1 className={styles.allyHeader}>Karttasivu</h1> {/* For a11y */}
         <Map zoom={zoom} mapClassName={styles.mapContainer__inner}>
+          <MapGuide />
           {mapTileLayers.ortokartta.visible && <Ortokartta />}
           {mapTileLayers.kantakartta.visible && <Kantakartta />}
 

--- a/src/domain/map/components/MapGuide/MapGuide.module.scss
+++ b/src/domain/map/components/MapGuide/MapGuide.module.scss
@@ -1,0 +1,18 @@
+.mapGuide {
+  background: var(--color-white);
+  color: black;
+  pointer-events: all;
+  padding: var(--spacing-2-xs);
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  box-shadow: 5px 5px 10px var(--color-black-20);
+  font-size: 14px;
+
+  &__colorBox {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    margin-right: 5px;
+  }
+}

--- a/src/domain/map/components/MapGuide/MapGuide.tsx
+++ b/src/domain/map/components/MapGuide/MapGuide.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { $enum } from 'ts-enum-util';
+import {
+  LIIKENNEHAITTA_STATUS,
+  getColorByStatus,
+} from '../../../common/utils/liikennehaittaindeksi';
+import styles from './MapGuide.module.scss';
+
+const MapGuide = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.mapGuide}>
+      {$enum(LIIKENNEHAITTA_STATUS).map((status) => (
+        <div>
+          <span
+            className={styles.mapGuide__colorBox}
+            style={{
+              background: getColorByStatus(status),
+            }}
+          />
+          <span className={styles.mapGuide__text}>{t(`map:guide:indexColor:${status}`)}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MapGuide;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -302,6 +302,14 @@
       "begin": "EN: Ajanjakson alku",
       "end": "EN: Ajanjakson loppu"
     },
+    "guide": {
+      "indexColor": {
+        "RED": "EN:Kriittinen",
+        "YELLOW": "EN:Huomioitava",
+        "GREEN": "EN:Ei merkittävä",
+        "BLUE": "EN:Indeksoimaton"
+      }
+    },
     "drawSquareButtonAria": "EN:Piirrä neliö kartalle",
     "drawPolygonButtonAria": "EN:Piirrä monikulmio kartalle"
   }

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -301,6 +301,14 @@
       "begin": "Ajanjakson alku",
       "end": "Ajanjakson loppu"
     },
+    "guide": {
+      "indexColor": {
+        "RED": "Kriittinen",
+        "YELLOW": "Huomioitava",
+        "GREEN": "Ei merkittävä",
+        "BLUE": "Indeksoimaton"
+      }
+    },
     "drawSquareButtonAria": "Piirrä neliö kartalle",
     "drawPolygonButtonAria": "Piirrä monikulmio kartalle"
   }

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -301,6 +301,14 @@
       "begin": "SV: Ajanjakson alku",
       "end": "SV: Ajanjakson loppu"
     },
+    "guide": {
+      "indexColor": {
+        "RED": "SV:Kriittinen",
+        "YELLOW": "SV:Huomioitava",
+        "GREEN": "SV:Ei merkittävä",
+        "BLUE": "SV:Indeksoimaton"
+      }
+    },
     "drawSquareButtonAria": "SV:Piirrä neliö kartalle",
     "drawPolygonButtonAria": "SV:Piirrä monikulmio kartalle"
   }


### PR DESCRIPTION
# Haitaton-ui pull-request

Kyseessä on

- [ ] Bugikorjaus
- [x] Uusi toiminnallisuus (ei muuta olemassaolevaa toteutusta)
- [ ] Uusi toiminnallisuus (muuttaa jo olemassaolevaa toteutusta)

## Kuvaus mitä pull-request toteuttaa / korjaa

Indeksien värinselitysboksi kartan yläkulmaan. 

## Checklist:

- [ ] Muuttujat ovat kuvaavasti nimettyjä eikä koodi sisällä kirjoitusvirheitä
- [ ] Muutokseni eivät aiheuta uusia virheitä consoleen
- [ ] Olen toteuttanut Jest-testit toiminnallisuuden testaukseen
