### PR TITLE
HAI-1149: Always show organization and type of construction site in map sidebar

### DIFF
--- a/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
@@ -34,6 +34,11 @@ type Props = {
 const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
   const { t } = useTranslation();
 
+  const organisaatioContent = hanke.omistajat[0]?.organisaatioNimi || '-';
+  const tyomaaTyyppiContent = hanke.tyomaaTyyppi.length
+    ? hanke.tyomaaTyyppi.map((tyyppi) => t(`hanke:tyomaaTyyppi:${tyyppi}`)).join(', ')
+    : '-';
+
   return (
     <Drawer
       variant="alwaysOpen"
@@ -77,15 +82,11 @@ const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
           />
           <SidebarSection
             title={t('hankeForm:labels.organisaatio')}
-            content={hanke.omistajat[0]?.organisaatioNimi || '-'}
+            content={organisaatioContent}
           />
           <SidebarSection
             title={t('hankeForm:labels.tyomaaTyyppi')}
-            content={
-              hanke.tyomaaTyyppi.length
-                ? hanke.tyomaaTyyppi.map((tyyppi) => t(`hanke:tyomaaTyyppi:${tyyppi}`)).join(', ')
-                : '-'
-            }
+            content={tyomaaTyyppiContent}
           />
           <SidebarSection title={t('hankeForm:labels.kuvaus')} content={hanke.kuvaus} />
           <hr />

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
@@ -75,17 +75,17 @@ const HankeSidebar: React.FC<Props> = ({ hanke, isOpen, handleClose }) => {
             title={t('hankeForm:labels.vaihe')}
             content={t(`hanke:vaihe:${hanke.vaihe}`)}
           />
-          {hanke.omistajat[0] && (
-            <SidebarSection
-              title={t('hankeForm:labels.organisaatio')}
-              content={hanke.omistajat[0].organisaatioNimi}
-            />
-          )}
+          <SidebarSection
+            title={t('hankeForm:labels.organisaatio')}
+            content={hanke.omistajat[0]?.organisaatioNimi || '-'}
+          />
           <SidebarSection
             title={t('hankeForm:labels.tyomaaTyyppi')}
-            content={hanke.tyomaaTyyppi
-              .map((tyyppi) => t(`hanke:tyomaaTyyppi:${tyyppi}`))
-              .join(', ')}
+            content={
+              hanke.tyomaaTyyppi.length
+                ? hanke.tyomaaTyyppi.map((tyyppi) => t(`hanke:tyomaaTyyppi:${tyyppi}`)).join(', ')
+                : '-'
+            }
           />
           <SidebarSection title={t('hankeForm:labels.kuvaus')} content={hanke.kuvaus} />
           <hr />


### PR DESCRIPTION
# Description

Modified big map sidebar so that information about organization and type of construction site are always displayed. If they are not present, '-' is shown.

### Jira Issue: HAI-1149

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other