### PR TITLE
HAI-1254 Change map layer between Opaskartta and Kantakartta when zooming in and out

### DIFF
--- a/src/common/components/map/Map.tsx
+++ b/src/common/components/map/Map.tsx
@@ -59,18 +59,18 @@ const Map: React.FC<Props> = ({
 
     // eslint-disable-next-line
     return () => mapObject.setTarget(undefined);
-  }, []);
+  }, [center, zoom]);
 
   useEffect(() => {
     if (!map) return;
     map.getView().setZoom(zoom);
-  }, [zoom]);
+  }, [map, zoom]);
 
   useEffect(() => {
     if (!map) return;
 
     map.getView().setCenter(center);
-  }, [center]);
+  }, [map, center]);
 
   return (
     <MapContext.Provider value={{ map, layers }}>

--- a/src/common/components/map/layers/TileLayer.tsx
+++ b/src/common/components/map/layers/TileLayer.tsx
@@ -5,10 +5,12 @@ import MapContext from '../MapContext';
 
 type Props = {
   source: TileWMS | OSM;
+  minZoom?: number;
+  maxZoom?: number;
   zIndex?: number;
 };
 
-const TileLayer: React.FC<Props> = ({ source, zIndex = 0 }) => {
+const TileLayer: React.FC<Props> = ({ source, minZoom, maxZoom, zIndex = 0 }) => {
   const { map } = useContext(MapContext);
 
   useEffect(() => {
@@ -16,6 +18,8 @@ const TileLayer: React.FC<Props> = ({ source, zIndex = 0 }) => {
 
     const tileLayer = new OLTileLayer({
       source,
+      minZoom,
+      maxZoom,
       zIndex,
     });
 
@@ -28,7 +32,7 @@ const TileLayer: React.FC<Props> = ({ source, zIndex = 0 }) => {
         map.removeLayer(tileLayer);
       }
     };
-  }, [map]);
+  }, [map, maxZoom, minZoom, zIndex, source]);
 
   return null;
 };

--- a/src/domain/map/components/Layers/Kantakartta.tsx
+++ b/src/domain/map/components/Layers/Kantakartta.tsx
@@ -3,30 +3,54 @@ import { TileWMS } from 'ol/source';
 import TileLayer from '../../../../common/components/map/layers/TileLayer';
 import { projection } from '../../../../common/components/map/utils';
 
+const sourceOptions = {
+  url: 'https://kartta.hel.fi/ws/geoserver/avoindata/wms',
+  projection,
+  cacheSize: 1000,
+  imageSmoothing: false,
+  hidpi: false,
+  serverType: 'geoserver',
+  transition: 0,
+  attributions: ['Aineistot &copy; <a href="https://kartta.hel.fi">Helsingin kaupunki</a>'],
+};
+
 const Kantakartta = () => (
-  <TileLayer
-    zIndex={2}
-    source={
-      new TileWMS({
-        url: 'https://kartta.hel.fi/ws/geoserver/avoindata/wms',
-        params: {
-          LAYERS: 'Kantakartta',
-          FORMAT: 'image/jpeg',
-          WIDTH: 256,
-          HEIGHT: 256,
-          VERSION: '1.1.1',
-          TRANSPARENT: 'false',
-        },
-        projection,
-        cacheSize: 1000,
-        imageSmoothing: false,
-        hidpi: false,
-        serverType: 'geoserver',
-        transition: 0,
-        attributions: ['Aineistot &copy; <a href="https://kartta.hel.fi">Helsingin kaupunki</a>'],
-      })
-    }
-  />
+  <>
+    <TileLayer
+      zIndex={2}
+      minZoom={9}
+      source={
+        new TileWMS({
+          ...sourceOptions,
+          params: {
+            LAYERS: 'Kantakartta',
+            FORMAT: 'image/jpeg',
+            WIDTH: 256,
+            HEIGHT: 256,
+            VERSION: '1.1.1',
+            TRANSPARENT: 'false',
+          },
+        })
+      }
+    />
+    <TileLayer
+      zIndex={2}
+      maxZoom={9}
+      source={
+        new TileWMS({
+          ...sourceOptions,
+          params: {
+            LAYERS: 'Opaskartta_Helsinki',
+            FORMAT: 'image/jpeg',
+            WIDTH: 256,
+            HEIGHT: 256,
+            VERSION: '1.1.1',
+            TRANSPARENT: 'false',
+          },
+        })
+      }
+    />
+  </>
 );
 
 export default Kantakartta;

--- a/src/domain/map/components/Layers/Ortokartta.tsx
+++ b/src/domain/map/components/Layers/Ortokartta.tsx
@@ -10,7 +10,7 @@ const Ortokartta = () => (
       new TileWMS({
         url: 'https://kartta.hel.fi/ws/geoserver/avoindata/wms',
         params: {
-          LAYERS: 'Ortoilmakuva_2020_5cm',
+          LAYERS: 'Ortoilmakuva',
           FORMAT: 'image/jpeg',
           WIDTH: 256,
           HEIGHT: 256,


### PR DESCRIPTION
# Description

Above zoom level 9 display Kantakartta and below level 9 display Opaskartta_Helsinki.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1254

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

When going in to for example public map view, Opaskartta should be displayed first and when zooming in it should change to Kantakartta.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
