### PR TITLE
HAI-1245 Fix address search only returning Finnish names even if search is in Swedish

### DIFF
--- a/src/domain/map/components/AddressSearch/AddressSearch.test.tsx
+++ b/src/domain/map/components/AddressSearch/AddressSearch.test.tsx
@@ -21,3 +21,60 @@ test('Address can be selected from suggestions', async () => {
   userEvent.click(screen.getByText('Elielinaukio 3'));
   expect(handleAddressSelect).toHaveBeenCalledWith([25496700, 6673224]);
 });
+
+test('Swedish address labels are returned when search term is in Swedish', async () => {
+  mockAxios.get.mockResolvedValueOnce({ data: addressData });
+
+  const handleAddressSelect = jest.fn();
+  render(<AddressSearch onAddressSelect={handleAddressSelect} />);
+
+  const searchInput = screen.getByPlaceholderText('Etsi osoitteella');
+
+  userEvent.type(searchInput, 'elielplatsen');
+  await waitFor(() => {
+    expect(mockAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  expect(screen.getByText('Elielplatsen 1')).toBeInTheDocument();
+  expect(screen.getByText('Elielplatsen 2')).toBeInTheDocument();
+  expect(screen.getByText('Elielplatsen 3')).toBeInTheDocument();
+  expect(screen.getByText('Elielplatsen 5')).toBeInTheDocument();
+});
+
+test('Finnish address labels are returned when search term is in Finnish', async () => {
+  mockAxios.get.mockResolvedValueOnce({ data: addressData });
+
+  const handleAddressSelect = jest.fn();
+  render(<AddressSearch onAddressSelect={handleAddressSelect} />);
+
+  const searchInput = screen.getByPlaceholderText('Etsi osoitteella');
+
+  userEvent.type(searchInput, 'elielinaukio');
+  await waitFor(() => {
+    expect(mockAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  expect(screen.getByText('Elielinaukio 1')).toBeInTheDocument();
+  expect(screen.getByText('Elielinaukio 2')).toBeInTheDocument();
+  expect(screen.getByText('Elielinaukio 3')).toBeInTheDocument();
+  expect(screen.getByText('Elielinaukio 5')).toBeInTheDocument();
+});
+
+test('Finnish address labels are returned when search term is incomplete and can be either Finnish or Swedish', async () => {
+  mockAxios.get.mockResolvedValueOnce({ data: addressData });
+
+  const handleAddressSelect = jest.fn();
+  render(<AddressSearch onAddressSelect={handleAddressSelect} />);
+
+  const searchInput = screen.getByPlaceholderText('Etsi osoitteella');
+
+  userEvent.type(searchInput, 'eliel');
+  await waitFor(() => {
+    expect(mockAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  expect(screen.getByText('Elielinaukio 1')).toBeInTheDocument();
+  expect(screen.getByText('Elielinaukio 2')).toBeInTheDocument();
+  expect(screen.getByText('Elielinaukio 3')).toBeInTheDocument();
+  expect(screen.getByText('Elielinaukio 5')).toBeInTheDocument();
+});

--- a/src/domain/map/components/AddressSearch/AddressSearch.tsx
+++ b/src/domain/map/components/AddressSearch/AddressSearch.tsx
@@ -15,7 +15,7 @@ type Address = {
 };
 
 const AddressSearch: React.FC<Props> = ({ onAddressSelect }) => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const suggestions = useRef([] as Address[]);
   const abortController = useRef(null as AbortController | null);
 
@@ -28,7 +28,13 @@ const AddressSearch: React.FC<Props> = ({ onAddressSelect }) => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const suggestionItems: Address[] = data.features.map((feature: any) => {
-        let label = i18n.language === 'sv' ? feature.properties.gatan : feature.properties.katunimi;
+        // Use Finnish street name as a label if it seems that user was searching for that,
+        // otherwise use Swedish street name
+        let label = feature.properties.katunimi.toLowerCase().includes(searchValue.toLowerCase())
+          ? feature.properties.katunimi
+          : feature.properties.gatan;
+
+        // Append street number to label if it exists in the result
         if (feature.properties.osoitenumero_teksti) {
           label += ` ${feature.properties.osoitenumero_teksti}`;
         }


### PR DESCRIPTION
# Description

Fixed it so that now it is checked if Finnish street name of result includes the search term and if so that name is used, otherwise Swedish street name is used.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1245

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other
