### PR TITLE
Hai 959 - E2E-testit pääputkelle, hankkeen luonti ja indeksien laskenta

### DIFF
--- a/cypress/integration/E2E.spec.ts
+++ b/cypress/integration/E2E.spec.ts
@@ -1,4 +1,11 @@
 /// <reference types="cypress" />
+import {
+  HANKE_KAISTAHAITTA,
+  HANKE_KAISTAPITUUSHAITTA,
+  HANKE_MELUHAITTA,
+  HANKE_POLYHAITTA,
+  HANKE_TARINAHAITTA,
+} from './../../src/domain/types/hanke';
 import { createHankeFromUI } from './../utils/formFiller';
 import {
   HANKE_VAIHE,
@@ -6,24 +13,57 @@ import {
   HANKE_SUUNNITTELUVAIHE,
 } from './../../src/domain/types/hanke';
 
-const drawCoordinateX = 100;
-const drawCoordinateY = 100;
-
+// TODO: define types that would not require unnecessary types
 const hankeMock: HankeDataDraft = {
+  id: 0, // not used but types require it
+  hankeTunnus: 'not used', // not used but types require it
+  tilat: {
+    // not used but types require it
+    onGeometrioita: false,
+    onKaikkiPakollisetLuontiTiedot: false,
+    onTiedotLiikenneHaittaIndeksille: false,
+    onLiikenneHaittaIndeksi: false,
+    onViereisiaHankkeita: false,
+    onAsiakasryhmia: false,
+  },
   onYKTHanke: true,
   nimi: 'E2E-hankkeen-testaus',
   kuvaus: 'Tämä on hankkeen kuvaus',
   alkuPvm: '10.01.2030',
   loppuPvm: '11.01.2032',
-  tyomaaKatuosoite: '',
+  haittaAlkuPvm: '10.01.2030',
+  haittaLoppuPvm: '10.01.2032', // TODO: BUG: HAI-974: loppuPvm cant be same as haittaLoppuPvm
+  tyomaaKatuosoite: 'Mannerheimintie 14',
   vaihe: HANKE_VAIHE.SUUNNITTELU,
   suunnitteluVaihe: HANKE_SUUNNITTELUVAIHE.KATUSUUNNITTELU_TAI_ALUEVARAUS,
-  haittaLoppuPvm: new Date('31.12.2031'),
+  omistajat: [
+    {
+      id: null, // not used but types require it
+      etunimi: 'Harri',
+      sukunimi: 'Hankettaja',
+      email: 'harri.hanketest@hankekatu.foo',
+      puhelinnumero: '12341234',
+      organisaatioId: null, // not used but types require it
+      organisaatioNimi: '', // not used but types require it
+      osasto: '', // not used but types require it
+    },
+  ],
+  kaistaHaitta: HANKE_KAISTAHAITTA.VIISI,
+  kaistaPituusHaitta: HANKE_KAISTAPITUUSHAITTA.VIISI,
+  meluHaitta: HANKE_MELUHAITTA.KOLME,
+  polyHaitta: HANKE_POLYHAITTA.KOLME,
+  tarinaHaitta: HANKE_TARINAHAITTA.KOLME,
 };
 
 context('HankeForm', () => {
-  it('Hanke form testing', () => {
+  beforeEach(() => {
     cy.login();
-    createHankeFromUI(hankeMock);
+  });
+
+  it('Hanke form testing', () => {
+    const countIndexes = true;
+    createHankeFromUI(hankeMock, countIndexes);
+    // TODO: validateHankeInfoFromHankeList(hankeMock)
+    // TODO: validateHankeInfoFromMap(hankeMock)
   });
 });

--- a/cypress/integration/E2E.spec.ts
+++ b/cypress/integration/E2E.spec.ts
@@ -1,3 +1,4 @@
+import { HankeIndexData, HANKE_INDEX_TYPE } from './../../src/domain/types/hanke';
 /// <reference types="cypress" />
 import {
   HANKE_KAISTAHAITTA,
@@ -12,6 +13,7 @@ import {
   HankeDataDraft,
   HANKE_SUUNNITTELUVAIHE,
 } from './../../src/domain/types/hanke';
+import { validateIndexes } from '../utils/indexValidator';
 
 // TODO: define types that would not require unnecessary types
 const hankeMock: HankeDataDraft = {
@@ -55,6 +57,16 @@ const hankeMock: HankeDataDraft = {
   tarinaHaitta: HANKE_TARINAHAITTA.KOLME,
 };
 
+const hankeMockIndex: Partial<HankeIndexData> = {
+  liikennehaittaIndeksi: {
+    indeksi: 4.8,
+    tyyppi: HANKE_INDEX_TYPE.PERUSINDEKSI,
+  },
+  pyorailyIndeksi: 3,
+  joukkoliikenneIndeksi: 4,
+  perusIndeksi: 4.8,
+};
+
 context('HankeForm', () => {
   beforeEach(() => {
     cy.login();
@@ -65,5 +77,6 @@ context('HankeForm', () => {
     createHankeFromUI(hankeMock, countIndexes);
     // TODO: validateHankeInfoFromHankeList(hankeMock)
     // TODO: validateHankeInfoFromMap(hankeMock)
+    validateIndexes(hankeMockIndex);
   });
 });

--- a/cypress/integration/E2E.spec.ts
+++ b/cypress/integration/E2E.spec.ts
@@ -1,5 +1,5 @@
-import { HankeIndexData, HANKE_INDEX_TYPE } from './../../src/domain/types/hanke';
 /// <reference types="cypress" />
+import { HankeIndexData, HANKE_INDEX_TYPE } from './../../src/domain/types/hanke';
 import {
   HANKE_KAISTAHAITTA,
   HANKE_KAISTAPITUUSHAITTA,
@@ -33,8 +33,8 @@ const hankeMock: HankeDataDraft = {
   kuvaus: 'Tämä on hankkeen kuvaus',
   alkuPvm: '10.01.2030',
   loppuPvm: '11.01.2032',
-  haittaAlkuPvm: '10.01.2030',
-  haittaLoppuPvm: '10.01.2032', // TODO: BUG: HAI-974: loppuPvm cant be same as haittaLoppuPvm
+  haittaAlkuPvm: '10.01.2030', // the dates are the same as hankeStart and end on purpose
+  haittaLoppuPvm: '11.01.2032',
   tyomaaKatuosoite: 'Mannerheimintie 14',
   vaihe: HANKE_VAIHE.SUUNNITTELU,
   suunnitteluVaihe: HANKE_SUUNNITTELUVAIHE.KATUSUUNNITTELU_TAI_ALUEVARAUS,
@@ -62,7 +62,7 @@ const hankeMockIndex: Partial<HankeIndexData> = {
     indeksi: 4.8,
     tyyppi: HANKE_INDEX_TYPE.PERUSINDEKSI,
   },
-  pyorailyIndeksi: 3,
+  pyorailyIndeksi: 1,
   joukkoliikenneIndeksi: 4,
   perusIndeksi: 4.8,
 };
@@ -70,13 +70,12 @@ const hankeMockIndex: Partial<HankeIndexData> = {
 context('HankeForm', () => {
   beforeEach(() => {
     cy.login();
+    cy.visit('/fi/hanke/uusi');
   });
 
-  it('Hanke form testing', () => {
+  it('Validate indexes are counted correctly with given hankeData', () => {
     const countIndexes = true;
     createHankeFromUI(hankeMock, countIndexes);
-    // TODO: validateHankeInfoFromHankeList(hankeMock)
-    // TODO: validateHankeInfoFromMap(hankeMock)
     validateIndexes(hankeMockIndex);
   });
 });

--- a/cypress/integration/E2E.spec.ts
+++ b/cypress/integration/E2E.spec.ts
@@ -1,18 +1,17 @@
 /// <reference types="cypress" />
-import { HankeIndexData, HANKE_INDEX_TYPE } from './../../src/domain/types/hanke';
 import {
+  HankeIndexData,
+  HANKE_INDEX_TYPE,
   HANKE_KAISTAHAITTA,
   HANKE_KAISTAPITUUSHAITTA,
   HANKE_MELUHAITTA,
   HANKE_POLYHAITTA,
   HANKE_TARINAHAITTA,
-} from './../../src/domain/types/hanke';
-import { createHankeFromUI } from './../utils/formFiller';
-import {
   HANKE_VAIHE,
   HankeDataDraft,
   HANKE_SUUNNITTELUVAIHE,
-} from './../../src/domain/types/hanke';
+} from '../../src/domain/types/hanke';
+import { createHankeFromUI } from '../utils/formFiller';
 import { validateIndexes } from '../utils/indexValidator';
 
 // TODO: define types that would not require unnecessary types

--- a/cypress/integration/E2E.spec.ts
+++ b/cypress/integration/E2E.spec.ts
@@ -1,0 +1,29 @@
+/// <reference types="cypress" />
+import { createHankeFromUI } from './../utils/formFiller';
+import {
+  HANKE_VAIHE,
+  HankeDataDraft,
+  HANKE_SUUNNITTELUVAIHE,
+} from './../../src/domain/types/hanke';
+
+const drawCoordinateX = 100;
+const drawCoordinateY = 100;
+
+const hankeMock: HankeDataDraft = {
+  onYKTHanke: true,
+  nimi: 'E2E-hankkeen-testaus',
+  kuvaus: 'Tämä on hankkeen kuvaus',
+  alkuPvm: '10.01.2030',
+  loppuPvm: '11.01.2032',
+  tyomaaKatuosoite: '',
+  vaihe: HANKE_VAIHE.SUUNNITTELU,
+  suunnitteluVaihe: HANKE_SUUNNITTELUVAIHE.KATUSUUNNITTELU_TAI_ALUEVARAUS,
+  haittaLoppuPvm: new Date('31.12.2031'),
+};
+
+context('HankeForm', () => {
+  it('Hanke form testing', () => {
+    cy.login();
+    createHankeFromUI(hankeMock);
+  });
+});

--- a/cypress/integration/E2E.spec.ts
+++ b/cypress/integration/E2E.spec.ts
@@ -14,7 +14,6 @@ import {
 import { createHankeFromUI } from '../utils/formFiller';
 import { validateIndexes } from '../utils/indexValidator';
 
-// TODO: define types that would not require unnecessary types
 const hankeMock: HankeDataDraft = {
   id: 0, // not used but types require it
   hankeTunnus: 'not used', // not used but types require it

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -37,6 +37,9 @@ Cypress.Commands.add('login', () => {
   //  if ($loginLink.text() === 'Kirjaudu') {
   //    cy.get('[data-testid=loginLink]').click();
 
+  // Wait for a redirect to the login page, otherwise tests would randomly fail
+  cy.get('#kc-header-wrapper', { timeout: 5000 }).should('be.visible');
+
   cy.url().then(($url) => {
     if ($url.indexOf('/auth/realms/haitaton') !== -1) {
       cy.url().should('include', '/auth/realms/haitaton');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -37,9 +37,6 @@ Cypress.Commands.add('login', () => {
   //  if ($loginLink.text() === 'Kirjaudu') {
   //    cy.get('[data-testid=loginLink]').click();
 
-  // Wait for a redirect to the login page, otherwise tests would randomly fail
-  cy.get('#kc-header-wrapper', { timeout: 5000 }).should('be.visible');
-
   cy.url().then(($url) => {
     if ($url.indexOf('/auth/realms/haitaton') !== -1) {
       cy.url().should('include', '/auth/realms/haitaton');

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es5",
     "lib": ["es5", "dom"],
     "isolatedModules": false,
-    "types": ["cypress", "cypress-axe", "cypress-localstorage-commands"]
+    "types": ["cypress", "cypress-axe", "cypress-localstorage-commands", "GeoJSON"]
   },
   "include": ["**/*.ts"]
 }

--- a/cypress/utils/formFiller.ts
+++ b/cypress/utils/formFiller.ts
@@ -242,11 +242,13 @@ export const fillForm4 = (hankeData: HankeDataDraft) => {
 };
 
 export const triggerIndexCount = () => {
+  cy.intercept('/api/hankkeet/*/tormaystarkastelu').as('tormaystarkastelu');
   // TODO: count indexes implementation here
   cy.get('[data-testid=submitButton]').click();
   cy.get('[data-testid=confirmationDialog]').should('be.visible');
   cy.get('[data-testid=indexConfirmationOK]').click();
   cy.get('[data-testid=formToastIndexSuccess]').children().should('be.visible');
+  cy.wait('@tormaystarkastelu');
 };
 
 export const createHankeFromUI = (hankeData: HankeDataDraft, countIndexes: boolean) => {

--- a/cypress/utils/formFiller.ts
+++ b/cypress/utils/formFiller.ts
@@ -241,8 +241,12 @@ export const fillForm4 = (hankeData: HankeDataDraft) => {
   }
 };
 
-export const countIndexes = () => {
+export const triggerIndexCount = () => {
   // TODO: count indexes implementation here
+  cy.get('[data-testid=submitButton]').click();
+  cy.get('[data-testid=confirmationDialog]').should('be.visible');
+  cy.get('[data-testid=indexConfirmationOK]').click();
+  cy.get('[data-testid=formToastIndexSuccess]').children().should('be.visible');
 };
 
 export const createHankeFromUI = (hankeData: HankeDataDraft, countIndexes: boolean) => {
@@ -261,6 +265,6 @@ export const createHankeFromUI = (hankeData: HankeDataDraft, countIndexes: boole
   fillForm4(hankeData);
   saveDraft();
   if (countIndexes) {
-    // TODO: laske indeksit, hyväksy ehdot
+    triggerIndexCount();
   }
 };

--- a/cypress/utils/formFiller.ts
+++ b/cypress/utils/formFiller.ts
@@ -104,7 +104,7 @@ export const fillForm2 = (hankeData: HankeDataDraft) => {
 };
 
 export const fillForm3 = (hankeData: HankeDataDraft) => {
-  if ('tyomaaKatuosoite' in hankeData && typeof hankeData.tyomaaKatuosoite === 'string') {
+  if (hankeData.tyomaaKatuosoite) {
     cy.get('input[data-testid=tyomaaKatuosoite]').type(hankeData.tyomaaKatuosoite);
   }
 };
@@ -207,13 +207,13 @@ export const selectTarinaHaitta = (tarinaHaitta: HANKE_TARINAHAITTA_KEY) => {
 };
 
 export const fillForm4 = (hankeData: HankeDataDraft) => {
-  if (typeof hankeData.haittaAlkuPvm === 'string') {
+  if (hankeData.haittaAlkuPvm) {
     cy.get('#haittaAlkuPvm').type(hankeData.haittaAlkuPvm);
   } else {
     cy.get('#haittaAlkuPvm').type(hankeData.alkuPvm);
   }
 
-  if (typeof hankeData.haittaLoppuPvm === 'string') {
+  if (hankeData.haittaLoppuPvm) {
     cy.get('#haittaLoppuPvm').type(hankeData.haittaLoppuPvm);
   } else {
     cy.get('#haittaLoppuPvm').type(hankeData.loppuPvm);
@@ -221,23 +221,23 @@ export const fillForm4 = (hankeData: HankeDataDraft) => {
 
   cy.get('[data-testid=form4Header]').click(); // Close datepicker because it is over kaistaHaitta-toggle-button
 
-  if (typeof hankeData.kaistaHaitta === 'string') {
+  if (hankeData.kaistaHaitta) {
     selectKaistaHaitta(hankeData.kaistaHaitta);
   }
 
-  if (typeof hankeData.kaistaPituusHaitta === 'string') {
+  if (hankeData.kaistaPituusHaitta) {
     selectKaistanPituusHaitta(hankeData.kaistaPituusHaitta);
   }
 
-  if (typeof hankeData.meluHaitta === 'string') {
+  if (hankeData.meluHaitta) {
     selectMeluHaitta(hankeData.meluHaitta);
   }
 
-  if (typeof hankeData.polyHaitta === 'string') {
+  if (hankeData.polyHaitta) {
     selectPolyHaitta(hankeData.polyHaitta);
   }
 
-  if (typeof hankeData.tarinaHaitta === 'string') {
+  if (hankeData.tarinaHaitta) {
     selectTarinaHaitta(hankeData.tarinaHaitta);
   }
 };

--- a/cypress/utils/formFiller.ts
+++ b/cypress/utils/formFiller.ts
@@ -1,6 +1,19 @@
 /// <reference types="cypress" />
 
 import {
+  HANKE_KAISTAHAITTA,
+  HANKE_KAISTAHAITTA_KEY,
+  HANKE_KAISTAPITUUSHAITTA,
+  HANKE_KAISTAPITUUSHAITTA_KEY,
+  HANKE_MELUHAITTA,
+  HANKE_MELUHAITTA_KEY,
+  HANKE_POLYHAITTA,
+  HANKE_POLYHAITTA_KEY,
+  HANKE_TARINAHAITTA,
+  HANKE_TARINAHAITTA_KEY,
+} from './../../src/domain/types/hanke';
+
+import {
   HANKE_VAIHE,
   HankeDataDraft,
   HANKE_SUUNNITTELUVAIHE,
@@ -69,8 +82,185 @@ export const nextFormPage = () => {
   cy.get('[data-testid=forward]').click();
 };
 
-export const createHankeFromUI = (hankeData: HankeDataDraft) => {
+export const drawPolygonToMap = () => {
+  const drawCoordinateX = 100;
+  const drawCoordinateY = 100;
+  cy.get('[data-testid=draw-control-Polygon]').click();
+  cy.get('#ol-map').click(drawCoordinateX, drawCoordinateY);
+  cy.get('#ol-map').click(drawCoordinateX + 300, drawCoordinateY);
+  cy.get('#ol-map').click(drawCoordinateX + 300, drawCoordinateY + 300);
+  cy.get('#ol-map').click(drawCoordinateX, drawCoordinateY + 300);
+  cy.get('#ol-map').dblclick(drawCoordinateX + 20, drawCoordinateY + 20);
+};
+
+export const saveDraft = () => {
+  cy.get('[data-testid=save-draft-button]').click();
+};
+
+export const fillForm2 = (hankeData: HankeDataDraft) => {
+  if (hankeData.omistajat && hankeData.omistajat[0]) {
+    cy.get('input[data-testid=omistajat-etunimi]').type(hankeData.omistajat[0].etunimi);
+    cy.get('input[data-testid=omistajat-sukunimi]').type(hankeData.omistajat[0].sukunimi);
+    cy.get('input[data-testid=omistajat-email]').type(hankeData.omistajat[0].email);
+    cy.get('input[data-testid=omistajat-puhelinnumero]').type(hankeData.omistajat[0].puhelinnumero);
+  }
+};
+
+export const fillForm3 = (hankeData: HankeDataDraft) => {
+  if ('tyomaaKatuosoite' in hankeData && typeof hankeData.tyomaaKatuosoite === 'string') {
+    cy.get('input[data-testid=tyomaaKatuosoite]').type(hankeData.tyomaaKatuosoite);
+  }
+};
+
+export const selectKaistaHaitta = (kaistaHaitta: HANKE_KAISTAHAITTA_KEY) => {
+  cy.get('#kaistaHaitta-toggle-button').click();
+  switch (kaistaHaitta) {
+    case HANKE_KAISTAHAITTA.YKSI:
+      cy.get('#kaistaHaitta-item-0').click();
+      break;
+    case HANKE_KAISTAHAITTA.KAKSI:
+      cy.get('#kaistaHaitta-item-1').click();
+      break;
+    case HANKE_KAISTAHAITTA.KOLME:
+      cy.get('#kaistaHaitta-item-2').click();
+      break;
+    case HANKE_KAISTAHAITTA.NELJA:
+      cy.get('#kaistaHaitta-item-3').click();
+      break;
+    case HANKE_KAISTAHAITTA.VIISI:
+      cy.get('#kaistaHaitta-item-4').click();
+      break;
+    default:
+      break;
+  }
+};
+
+export const selectKaistanPituusHaitta = (kaistanPituusHaitta: HANKE_KAISTAPITUUSHAITTA_KEY) => {
+  cy.get('#kaistaPituusHaitta-toggle-button').click();
+  switch (kaistanPituusHaitta) {
+    case HANKE_KAISTAPITUUSHAITTA.YKSI:
+      cy.get('#kaistaPituusHaitta-item-0').click();
+      break;
+    case HANKE_KAISTAPITUUSHAITTA.KAKSI:
+      cy.get('#kaistaPituusHaitta-item-1').click();
+      break;
+    case HANKE_KAISTAPITUUSHAITTA.KOLME:
+      cy.get('#kaistaPituusHaitta-item-2').click();
+      break;
+    case HANKE_KAISTAPITUUSHAITTA.NELJA:
+      cy.get('#kaistaPituusHaitta-item-3').click();
+      break;
+    case HANKE_KAISTAPITUUSHAITTA.VIISI:
+      cy.get('#kaistaPituusHaitta-item-4').click();
+      break;
+    default:
+      break;
+  }
+};
+
+export const selectMeluHaitta = (meluHaitta: HANKE_MELUHAITTA_KEY) => {
+  cy.get('#meluHaitta-toggle-button').click();
+  switch (meluHaitta) {
+    case HANKE_MELUHAITTA.YKSI:
+      cy.get('#meluHaitta-item-0').click();
+      break;
+    case HANKE_MELUHAITTA.KAKSI:
+      cy.get('#meluHaitta-item-1').click();
+      break;
+    case HANKE_MELUHAITTA.KOLME:
+      cy.get('#meluHaitta-item-2').click();
+      break;
+    default:
+      break;
+  }
+};
+
+export const selectPolyHaitta = (polyHaitta: HANKE_POLYHAITTA_KEY) => {
+  cy.get('#polyHaitta-toggle-button').click();
+  switch (polyHaitta) {
+    case HANKE_POLYHAITTA.YKSI:
+      cy.get('#polyHaitta-item-0').click();
+      break;
+    case HANKE_POLYHAITTA.KAKSI:
+      cy.get('#polyHaitta-item-1').click();
+      break;
+    case HANKE_POLYHAITTA.KOLME:
+      cy.get('#polyHaitta-item-2').click();
+      break;
+    default:
+      break;
+  }
+};
+
+export const selectTarinaHaitta = (tarinaHaitta: HANKE_TARINAHAITTA_KEY) => {
+  cy.get('#tarinaHaitta-toggle-button').click();
+  switch (tarinaHaitta) {
+    case HANKE_TARINAHAITTA.YKSI:
+      cy.get('#tarinaHaitta-item-0').click();
+      break;
+    case HANKE_TARINAHAITTA.KAKSI:
+      cy.get('#tarinaHaitta-item-1').click();
+      break;
+    case HANKE_TARINAHAITTA.KOLME:
+      cy.get('#tarinaHaitta-item-2').click();
+      break;
+    default:
+      break;
+  }
+};
+
+export const fillForm4 = (hankeData: HankeDataDraft) => {
+  typeof hankeData.haittaAlkuPvm === 'string'
+    ? cy.get('#haittaAlkuPvm').type(hankeData.haittaAlkuPvm)
+    : cy.get('#haittaAlkuPvm').type(hankeData.alkuPvm);
+
+  typeof hankeData.haittaLoppuPvm === 'string'
+    ? cy.get('#haittaLoppuPvm').type(hankeData.haittaLoppuPvm)
+    : cy.get('#haittaLoppuPvm').type(hankeData.loppuPvm);
+
+  cy.get('[data-testid=form4Header]').click(); // Close datepicker because it is over kaistaHaitta-toggle-button
+
+  if (typeof hankeData.kaistaHaitta === 'string') {
+    selectKaistaHaitta(hankeData.kaistaHaitta);
+  }
+
+  if (typeof hankeData.kaistaPituusHaitta === 'string') {
+    selectKaistanPituusHaitta(hankeData.kaistaPituusHaitta);
+  }
+
+  if (typeof hankeData.meluHaitta === 'string') {
+    selectMeluHaitta(hankeData.meluHaitta);
+  }
+
+  if (typeof hankeData.polyHaitta === 'string') {
+    selectPolyHaitta(hankeData.polyHaitta);
+  }
+
+  if (typeof hankeData.tarinaHaitta === 'string') {
+    selectTarinaHaitta(hankeData.tarinaHaitta);
+  }
+};
+
+export const countIndexes = () => {
+  // TODO: count indexes implementation here
+};
+
+export const createHankeFromUI = (hankeData: HankeDataDraft, countIndexes: boolean) => {
   cy.visit('/fi/hanke/uusi');
   fillForm0(hankeData);
   nextFormPage();
+  drawPolygonToMap();
+  saveDraft();
+  nextFormPage();
+  fillForm2(hankeData);
+  saveDraft();
+  nextFormPage();
+  fillForm3(hankeData);
+  saveDraft();
+  nextFormPage();
+  fillForm4(hankeData);
+  saveDraft();
+  if (countIndexes) {
+    // TODO: laske indeksit, hyväksy ehdot
+  }
 };

--- a/cypress/utils/formFiller.ts
+++ b/cypress/utils/formFiller.ts
@@ -244,7 +244,6 @@ export const fillForm4 = (hankeData: HankeDataDraft) => {
 
 export const triggerIndexCount = () => {
   cy.intercept('/api/hankkeet/*/tormaystarkastelu').as('tormaystarkastelu');
-  // TODO: count indexes implementation here
   cy.get('[data-testid=submitButton]').click();
   cy.get('[data-testid=confirmationDialog]').should('be.visible');
   cy.get('[data-testid=indexConfirmationOK]').click();

--- a/cypress/utils/formFiller.ts
+++ b/cypress/utils/formFiller.ts
@@ -1,0 +1,76 @@
+/// <reference types="cypress" />
+
+import {
+  HANKE_VAIHE,
+  HankeDataDraft,
+  HANKE_SUUNNITTELUVAIHE,
+  HANKE_VAIHE_KEY,
+  HANKE_SUUNNITTELUVAIHE_KEY,
+} from './../../src/domain/types/hanke';
+
+export const selectHankeVaihe = (
+  vaihe: HANKE_VAIHE_KEY,
+  suunnitteluVaihe?: HANKE_SUUNNITTELUVAIHE_KEY
+) => {
+  cy.get('#vaihe-toggle-button').click();
+  switch (vaihe) {
+    case HANKE_VAIHE.OHJELMOINTI:
+      cy.get('#vaihe-item-0').click();
+      break;
+    case HANKE_VAIHE.SUUNNITTELU:
+      cy.get('#vaihe-item-1').click();
+      if (suunnitteluVaihe) {
+        cy.get('#suunnitteluVaihe-toggle-button').click();
+        switch (suunnitteluVaihe) {
+          case HANKE_SUUNNITTELUVAIHE.YLEIS_TAI_HANKE:
+            cy.get('#suunnitteluVaihe-item-0').click();
+            break;
+          case HANKE_SUUNNITTELUVAIHE.KATUSUUNNITTELU_TAI_ALUEVARAUS:
+            cy.get('#suunnitteluVaihe-item-1').click();
+            break;
+          case HANKE_SUUNNITTELUVAIHE.RAKENNUS_TAI_TOTEUTUS:
+            cy.get('#suunnitteluVaihe-item-2').click();
+            break;
+          case HANKE_SUUNNITTELUVAIHE.TYOMAAN_TAI_HANKKEEN_AIKAINEN:
+            cy.get('#suunnitteluVaihe-item-3').click();
+            break;
+          default:
+            break;
+        }
+      } else {
+        throw new Error('Tämä testin vaihe tarvitsee suunnitteluvaiheen');
+      }
+      break;
+    case HANKE_VAIHE.RAKENTAMINEN:
+      cy.get('#vaihe-item-2').click();
+      break;
+    default:
+      break;
+  }
+};
+
+export const fillForm0 = (hankeData: HankeDataDraft) => {
+  if (hankeData.onYKTHanke) {
+    cy.get('input[data-testid=onYKTHanke]').click();
+  }
+  cy.get('input[data-testid=nimi]').type(hankeData.nimi);
+  cy.get('textarea[data-testid=kuvaus]').type(hankeData.kuvaus);
+  cy.get('#alkuPvm').type(hankeData.alkuPvm);
+  cy.get('#loppuPvm').type(hankeData.loppuPvm);
+  cy.get('input[data-testid=nimi]').click();
+  selectHankeVaihe(
+    hankeData.vaihe,
+    hankeData.suunnitteluVaihe ? hankeData.suunnitteluVaihe : undefined
+  );
+};
+
+export const nextFormPage = () => {
+  cy.get('[data-testid=forward]').should('not.be.disabled');
+  cy.get('[data-testid=forward]').click();
+};
+
+export const createHankeFromUI = (hankeData: HankeDataDraft) => {
+  cy.visit('/fi/hanke/uusi');
+  fillForm0(hankeData);
+  nextFormPage();
+};

--- a/cypress/utils/formFiller.ts
+++ b/cypress/utils/formFiller.ts
@@ -11,15 +11,12 @@ import {
   HANKE_POLYHAITTA_KEY,
   HANKE_TARINAHAITTA,
   HANKE_TARINAHAITTA_KEY,
-} from './../../src/domain/types/hanke';
-
-import {
   HANKE_VAIHE,
   HankeDataDraft,
   HANKE_SUUNNITTELUVAIHE,
   HANKE_VAIHE_KEY,
   HANKE_SUUNNITTELUVAIHE_KEY,
-} from './../../src/domain/types/hanke';
+} from '../../src/domain/types/hanke';
 
 export const selectHankeVaihe = (
   vaihe: HANKE_VAIHE_KEY,
@@ -210,13 +207,17 @@ export const selectTarinaHaitta = (tarinaHaitta: HANKE_TARINAHAITTA_KEY) => {
 };
 
 export const fillForm4 = (hankeData: HankeDataDraft) => {
-  typeof hankeData.haittaAlkuPvm === 'string'
-    ? cy.get('#haittaAlkuPvm').type(hankeData.haittaAlkuPvm)
-    : cy.get('#haittaAlkuPvm').type(hankeData.alkuPvm);
+  if (typeof hankeData.haittaAlkuPvm === 'string') {
+    cy.get('#haittaAlkuPvm').type(hankeData.haittaAlkuPvm);
+  } else {
+    cy.get('#haittaAlkuPvm').type(hankeData.alkuPvm);
+  }
 
-  typeof hankeData.haittaLoppuPvm === 'string'
-    ? cy.get('#haittaLoppuPvm').type(hankeData.haittaLoppuPvm)
-    : cy.get('#haittaLoppuPvm').type(hankeData.loppuPvm);
+  if (typeof hankeData.haittaLoppuPvm === 'string') {
+    cy.get('#haittaLoppuPvm').type(hankeData.haittaLoppuPvm);
+  } else {
+    cy.get('#haittaLoppuPvm').type(hankeData.loppuPvm);
+  }
 
   cy.get('[data-testid=form4Header]').click(); // Close datepicker because it is over kaistaHaitta-toggle-button
 

--- a/cypress/utils/indexValidator.ts
+++ b/cypress/utils/indexValidator.ts
@@ -1,0 +1,21 @@
+/// <reference types="cypress" />
+import { HankeIndexData } from './../../src/domain/types/hanke';
+
+export const validateIndexes = (hankeIndexData: Partial<HankeIndexData>) => {
+  if (hankeIndexData.liikennehaittaIndeksi && hankeIndexData.liikennehaittaIndeksi.indeksi) {
+    cy.get('[data-testid=test-liikennehaittaIndeksi]').contains(
+      hankeIndexData.liikennehaittaIndeksi.indeksi
+    );
+  }
+  if (hankeIndexData.pyorailyIndeksi) {
+    cy.get('[data-testid=test-pyorailyIndeksi]').contains(hankeIndexData.pyorailyIndeksi);
+  }
+  if (hankeIndexData.joukkoliikenneIndeksi) {
+    cy.get('[data-testid=test-joukkoliikenneIndeksi]').contains(
+      hankeIndexData.joukkoliikenneIndeksi
+    );
+  }
+  if (hankeIndexData.perusIndeksi) {
+    cy.get('[data-testid=test-ruuhkautumisIndeksi]').contains(hankeIndexData.perusIndeksi);
+  }
+};

--- a/cypress/utils/indexValidator.ts
+++ b/cypress/utils/indexValidator.ts
@@ -1,5 +1,5 @@
 /// <reference types="cypress" />
-import { HankeIndexData } from './../../src/domain/types/hanke';
+import { HankeIndexData } from '../../src/domain/types/hanke';
 
 export const validateIndexes = (hankeIndexData: Partial<HankeIndexData>) => {
   if (hankeIndexData.liikennehaittaIndeksi && hankeIndexData.liikennehaittaIndeksi.indeksi) {

--- a/src/common/components/confirmationDialog/ConfirmationDialogUI.tsx
+++ b/src/common/components/confirmationDialog/ConfirmationDialogUI.tsx
@@ -25,7 +25,7 @@ const ConfirmationDialog: React.FC<Props> = ({ body, children, isOpen, handleClo
   return (
     <AlertDialog isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={handleClose} isCentered>
       <AlertDialogOverlay />
-      <AlertDialogContent>
+      <AlertDialogContent data-testid="confirmationDialog">
         <AlertDialogCloseButton />
         <AlertDialogBody>{body}</AlertDialogBody>
         <AlertDialogFooter>

--- a/src/domain/hanke/edit/Form4.tsx
+++ b/src/domain/hanke/edit/Form4.tsx
@@ -8,7 +8,7 @@ import {
   HANKE_KAISTAHAITTA,
   HANKE_KAISTAPITUUSHAITTA,
   HANKE_MELUHAITTA,
-  HANKE_POLYAITTA,
+  HANKE_POLYHAITTA,
   HANKE_TARINAHAITTA,
 } from '../../types/hanke';
 import { FORMFIELD, FormProps } from './types';
@@ -101,7 +101,7 @@ const Form4: React.FC<FormProps> = ({ control, errors, formData }) => {
             name={FORMFIELD.POLYHAITTA}
             id={FORMFIELD.POLYHAITTA}
             control={control}
-            options={$enum(HANKE_POLYAITTA).map((value) => ({
+            options={$enum(HANKE_POLYHAITTA).map((value) => ({
               value,
               label: t(`hanke:${FORMFIELD.POLYHAITTA}:${value}`),
             }))}

--- a/src/domain/hanke/edit/FormButtons.tsx
+++ b/src/domain/hanke/edit/FormButtons.tsx
@@ -79,6 +79,7 @@ const FormButtons: React.FC<Props> = ({
             onCalculateIndexes(hankeTunnus);
             setIsOpen(false);
           }}
+          data-testid="indexConfirmationOK"
         >
           {t('hankeForm:confirmIndexCalculationButton')}
         </Button>

--- a/src/domain/hanke/edit/FormNotifications.tsx
+++ b/src/domain/hanke/edit/FormNotifications.tsx
@@ -28,22 +28,38 @@ const FormNotifications: React.FC<Props> = ({ hankeTunnus }) => {
   return (
     <>
       {showNotification === 'success' && (
-        <Notification label={t('hankeForm:savingSuccessHeader')} typeProps="success">
+        <Notification
+          label={t('hankeForm:savingSuccessHeader')}
+          typeProps="success"
+          testId="formToastSuccess"
+        >
           {t('hankeForm:savingSuccessText')}
         </Notification>
       )}
       {showNotification === 'error' && (
-        <Notification label={t('hankeForm:savingFailHeader')} typeProps="error">
+        <Notification
+          label={t('hankeForm:savingFailHeader')}
+          typeProps="error"
+          testId="formToastError"
+        >
           {t('hankeForm:savingFailText')}
         </Notification>
       )}
       {showNotification === 'indexSuccess' && (
-        <Notification label={t('hankeForm:indexCalculationSuccessHeader')} typeProps="success">
+        <Notification
+          label={t('hankeForm:indexCalculationSuccessHeader')}
+          typeProps="success"
+          testId="formToastIndexSuccess"
+        >
           {t('hankeForm:indexCalculationSuccessText')}
         </Notification>
       )}
       {showNotification === 'indexError' && (
-        <Notification label={t('hankeForm:indexCalculationFailHeader')} typeProps="error">
+        <Notification
+          label={t('hankeForm:indexCalculationFailHeader')}
+          typeProps="error"
+          testId="formToastIndexError"
+        >
           {t('hankeForm:indexCalculationFailText')}
         </Notification>
       )}

--- a/src/domain/hanke/edit/Notification.tsx
+++ b/src/domain/hanke/edit/Notification.tsx
@@ -19,7 +19,7 @@ const NotificationComp: React.FC<Props> = ({
       position="top-right"
       dismissible
       autoClose
-      autoCloseDuration={30000}
+      autoCloseDuration={3000}
       closeButtonLabelText="Close toast"
       type={typeProps}
       style={{ zIndex: 100 }}

--- a/src/domain/hanke/edit/Notification.tsx
+++ b/src/domain/hanke/edit/Notification.tsx
@@ -13,20 +13,19 @@ const NotificationComp: React.FC<Props> = ({
   testId = 'notification',
   children,
 }) => (
-  <div data-testid={testId}>
-    <Notification
-      label={label}
-      position="top-right"
-      dismissible
-      autoClose
-      autoCloseDuration={3000}
-      closeButtonLabelText="Close toast"
-      type={typeProps}
-      style={{ zIndex: 100 }}
-    >
-      {children}
-    </Notification>
-  </div>
+  <Notification
+    label={label}
+    position="top-right"
+    dismissible
+    autoClose
+    autoCloseDuration={3000}
+    closeButtonLabelText="Close toast"
+    type={typeProps}
+    style={{ zIndex: 100 }}
+    dataTestId={testId}
+  >
+    {children}
+  </Notification>
 );
 
 export default NotificationComp;

--- a/src/domain/hanke/edit/Notification.tsx
+++ b/src/domain/hanke/edit/Notification.tsx
@@ -4,22 +4,29 @@ import { Notification, NotificationType } from 'hds-react';
 type Props = {
   label: string;
   typeProps: NotificationType;
+  testId?: string;
 };
 
-const NotificationComp: React.FC<Props> = ({ label, typeProps, children }) => (
-  <Notification
-    label={label}
-    position="top-right"
-    dismissible
-    autoClose
-    autoCloseDuration={3000}
-    closeButtonLabelText="Close toast"
-    type={typeProps}
-    style={{ zIndex: 100 }}
-    data-test-id="notification"
-  >
-    {children}
-  </Notification>
+const NotificationComp: React.FC<Props> = ({
+  label,
+  typeProps,
+  testId = 'notification',
+  children,
+}) => (
+  <div data-testid={testId}>
+    <Notification
+      label={label}
+      position="top-right"
+      dismissible
+      autoClose
+      autoCloseDuration={30000}
+      closeButtonLabelText="Close toast"
+      type={typeProps}
+      style={{ zIndex: 100 }}
+    >
+      {children}
+    </Notification>
+  </div>
 );
 
 export default NotificationComp;

--- a/src/domain/types/hanke.ts
+++ b/src/domain/types/hanke.ts
@@ -173,8 +173,8 @@ export interface HankeData {
   suunnitteluVaihe: HANKE_SUUNNITTELUVAIHE_KEY | null;
   tyomaaTyyppi: HANKE_TYOMAATYYPPI_KEY[];
   tyomaaKoko: HANKE_TYOMAAKOKO_KEY | null;
-  haittaAlkuPvm: Date | null;
-  haittaLoppuPvm: Date | null;
+  haittaAlkuPvm: string | null;
+  haittaLoppuPvm: string | null;
   kaistaHaitta: HANKE_KAISTAHAITTA_KEY | null;
   kaistaPituusHaitta: HANKE_KAISTAPITUUSHAITTA_KEY | null;
   liikennehaittaindeksi: LiikenneHaittaIndeksi | null;

--- a/src/domain/types/hanke.ts
+++ b/src/domain/types/hanke.ts
@@ -84,12 +84,12 @@ export enum HANKE_MELUHAITTA {
 }
 export type HANKE_MELUHAITTA_KEY = keyof typeof HANKE_MELUHAITTA;
 
-export enum HANKE_POLYAITTA {
+export enum HANKE_POLYHAITTA {
   YKSI = 'YKSI',
   KAKSI = 'KAKSI',
   KOLME = 'KOLME',
 }
-export type HANKE_POLYAITTA_KEY = keyof typeof HANKE_POLYAITTA;
+export type HANKE_POLYHAITTA_KEY = keyof typeof HANKE_POLYHAITTA;
 
 export enum HANKE_TARINAHAITTA {
   YKSI = 'YKSI',
@@ -179,7 +179,7 @@ export interface HankeData {
   kaistaPituusHaitta: HANKE_KAISTAPITUUSHAITTA_KEY | null;
   liikennehaittaindeksi: LiikenneHaittaIndeksi | null;
   meluHaitta: HANKE_MELUHAITTA_KEY | null;
-  polyHaitta: HANKE_POLYAITTA_KEY | null;
+  polyHaitta: HANKE_POLYHAITTA | null;
   tarinaHaitta: HANKE_TARINAHAITTA_KEY | null;
   omistajat: Array<HankeContact>;
   arvioijat: Array<HankeContact>;


### PR DESCRIPTION
# Haitaton-ui pull-request

Kyseessä on

- [ ] Bugikorjaus
- [X] Uusi toiminnallisuus (ei muuta olemassaolevaa toteutusta)
- [ ] Uusi toiminnallisuus (muuttaa jo olemassaolevaa toteutusta)

## Kuvaus mitä pull-request toteuttaa / korjaa
- E2E-testi mikä piirtää kartalle hankkeen neliönä ja laskee indeksit
- Kirjoitettiin testeille apufunktio formFiller hankkeiden generoimiseen UI:n kautta (ennen manuaalisesti/staattisesti)
--> E2E-testeissä hanke voidaan luoda kutsumalla createHankeFromUI(HankeData, countIndexes)
--> E2E-testejä voidaan laajentaa koskemaan erilaiset haittojen permutaatiot tyyliin:
```
for hanke in Hankkeet:
  createHankeFromUI(hanke, countIndexes=true)
  validateIndexes(hanke)
```

## Checklist:

- [X] Muuttujat ovat kuvaavasti nimettyjä eikä koodi sisällä kirjoitusvirheitä
- [X] Muutokseni eivät aiheuta uusia virheitä consoleen
