### PR TITLE
HAI-1148 hovered and selected hanke geometries are highlighted

### DIFF
--- a/src/domain/map/HankeMap.tsx
+++ b/src/domain/map/HankeMap.tsx
@@ -48,8 +48,8 @@ const HankeMap: React.FC = () => {
             <FeatureClick />
             <GeometryHover>
               <HankeHoverBox />
+              <HankeLayer />
             </GeometryHover>
-            <HankeLayer />
           </HankkeetProvider>
 
           <Controls>

--- a/src/domain/map/components/Layers/HankeLayer.tsx
+++ b/src/domain/map/components/Layers/HankeLayer.tsx
@@ -7,6 +7,7 @@ import { useDateRangeFilter } from '../../hooks/useDateRangeFilter';
 import { styleFunction } from '../../utils/geometryStyle';
 import CenterProjectOnMap from '../interations/CenterProjectOnMap';
 import HankkeetContext from '../../HankkeetProviderContext';
+import HighlightFeatureOnMap from '../interations/HighlightFeatureOnMap';
 
 const HankeLayer = () => {
   const { hankkeet } = useContext(HankkeetContext);
@@ -48,6 +49,7 @@ const HankeLayer = () => {
         {hankkeetFilteredByAll.length}
       </div>
       <CenterProjectOnMap source={hankeSource.current} />
+      <HighlightFeatureOnMap source={hankeSource.current} />
 
       <VectorLayer
         source={hankeSource.current}

--- a/src/domain/map/components/interations/HighlightFeatureOnMap.tsx
+++ b/src/domain/map/components/interations/HighlightFeatureOnMap.tsx
@@ -1,0 +1,49 @@
+import React, { useContext, useEffect } from 'react';
+import { Vector as VectorSource } from 'ol/source';
+import { useLocation } from 'react-router-dom';
+import MapContext from '../../../../common/components/map/MapContext';
+import HoverContext from '../../../../common/components/map/interactions/hover/HoverContext';
+import { styleFunction } from '../../utils/geometryStyle';
+
+type Props = {
+  source: VectorSource;
+};
+
+const HighlightFeatureOnMap: React.FC<Props> = ({ source }) => {
+  const location = useLocation();
+  const { map } = useContext(MapContext);
+  const { hoveredHankeTunnukset } = useContext(HoverContext);
+  const hankeTunnus = new URLSearchParams(location.search).get('hanke');
+
+  const highlightFeature = () => {
+    source.getFeatures().some((feature) => {
+      if (
+        hoveredHankeTunnukset.includes(feature.get('hankeTunnus')) ||
+        feature.get('hankeTunnus') === hankeTunnus
+      ) {
+        feature.setStyle(styleFunction(feature, undefined, true));
+      } else {
+        feature.setStyle(undefined);
+      }
+      return false;
+    });
+  };
+
+  useEffect(() => {
+    source.on('featuresAdded', () => {
+      highlightFeature();
+    });
+  }, [map]);
+
+  useEffect(() => {
+    highlightFeature();
+  }, [hankeTunnus]);
+
+  useEffect(() => {
+    highlightFeature();
+  }, [hoveredHankeTunnukset]);
+
+  return null;
+};
+
+export default HighlightFeatureOnMap;

--- a/src/domain/map/utils/geometryStyle.ts
+++ b/src/domain/map/utils/geometryStyle.ts
@@ -7,57 +7,89 @@ import {
   LIIKENNEHAITTA_STATUS,
 } from '../../common/utils/liikennehaittaindeksi';
 
-const opacity = 0.75;
+const opacity = 0.45;
+const opacityHL = 0.85;
 
 const stroke = new Stroke({ color: 'black', width: 2 });
+const strokeHL = new Stroke({ color: 'black', width: 6 });
 
 const STYLES = {
-  [LIIKENNEHAITTA_STATUS.BLUE]: new Style({
+  BLUE: new Style({
     fill: new Fill({
       color: getColorByStatus(LIIKENNEHAITTA_STATUS.BLUE, opacity),
     }),
     stroke,
   }),
-  [LIIKENNEHAITTA_STATUS.GREEN]: new Style({
+  BLUE_HL: new Style({
+    fill: new Fill({
+      color: getColorByStatus(LIIKENNEHAITTA_STATUS.BLUE, opacityHL),
+    }),
+    stroke: strokeHL,
+  }),
+  GREEN: new Style({
     fill: new Fill({
       color: getColorByStatus(LIIKENNEHAITTA_STATUS.GREEN, opacity),
     }),
     stroke,
   }),
-  [LIIKENNEHAITTA_STATUS.GREY]: new Style({
+  GREEN_HL: new Style({
+    fill: new Fill({
+      color: getColorByStatus(LIIKENNEHAITTA_STATUS.GREEN, opacityHL),
+    }),
+    stroke: strokeHL,
+  }),
+  GREY: new Style({
     fill: new Fill({
       color: getColorByStatus(LIIKENNEHAITTA_STATUS.GREY, opacity),
     }),
     stroke,
   }),
-  [LIIKENNEHAITTA_STATUS.YELLOW]: new Style({
+  GREY_HL: new Style({
+    fill: new Fill({
+      color: getColorByStatus(LIIKENNEHAITTA_STATUS.GREY, opacityHL),
+    }),
+    stroke: strokeHL,
+  }),
+  YELLOW: new Style({
     fill: new Fill({
       color: getColorByStatus(LIIKENNEHAITTA_STATUS.YELLOW, opacity),
     }),
     stroke,
   }),
-  [LIIKENNEHAITTA_STATUS.RED]: new Style({
+  YELLOW_HL: new Style({
+    fill: new Fill({
+      color: getColorByStatus(LIIKENNEHAITTA_STATUS.YELLOW, opacityHL),
+    }),
+    stroke: strokeHL,
+  }),
+  RED: new Style({
     fill: new Fill({
       color: getColorByStatus(LIIKENNEHAITTA_STATUS.RED, opacity),
     }),
     stroke,
   }),
+  RED_HL: new Style({
+    fill: new Fill({
+      color: getColorByStatus(LIIKENNEHAITTA_STATUS.RED, opacityHL),
+    }),
+    stroke: strokeHL,
+  }),
 };
 
-export const getStyleByStatus = (status: LIIKENNEHAITTA_STATUS): Style =>
+export const getStyleByStatus = (status: LIIKENNEHAITTA_STATUS, highlight = false): Style =>
   $enum.mapValue(status).with({
-    [LIIKENNEHAITTA_STATUS.BLUE]: STYLES[LIIKENNEHAITTA_STATUS.BLUE],
-    [LIIKENNEHAITTA_STATUS.GREEN]: STYLES[LIIKENNEHAITTA_STATUS.GREEN],
-    [LIIKENNEHAITTA_STATUS.GREY]: STYLES[LIIKENNEHAITTA_STATUS.GREY],
-    [LIIKENNEHAITTA_STATUS.YELLOW]: STYLES[LIIKENNEHAITTA_STATUS.YELLOW],
-    [LIIKENNEHAITTA_STATUS.RED]: STYLES[LIIKENNEHAITTA_STATUS.RED],
+    [LIIKENNEHAITTA_STATUS.BLUE]: highlight ? STYLES.BLUE_HL : STYLES.BLUE,
+    [LIIKENNEHAITTA_STATUS.GREEN]: highlight ? STYLES.GREEN_HL : STYLES.GREEN,
+    [LIIKENNEHAITTA_STATUS.GREY]: highlight ? STYLES.GREY_HL : STYLES.GREY,
+    [LIIKENNEHAITTA_STATUS.YELLOW]: highlight ? STYLES.YELLOW_HL : STYLES.YELLOW,
+    [LIIKENNEHAITTA_STATUS.RED]: highlight ? STYLES.RED_HL : STYLES.RED,
   });
 
 // Performance tips: https://github.com/openlayers/openlayers/issues/8392
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const styleFunction: any = (feature: Feature) => {
+export const styleFunction: any = (feature: Feature, renderFeature: any, highlight = false) => {
   const liikenneHaittaIndeksi: number | null = feature.get('liikennehaittaindeksi');
   const status = getStatusByIndex(liikenneHaittaIndeksi);
 
-  return getStyleByStatus(status);
+  return getStyleByStatus(status, highlight);
 };


### PR DESCRIPTION
# Description

Hover your cursor over a geometry on the map. The geometries of the hanke are "highlighted"

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
