### PR TITLE
HAI-1421 Add target for skip to content accessibility shortcut

### DIFF
--- a/src/common/components/header/Header.tsx
+++ b/src/common/components/header/Header.tsx
@@ -8,6 +8,7 @@ import authService from '../../../domain/auth/authService';
 import useUser from '../../../domain/auth/useUser';
 import { Language, LANGUAGES } from '../../types/language';
 import { I18NLANGKEY } from '../../../locales/constants';
+import { SKIP_TO_ELEMENT_ID } from '../../constants/constants';
 
 const Header: React.FC = () => {
   const {
@@ -49,7 +50,7 @@ const Header: React.FC = () => {
     <Navigation
       menuToggleAriaLabel={t('common:components:multiselect:toggle')}
       title="Haitaton"
-      skipTo="#"
+      skipTo={`#${SKIP_TO_ELEMENT_ID}`}
       skipToContentLabel={t('common:components:header:skipToContentLabel')}
       titleUrl={HOME.path}
       className="header"

--- a/src/common/components/text/Text.tsx
+++ b/src/common/components/text/Text.tsx
@@ -18,6 +18,8 @@ export type StyleAs =
 
 export type Spacing = '3-xs' | '2-xs' | 'xs' | 's' | 'm' | 'l';
 
+type RestProps = Record<string, unknown>;
+
 export type Props = {
   tag: Tag;
   weight?: Weight;
@@ -39,7 +41,7 @@ const Text = ({
   spacingTop,
   className,
   ...rest
-}: Props) => {
+}: Props & RestProps) => {
   const Component = tag;
 
   return (

--- a/src/common/constants/constants.ts
+++ b/src/common/constants/constants.ts
@@ -1,0 +1,1 @@
+export const SKIP_TO_ELEMENT_ID = 'set-focus-here';

--- a/src/domain/forms/MultipageForm.tsx
+++ b/src/domain/forms/MultipageForm.tsx
@@ -5,6 +5,7 @@ import useLocale from '../../common/hooks/useLocale';
 import Text from '../../common/components/text/Text';
 import { createStepReducer } from './formStepReducer';
 import { ACTION_TYPE, StepperStep } from './types';
+import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
 
 interface FormStep extends StepperStep {
   element: React.ReactNode;
@@ -78,7 +79,7 @@ const MultipageForm: React.FC<Props> = ({
 
   return (
     <form className={styles.formContainer} onSubmit={onSubmit}>
-      <Text tag="h1" styleAs="h1" weight="bold">
+      <Text tag="h1" styleAs="h1" weight="bold" id={SKIP_TO_ELEMENT_ID} tabIndex={-1}>
         {heading}
       </Text>
 

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -37,6 +37,7 @@ import OwnHankeMapHeader from '../../map/components/OwnHankeMap/OwnHankeMapHeade
 import CompressedAreaIndex from '../hankeIndexes/CompressedAreaIndex';
 import HankeDraftStateNotification from '../edit/components/HankeDraftStateNotification';
 import { useIsHankeValid } from '../edit/hooks/useIsHankeValid';
+import { SKIP_TO_ELEMENT_ID } from '../../../common/constants/constants';
 
 type AreaProps = {
   area: HankeAlue;
@@ -130,7 +131,7 @@ const HankeView: React.FC<Props> = ({ hankeData, onEditHanke, onDeleteHanke }) =
     <article className={styles.hankeViewContainer}>
       <header className={styles.headerContainer}>
         <Container>
-          <Text tag="h1" styleAs="h1" weight="bold">
+          <Text tag="h1" styleAs="h1" weight="bold" id={SKIP_TO_ELEMENT_ID} tabIndex={-1}>
             {hankeData?.nimi}
           </Text>
           <Text tag="h2" styleAs="h3" weight="bold" spacingBottom="l">

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -28,6 +28,7 @@ import OwnHankeMap from '../../map/components/OwnHankeMap/OwnHankeMap';
 import OwnHankeMapHeader from '../../map/components/OwnHankeMap/OwnHankeMapHeader';
 import HankeDraftStateNotification from '../edit/components/HankeDraftStateNotification';
 import Container from '../../../common/components/container/Container';
+import { SKIP_TO_ELEMENT_ID } from '../../../common/constants/constants';
 
 type CustomAccordionProps = {
   hanke: HankeData;
@@ -433,6 +434,8 @@ const PaginatedPortfolio: React.FC<PagedRowsProps> = ({ data }) => {
             styleAs="h1"
             spacingBottom="s"
             weight="bold"
+            id={SKIP_TO_ELEMENT_ID}
+            tabIndex={-1}
           >
             {t('hankePortfolio:pageHeader')}
           </Text>

--- a/src/domain/homepage/HomepageComponent.tsx
+++ b/src/domain/homepage/HomepageComponent.tsx
@@ -12,6 +12,7 @@ import img3 from './HKMS000005_km003yz2.webp';
 import img4 from './kartta.png';
 import Linkbox from '../../common/components/Linkbox/Linkbox';
 import useUser from '../auth/useUser';
+import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
 
 const Homepage: React.FC = () => {
   const { t } = useTranslation();
@@ -77,7 +78,14 @@ const Homepage: React.FC = () => {
     <>
       <div className={styles.heroContainer}>
         <section className={styles.hero}>
-          <Text tag="h1" styleAs="h1" spacing="s" weight="bold">
+          <Text
+            tag="h1"
+            styleAs="h1"
+            spacing="s"
+            weight="bold"
+            id={SKIP_TO_ELEMENT_ID}
+            tabIndex={-1}
+          >
             {t('homepage:pageTitle')}
           </Text>
           <Text tag="h2" styleAs="h3" spacing="s" weight="bold">

--- a/src/domain/mapAndList/MapAndListContainer.tsx
+++ b/src/domain/mapAndList/MapAndListContainer.tsx
@@ -5,13 +5,20 @@ import { IconMap, IconLayers } from 'hds-react/icons';
 import { useTranslation } from 'react-i18next';
 import { Outlet, NavLink } from 'react-router-dom';
 import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
+import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
 
 const MapAndListContainer: React.FC = () => {
   const { PUBLIC_HANKKEET_LIST, PUBLIC_HANKKEET_MAP } = useLocalizedRoutes();
   const { t } = useTranslation();
 
   return (
-    <Flex direction="column" height="100%" marginBottom="var(--spacing-2-xl)">
+    <Flex
+      direction="column"
+      height="100%"
+      marginBottom="var(--spacing-2-xl)"
+      id={SKIP_TO_ELEMENT_ID}
+      tabIndex={-1}
+    >
       <Flex justify="center" align="center" margin="var(--spacing-m)">
         <div>
           <NavLink to={PUBLIC_HANKKEET_MAP.path}>

--- a/src/pages/staticPages/AccessibilityPage.tsx
+++ b/src/pages/staticPages/AccessibilityPage.tsx
@@ -5,6 +5,7 @@ import PageMeta from '../components/PageMeta';
 import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
 import Container from '../../common/components/container/Container';
 import Text from '../../common/components/text/Text';
+import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
 
 const AccessibilityPage: React.FC = () => {
   const { ACCESSIBILITY } = useLocalizedRoutes();
@@ -13,7 +14,7 @@ const AccessibilityPage: React.FC = () => {
   return (
     <Container>
       <PageMeta routeData={ACCESSIBILITY} />
-      <Text tag="h1" styleAs="h2" spacing="s" weight="bold">
+      <Text tag="h1" styleAs="h2" spacing="s" weight="bold" id={SKIP_TO_ELEMENT_ID} tabIndex={-1}>
         {t('staticPages:accessibility:title')}
       </Text>
       <HdsContainer style={{ padding: '2rem', backgroundColor: 'white' }}>

--- a/src/pages/staticPages/InfoPage.tsx
+++ b/src/pages/staticPages/InfoPage.tsx
@@ -6,6 +6,7 @@ import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
 import Container from '../../common/components/container/Container';
 import Text from '../../common/components/text/Text';
 import styles from './StaticContent.module.scss';
+import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
 
 const InfoPage: React.FC = () => {
   const { HAITATON_INFO } = useLocalizedRoutes();
@@ -14,7 +15,7 @@ const InfoPage: React.FC = () => {
   return (
     <Container>
       <PageMeta routeData={HAITATON_INFO} />
-      <Text tag="h1" styleAs="h2" spacing="s" weight="bold">
+      <Text tag="h1" styleAs="h2" spacing="s" weight="bold" id={SKIP_TO_ELEMENT_ID} tabIndex={-1}>
         {t('staticPages:info:title')}
       </Text>
 

--- a/src/pages/staticPages/PrivacyPolicyPage.tsx
+++ b/src/pages/staticPages/PrivacyPolicyPage.tsx
@@ -5,6 +5,7 @@ import PageMeta from '../components/PageMeta';
 import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
 import Container from '../../common/components/container/Container';
 import Text from '../../common/components/text/Text';
+import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
 
 const PrivacyPolicyPage: React.FC = () => {
   const { PRIVACY_POLICY } = useLocalizedRoutes();
@@ -13,7 +14,7 @@ const PrivacyPolicyPage: React.FC = () => {
   return (
     <Container>
       <PageMeta routeData={PRIVACY_POLICY} />
-      <Text tag="h1" styleAs="h2" spacing="s" weight="bold">
+      <Text tag="h1" styleAs="h2" spacing="s" weight="bold" id={SKIP_TO_ELEMENT_ID} tabIndex={-1}>
         {t('staticPages:privacyPolicy:title')}
       </Text>
 

--- a/src/pages/staticPages/ReferencesPage.tsx
+++ b/src/pages/staticPages/ReferencesPage.tsx
@@ -5,6 +5,7 @@ import PageMeta from '../components/PageMeta';
 import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
 import Container from '../../common/components/container/Container';
 import Text from '../../common/components/text/Text';
+import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
 
 const ReferencesPage: React.FC = () => {
   const { HAITATON_INFO } = useLocalizedRoutes();
@@ -14,7 +15,7 @@ const ReferencesPage: React.FC = () => {
   return (
     <Container>
       <PageMeta routeData={HAITATON_INFO} />
-      <Text tag="h1" styleAs="h2" spacing="s" weight="bold">
+      <Text tag="h1" styleAs="h2" spacing="s" weight="bold" id={SKIP_TO_ELEMENT_ID} tabIndex={-1}>
         {t('staticPages:references:title')}
       </Text>
       <HdsContainer style={{ padding: '2rem', backgroundColor: 'white' }}>


### PR DESCRIPTION
# Description

There is a skip to content accessibility shortcut located in the top bar, which did not have target element id. Added the id and added that id for each page heading element.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1421

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Navigate the page using tab key. The first element to receive focus when loading the page should be a link with text "Siirry pääsisältöön" and then pressing enter should move focus to the first h1 element of the page you are on if there is one.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: