### PR TITLE
HAI-1139 Disable the OIDC client ID environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 SASS_PATH=./src/assets/styles
 REACT_APP_APPLICATION_NAME=$npm_package_name
 REACT_APP_OIDC_AUTHORITY="https://tunnistamo.test.hel.ninja/openid"
-REACT_APP_OIDC_CLIENT_ID="haitaton-admin-ui-dev"
+#REACT_APP_OIDC_CLIENT_ID="haitaton-admin-ui-dev"
 REACT_APP_OIDC_SCOPE="openid profile"
 REACT_APP_VERSION=$npm_package_version
 REACT_APP_SENTRY_DSN='https://24d073314fb3414cae1d6fef8c34a8f4@o394401.ingest.sentry.io/5617533'


### PR DESCRIPTION
# Description

Overriding the environment variable in the cloud environments doesn't
seem to be working, so try to disable the variable in the .env file and
see if that makes any difference.

### Jira Issue: HAI-1139

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Other
