### PR TITLE
HAI-1295 Add application type to application data

### DIFF
--- a/src/domain/johtoselvitys/BasicInfo.tsx
+++ b/src/domain/johtoselvitys/BasicInfo.tsx
@@ -25,6 +25,7 @@ export const validationSchema = {
 export interface InitialValueTypes {
   applicationType: ApplicationType;
   applicationData: {
+    applicationType: ApplicationType;
     name: string;
     startTime: number | null;
     endTime: number | null;
@@ -41,6 +42,7 @@ export interface InitialValueTypes {
 export const initialValues: InitialValueTypes = {
   applicationType: 'CABLE_REPORT',
   applicationData: {
+    applicationType: 'CABLE_REPORT',
     name: '',
     startTime: null,
     endTime: null,

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -201,6 +201,7 @@ const JohtoselvitysContainer: React.FC = () => {
     id: null,
     applicationType: 'CABLE_REPORT',
     applicationData: {
+      applicationType: 'CABLE_REPORT',
       name: '',
       customerWithContacts: {
         customer: {

--- a/src/domain/johtoselvitys/sampleRequest.json
+++ b/src/domain/johtoselvitys/sampleRequest.json
@@ -1,7 +1,7 @@
 {
   "id": null,
   "userId": "JaskaJokunen",
-  "applicationType": "CABLE_APPLICATION",
+  "applicationType": "CABLE_REPORT",
   "applicationData": {
     "name": "Haitaton hankkeen nimi",
     "customerWithContacts": {

--- a/src/domain/johtoselvitys/types.ts
+++ b/src/domain/johtoselvitys/types.ts
@@ -43,6 +43,7 @@ export type Customer = {
 };
 
 export type JohtoselvitysFormData = {
+  applicationType: ApplicationType;
   name: string;
   customerWithContacts: {
     customer: Customer;


### PR DESCRIPTION
# Description

The backend uses the application type data field to decide which application type it should deserialize the incoming JSON to. Because of technical limitations, the type field needs to be inside the application data, since that's the polymorphic object.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1295

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Other

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: