### PR TITLE
HAI-1146 custom minimap to control the bigger map on the main map page

### DIFF
--- a/src/common/components/map/Map.tsx
+++ b/src/common/components/map/Map.tsx
@@ -41,7 +41,7 @@ const Map: React.FC<Props> = ({
         center,
         zoom,
         minZoom: 5,
-        maxZoom: 15,
+        maxZoom: 13,
         projection,
       }),
       layers: [],

--- a/src/common/components/map/controls/MapControl.scss
+++ b/src/common/components/map/controls/MapControl.scss
@@ -1,0 +1,26 @@
+.ol-custom-overviewmap,
+.ol-custom-overviewmap.ol-uncollapsible {
+  bottom: 200px;
+  right: 8px;
+  left: auto;
+}
+
+.ol-custom-overviewmap:not(.ol-collapsed) {
+  border: 1px solid black;
+}
+
+.ol-custom-overviewmap .ol-overviewmap-map {
+  border: none;
+  width: 252px;
+}
+
+.ol-custom-overviewmap .ol-overviewmap-box {
+  border: 2px solid black;
+}
+
+.ol-custom-overviewmap:not(.ol-collapsed) button {
+  bottom: auto;
+  left: auto;
+  right: 1px;
+  top: 1px;
+}

--- a/src/common/components/map/controls/MapControl.tsx
+++ b/src/common/components/map/controls/MapControl.tsx
@@ -1,0 +1,65 @@
+import { useContext, useEffect } from 'react';
+import OLTileLayer from 'ol/layer/Tile';
+import { TileWMS } from 'ol/source';
+import * as ol from 'ol';
+import { OverviewMap } from 'ol/control';
+import { DragZoom } from 'ol/interaction';
+import MapContext from '../MapContext';
+import { projection } from '../utils';
+import './MapControl.scss';
+
+const MapControl: React.FC = () => {
+  const { map } = useContext(MapContext);
+
+  useEffect(() => {
+    if (!map) return;
+
+    const overviewMapTileLayer = new OLTileLayer({
+      source: new TileWMS({
+        url: 'https://kartta.hel.fi/ws/geoserver/avoindata/wms',
+        params: {
+          LAYERS: 'Kantakartta',
+          FORMAT: 'image/jpeg',
+          WIDTH: 256,
+          HEIGHT: 256,
+          VERSION: '1.1.1',
+          TRANSPARENT: 'false',
+        },
+        projection,
+        cacheSize: 1000,
+        imageSmoothing: false,
+        hidpi: false,
+        serverType: 'geoserver',
+        transition: 0,
+      }),
+    });
+
+    const overviewMapControl = new OverviewMap({
+      className: 'ol-overviewmap ol-custom-overviewmap',
+      layers: [overviewMapTileLayer],
+      collapseLabel: '\u00BB',
+      label: '\u00BB',
+      collapsed: false,
+      view: new ol.View({
+        zoom: 3,
+        minZoom: 2,
+        maxZoom: 6,
+        projection,
+      }),
+    });
+
+    map.addControl(overviewMapControl);
+    map.addInteraction(new DragZoom());
+
+    // eslint-disable-next-line
+    return () => {
+      if (map) {
+        map.removeControl(overviewMapControl);
+      }
+    };
+  }, [map]);
+
+  return null;
+};
+
+export default MapControl;

--- a/src/domain/map/HankeMap.tsx
+++ b/src/domain/map/HankeMap.tsx
@@ -17,6 +17,7 @@ import GeometryHover from '../../common/components/map/interactions/hover/Geomet
 import HankeHoverBox from './components/HankeHover/HankeHoverBox';
 import MapGuide from './components/MapGuide/MapGuide';
 import HankkeetProvider from './HankkeetProvider';
+import MapControl from '../../common/components/map/controls/MapControl';
 
 const HankeMap: React.FC = () => {
   const [zoom] = useState(9); // TODO: also take zoom into consideration
@@ -40,6 +41,7 @@ const HankeMap: React.FC = () => {
           <MapGuide />
           {mapTileLayers.ortokartta.visible && <Ortokartta />}
           {mapTileLayers.kantakartta.visible && <Kantakartta />}
+          <MapControl />
 
           <HankkeetProvider>
             <HankeSidebar />


### PR DESCRIPTION
# Description

Minimap component created to control the bigger map.
The component can be used when drawing geometries but is not added into there yet -- as the geometry drawing canvas is still quite small and will be changed when the new designs are implemented.

### Jira Issue:

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other