### PR TITLE
HAI-1199 Don't require confirmation when selecting dates in new hanke form

### DIFF
--- a/src/common/utils/date.ts
+++ b/src/common/utils/date.ts
@@ -3,9 +3,21 @@ import startOfDay from 'date-fns/startOfDay';
 import format from 'date-fns/format';
 
 // React-datepicker use 00:00 time and TZ so without endOfDay, selected day will be yesterday
-export const toEndOfDayUTCISO = (date: Date) => endOfDay(date).toISOString();
+export const toEndOfDayUTCISO = (date: Date) => {
+  try {
+    return endOfDay(date).toISOString();
+  } catch (error) {
+    return '';
+  }
+};
 
-export const toStartOfDayUTCISO = (date: Date) => startOfDay(date).toISOString();
+export const toStartOfDayUTCISO = (date: Date) => {
+  try {
+    return startOfDay(date).toISOString();
+  } catch (error) {
+    return '';
+  }
+};
 
 export const formatToFinnishDate = (date: string) => format(new Date(date), 'dd.MM.yyyy');
 

--- a/src/domain/hanke/newForm/BasicHankeInfo.tsx
+++ b/src/domain/hanke/newForm/BasicHankeInfo.tsx
@@ -144,10 +144,7 @@ export const BasicHankeInfo: React.FC = () => {
           onChange={(date: string) => {
             const convertedDateString = convertFinnishDate(date);
             if (convertedDateString.length > 0) {
-              formik.setFieldValue(
-                'alkuPvm',
-                toStartOfDayUTCISO(new Date(convertedDateString)) || ''
-              );
+              formik.setFieldValue('alkuPvm', toStartOfDayUTCISO(new Date(convertedDateString)));
             }
             alkuPvmInputIsDirty.current = true;
           }}
@@ -159,6 +156,7 @@ export const BasicHankeInfo: React.FC = () => {
           value={!formik.values.alkuPvm ? undefined : formatToFinnishDate(formik.values.alkuPvm)}
           required
           errorText={getErrorMessage('alkuPvm')}
+          disableConfirmation
         />
         <DateInput
           id="loppuPvm"
@@ -168,10 +166,7 @@ export const BasicHankeInfo: React.FC = () => {
           onChange={(date: string) => {
             const convertedDateString = convertFinnishDate(date);
             if (convertedDateString.length > 0) {
-              formik.setFieldValue(
-                'loppuPvm',
-                toEndOfDayUTCISO(new Date(convertedDateString)) || ''
-              );
+              formik.setFieldValue('loppuPvm', toEndOfDayUTCISO(new Date(convertedDateString)));
             }
             loppuPvmInputIsDirty.current = true;
           }}
@@ -183,6 +178,7 @@ export const BasicHankeInfo: React.FC = () => {
           value={!formik.values.loppuPvm ? undefined : formatToFinnishDate(formik.values.loppuPvm)}
           required
           errorText={getErrorMessage('loppuPvm')}
+          disableConfirmation
         />
       </div>
       <Combobox<OptionTyyppi>

--- a/src/domain/hanke/newForm/Haitat.tsx
+++ b/src/domain/hanke/newForm/Haitat.tsx
@@ -48,7 +48,7 @@ export const Haitat: React.FC = () => {
           if (convertedDateString.length > 0) {
             formik.setFieldValue(
               'haittaAlkuPvm',
-              toStartOfDayUTCISO(new Date(convertedDateString)) || ''
+              toStartOfDayUTCISO(new Date(convertedDateString))
             );
           }
           haittaAlkuPvmIsDirty.current = true;
@@ -64,6 +64,7 @@ export const Haitat: React.FC = () => {
             : formatToFinnishDate(formik.values.haittaAlkuPvm)
         }
         required
+        disableConfirmation
       />
       <DateInput
         id="haittaLoppuPvm"
@@ -73,10 +74,7 @@ export const Haitat: React.FC = () => {
         onChange={(date: string) => {
           const convertedDateString = convertFinnishDate(date);
           if (convertedDateString.length > 0) {
-            formik.setFieldValue(
-              'haittaLoppuPvm',
-              toEndOfDayUTCISO(new Date(convertedDateString)) || ''
-            );
+            formik.setFieldValue('haittaLoppuPvm', toEndOfDayUTCISO(new Date(convertedDateString)));
           }
           haittaLoppuPvmIsDirty.current = true;
         }}
@@ -91,6 +89,7 @@ export const Haitat: React.FC = () => {
             : formatToFinnishDate(formik.values.haittaLoppuPvm)
         }
         required
+        disableConfirmation
       />
       <Select
         required


### PR DESCRIPTION
# Description

Previously DateInputs have required user to click Select button to confirm date selection. Changed it so that confirmation is not required and just clicking the date selects it.

### Jira Issue: HAI-1199

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other