### PR TITLE
HAI-1279 Implement haitat page to hanke form

### DIFF
--- a/src/domain/hanke/edit/HankeForm.tsx
+++ b/src/domain/hanke/edit/HankeForm.tsx
@@ -25,6 +25,7 @@ import api from '../../api/api';
 import MultipageForm from '../../forms/MultipageForm';
 import FormActions from '../../forms/components/FormActions';
 import { useLocalizedRoutes } from '../../../common/hooks/useLocalizedRoutes';
+import HankeHaitatForm from './HankeHaitatForm';
 
 async function saveHanke({
   data,
@@ -151,6 +152,11 @@ const HankeForm: React.FC<Props> = ({
     {
       element: <Form1 errors={errors} register={register} formData={formValues} />,
       label: t('hankeForm:hankkeenAlueForm:header'),
+      state: isNewHanke ? StepState.disabled : StepState.available,
+    },
+    {
+      element: <HankeHaitatForm formData={formValues} />,
+      label: t('hankeForm:hankkeenHaitatForm:header'),
       state: isNewHanke ? StepState.disabled : StepState.available,
     },
     {

--- a/src/domain/hanke/edit/HankeHaitatForm.tsx
+++ b/src/domain/hanke/edit/HankeHaitatForm.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import HankeIndexes from '../../map/components/HankeSidebar/HankeIndexes';
+import { HankeDataFormState } from './types';
+
+type Props = {
+  formData: HankeDataFormState;
+};
+
+const HankeHaitatForm: React.FC<Props> = ({ formData }) => {
+  return <HankeIndexes hankeIndexData={formData.tormaystarkasteluTulos} />;
+};
+
+export default HankeHaitatForm;

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.module.scss
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.module.scss
@@ -4,7 +4,8 @@
   padding: 0.4rem 0.2rem 0.4rem 1rem;
 
   &__titlesContainer {
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(auto, 300px));
     flex-grow: 1;
   }
 
@@ -13,11 +14,12 @@
     text-align: center;
     flex-direction: column-reverse;
     margin-right: 8px;
+    flex-shrink: 0;
   }
 }
 
 .indexTitle {
-  padding: 0.4rem 0.2rem 0.4rem 1rem;
+  padding: 0.4rem 0.2rem 0.4rem 0;
   display: flex;
 }
 

--- a/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeIndexes.tsx
@@ -21,7 +21,7 @@ type IndexProps = {
 const IndexSection: React.FC<IndexProps> = ({ title, content, index, testId, loading }) => (
   <div className={styles.indexContainer}>
     <div className={styles.indexContainer__titlesContainer}>
-      <Text tag="h2" styleAs={content ? 'h6' : 'h5'} weight="bold">
+      <Text tag="h2" styleAs="h6" weight="bold">
         {title}
       </Text>
       {content && (
@@ -31,7 +31,6 @@ const IndexSection: React.FC<IndexProps> = ({ title, content, index, testId, loa
       )}
     </div>
     <div className={styles.indexContainer__number}>
-      {content && <div>&nbsp;</div>}
       {loading && <LoadingSpinner small />}
       {!loading && (
         <div
@@ -71,7 +70,7 @@ const HankeIndexes: React.FC<Props> = ({ hankeIndexData, displayTooltip, loading
   return (
     <div>
       <div className={styles.indexTitle}>
-        <Text tag="h2" styleAs="h5" weight="bold">
+        <Text tag="h2" styleAs="h4" weight="bold">
           {t('hankeIndexes:haittaindeksit')}
         </Text>
         {displayTooltip && (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -337,7 +337,7 @@
       "header": "EN:Hankkeen lisätiedot"
     },
     "hankkeenHaitatForm": {
-      "header": "EN:Hankkeen haitat"
+      "header": "EN:Haitat"
     },
     "finishedForm": {
       "header": "EN:Lomake on lähetetty onnistuneesti"

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -337,7 +337,7 @@
       "header": "Hankkeen lisätiedot"
     },
     "hankkeenHaitatForm": {
-      "header": "Hankkeen haitat"
+      "header": "Haitat"
     },
     "finishedForm": {
       "header": "Lomake on lähetetty onnistuneesti"

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -337,7 +337,7 @@
       "header": "SV:Hankkeen lisätiedot"
     },
     "hankkeenHaitatForm": {
-      "header": "SV:Hankkeen haitat"
+      "header": "SV:Haitat"
     },
     "finishedForm": {
       "header": "SV:Lomake on lähetetty onnistuneesti"


### PR DESCRIPTION
# Description

Added haitat page to hanke form which displays haittaindexes for the created hanke.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1279

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
