### PR TITLE
HAI-1341 Fix language selection breaking when opening the site first time

### DIFF
--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -15,7 +15,7 @@ i18n
       sv,
     },
     detection: {
-      order: ['localStorage', 'sessionStorage', 'path', 'navigator'],
+      order: ['localStorage', 'sessionStorage', 'path'],
     },
     fallbackLng: 'fi',
     debug: false,


### PR DESCRIPTION
# Description

Removed navigator from language detector detection order options so that users browser language does not affect detection, so that if language is not found from localStorage, sessionStorage or path, fallback language of fi will be used.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1341

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other