### PR TITLE
HAI-1209 Fix save notification covering part of the hanke form even when it is closed

### DIFF
--- a/src/domain/hanke/edit/components/Notification.tsx
+++ b/src/domain/hanke/edit/components/Notification.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Notification, NotificationType } from 'hds-react';
 
 type Props = {
@@ -12,20 +12,29 @@ const NotificationComp: React.FC<Props> = ({
   typeProps,
   testId = 'notification',
   children,
-}) => (
-  <Notification
-    label={label}
-    position="top-right"
-    dismissible
-    autoClose
-    autoCloseDuration={2000}
-    closeButtonLabelText="Close toast"
-    type={typeProps}
-    style={{ zIndex: 100 }}
-    dataTestId={testId}
-  >
-    {children}
-  </Notification>
-);
+}) => {
+  const [open, setOpen] = useState(true);
+
+  if (open) {
+    return (
+      <Notification
+        label={label}
+        position="top-right"
+        dismissible
+        autoClose
+        autoCloseDuration={2000}
+        closeButtonLabelText="Close toast"
+        onClose={() => setOpen(false)}
+        type={typeProps}
+        style={{ zIndex: 100 }}
+        dataTestId={testId}
+      >
+        {children}
+      </Notification>
+    );
+  }
+
+  return null;
+};
 
 export default NotificationComp;


### PR DESCRIPTION
# Description

Fixed an issue where invisible save notification in hanke form was left covering part of the form even when the notification was closed.

### Jira Issue: HAI-1209

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other