### PR TITLE
HAI-1455 Implement naming of cable report application areas

### DIFF
--- a/src/common/hooks/useForceUpdate.ts
+++ b/src/common/hooks/useForceUpdate.ts
@@ -1,5 +1,9 @@
 import { useCallback, useState } from 'react';
 
+/**
+ * Returns a forceUpdate function that can be used to
+ * force a React component to re-render
+ */
 export default function useForceUpdate() {
   const [, updateState] = useState(0);
 

--- a/src/common/hooks/useForceUpdate.ts
+++ b/src/common/hooks/useForceUpdate.ts
@@ -1,0 +1,9 @@
+import { useCallback, useState } from 'react';
+
+export default function useForceUpdate() {
+  const [, updateState] = useState(0);
+
+  const forceUpdate = useCallback(() => updateState((state) => state + 1), []);
+
+  return forceUpdate;
+}

--- a/src/common/types/hanke.ts
+++ b/src/common/types/hanke.ts
@@ -1,4 +1,4 @@
-import GeoJSON, { Polygon } from 'geojson';
+import GeoJSON from 'geojson';
 
 export interface HankeGeoJSONProperties {
   hankeTunnus: string;
@@ -9,11 +9,6 @@ export interface CRS {
     name: string;
   };
 }
-
-export type HaitatonGeometry = GeoJSON.Geometry & {
-  crs: CRS;
-  geometries: Polygon[];
-};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type HankeGeoJSON = GeoJSON.FeatureCollection<any, HankeGeoJSONProperties> & {

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -1,4 +1,6 @@
-import { HaitatonGeometry } from '../../../common/types/hanke';
+import { Polygon, Position } from 'geojson';
+import { Coordinate } from 'ol/coordinate';
+import { CRS } from '../../../common/types/hanke';
 
 export type ApplicationType = 'CABLE_REPORT';
 
@@ -49,13 +51,37 @@ export type CustomerWithContacts = {
   contacts: Contact[];
 };
 
+type PolygonWithCRS = Polygon & { crs: CRS };
+
+export class ApplicationGeometry implements PolygonWithCRS {
+  type: 'Polygon' = 'Polygon';
+
+  crs: CRS = {
+    type: 'name',
+    properties: {
+      name: 'urn:ogc:def:crs:EPSG::3879',
+    },
+  };
+
+  coordinates: Position[][] = [];
+
+  constructor(coordinates: Coordinate[][]) {
+    this.coordinates = coordinates;
+  }
+}
+
+export type ApplicationArea = {
+  name: string;
+  geometry: ApplicationGeometry;
+};
+
 export type JohtoselvitysData = {
   hankeTunnus: string;
   applicationType: ApplicationType;
   name: string;
   customerWithContacts: CustomerWithContacts;
   contractorWithContacts: CustomerWithContacts;
-  geometry: HaitatonGeometry;
+  areas: ApplicationArea[];
   startTime: string | null;
   endTime: string | null;
   identificationNumber: string; // asiointitunnus

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -1,3 +1,4 @@
+import { TFunction } from 'i18next';
 import api from '../api/api';
 import { Application } from './types/application';
 
@@ -18,4 +19,10 @@ export async function saveApplication(data: Application) {
 export async function sendApplication(applicationId: number) {
   const response = await api.post<Application>(`/hakemukset/${applicationId}/send-application`, {});
   return response.data;
+}
+
+export function getAreaDefaultName(t: TFunction, index: number) {
+  const label = t('hakemus:labels:workArea');
+  if (index > 0) return `${label} ${index + 1}`;
+  return label;
 }

--- a/src/domain/hanke/edit/HankeFormAlueet.tsx
+++ b/src/domain/hanke/edit/HankeFormAlueet.tsx
@@ -1,20 +1,20 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
 import { Feature } from 'ol';
 import VectorSource from 'ol/source/Vector';
-import { Coordinate } from 'ol/coordinate';
 import Geometry from 'ol/geom/Geometry';
 import { Box } from '@chakra-ui/react';
 import HankeDrawer from '../../map/components/HankeDrawer/HankeDrawer';
 import { useFormPage } from './hooks/useFormPage';
 import { FORMFIELD, FormProps, HankeAlueFormState } from './types';
-import { doAddressSearch, formatSurfaceArea } from '../../map/utils';
+import { formatSurfaceArea } from '../../map/utils';
 import Haitat from './components/Haitat';
 import Text from '../../../common/components/text/Text';
 import useSelectableTabs from '../../../common/hooks/useSelectableTabs';
 import useHighlightArea from '../../map/hooks/useHighlightArea';
+import useAddressCoordinate from '../../map/hooks/useAddressCoordinate';
 
 function getEmptyArea(feature: Feature): Omit<HankeAlueFormState, 'id' | 'geometriat'> {
   return {
@@ -36,20 +36,12 @@ const HankeFormAlueet: React.FC<FormProps> = ({ formData }) => {
     name: FORMFIELD.HANKEALUEET,
   });
   const [drawSource] = useState<VectorSource>(new VectorSource());
-  const [addressCoordinate, setAddressCoordinate] = useState<Coordinate | undefined>();
+  const addressCoordinate = useAddressCoordinate(formData.tyomaaKatuosoite);
   useFormPage();
 
   const { tabRefs } = useSelectableTabs(hankeAlueet.length, { selectLastTabOnChange: true });
 
   const higlightArea = useHighlightArea();
-
-  useEffect(() => {
-    if (formData.tyomaaKatuosoite) {
-      doAddressSearch(formData.tyomaaKatuosoite).then(({ data }) => {
-        setAddressCoordinate(data.features[0]?.geometry.coordinates);
-      });
-    }
-  }, [formData.tyomaaKatuosoite]);
 
   const handleAddFeature = useCallback(
     (feature: Feature<Geometry>) => {

--- a/src/domain/johtoselvitys/Geometries.module.scss
+++ b/src/domain/johtoselvitys/Geometries.module.scss
@@ -1,3 +1,5 @@
+@import 'layout.scss';
+
 .mapContainer {
   position: relative;
   width: 100%;
@@ -17,4 +19,16 @@
   padding: var(--spacing-m);
   margin-top: var(--spacing-xs);
   margin-bottom: var(--spacing-s);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--spacing-s);
+
+  .nameInput {
+    width: auto;
+
+    @include respond-above(s) {
+      width: 350px;
+    }
+  }
 }

--- a/src/domain/johtoselvitys/Geometries.tsx
+++ b/src/domain/johtoselvitys/Geometries.tsx
@@ -1,14 +1,14 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Feature } from 'ol';
 import VectorSource, { VectorSourceEvent } from 'ol/source/Vector';
+import Polygon from 'ol/geom/Polygon';
 import Geometry from 'ol/geom/Geometry';
-import GeoJSON from 'ol/format/GeoJSON';
-import GeometryCollection from 'ol/geom/GeometryCollection';
-import { useFormContext } from 'react-hook-form';
+import { useFieldArray, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@chakra-ui/react';
 import { Button, Fieldset, IconTrash, Tab, TabList, TabPanel, Tabs } from 'hds-react';
-import { debounce, sortBy, uniqueId } from 'lodash';
+import { debounce } from 'lodash';
+
 import VectorLayer from '../../common/components/map/layers/VectorLayer';
 import Map from '../../common/components/map/Map';
 import FitSource from '../map/components/interations/FitSource';
@@ -16,7 +16,7 @@ import Kantakartta from '../map/components/Layers/Kantakartta';
 import styles from './Geometries.module.scss';
 import Controls from '../../common/components/map/controls/Controls';
 import DrawModule from '../../common/components/map/modules/draw/DrawModule';
-import { formatFeaturesToAlluGeoJSON, formatSurfaceArea } from '../map/utils';
+import { formatSurfaceArea } from '../map/utils';
 import Text from '../../common/components/text/Text';
 import ResponsiveGrid from '../../common/components/grid/ResponsiveGrid';
 import DatePicker from '../../common/components/datePicker/DatePicker';
@@ -24,87 +24,64 @@ import useLocale from '../../common/hooks/useLocale';
 import OverviewMapControl from '../../common/components/map/controls/OverviewMapControl';
 import useSelectableTabs from '../../common/hooks/useSelectableTabs';
 import useHighlightArea from '../map/hooks/useHighlightArea';
-import { JohtoselvitysFormValues } from './types';
-import { HaitatonGeometry } from '../../common/types/hanke';
+import { JohtoselvitysArea, JohtoselvitysFormValues } from './types';
+import AddressSearchContainer from '../map/components/AddressSearch/AddressSearchContainer';
+import useAddressCoordinate from '../map/hooks/useAddressCoordinate';
+import TextInput from '../../common/components/textInput/TextInput';
+import { ApplicationGeometry } from '../application/types/application';
+import useForceUpdate from '../../common/hooks/useForceUpdate';
+import { getAreaDefaultName } from '../application/utils';
 
-function useFeatures(
-  vectorSource: VectorSource,
-  collection: GeometryCollection | Feature[] | null
-) {
-  const [features, setFeatures] = useState<Feature[]>([]);
-  const featuresAdded = useRef(false);
-
-  // Add features to vector source if they have not been added yet
-  useEffect(() => {
-    if (!featuresAdded.current && collection !== null) {
-      let featuresToAdd = null;
-
-      if (collection instanceof GeometryCollection) {
-        featuresToAdd = collection.getGeometries().map((geom) => new Feature(geom));
-      } else {
-        featuresToAdd = collection;
-      }
-
-      featuresToAdd.map((feature) => {
-        if (!feature.getId()) {
-          feature.setId(uniqueId());
-        }
-        return feature;
-      });
-
-      if (featuresToAdd.length > 0) {
-        vectorSource.addFeatures(featuresToAdd);
-        setFeatures(featuresToAdd);
-      }
-
-      featuresAdded.current = true;
-    }
-  }, [features.length, vectorSource, collection]);
-
-  // Update features array when features in vector source change
-  useEffect(() => {
-    const onDrawChange = debounce((event: VectorSourceEvent<Geometry>) => {
-      const featuresInSource = vectorSource.getFeatures();
-
-      const { feature } = event;
-      if (!feature.getId()) {
-        feature.setId(uniqueId());
-      }
-
-      setFeatures(featuresInSource);
-    }, 100);
-
-    vectorSource.on('addfeature', onDrawChange);
-    vectorSource.on('changefeature', onDrawChange);
-    vectorSource.on('removefeature', onDrawChange);
-
-    return function cleanup() {
-      onDrawChange.cancel();
-      vectorSource.un('addfeature', onDrawChange);
-      vectorSource.un('changefeature', onDrawChange);
-      vectorSource.un('removefeature', onDrawChange);
-    };
-  }, [vectorSource]);
-
-  return sortBy(features, (feature) => feature.getId());
+function getEmptyArea(feature: Feature<Geometry>): JohtoselvitysArea {
+  return {
+    name: '',
+    geometry: new ApplicationGeometry((feature.getGeometry() as Polygon).getCoordinates()),
+    feature,
+  };
 }
-
-export const initialValues = {
-  geometriat: null,
-};
 
 export const Geometries: React.FC = () => {
   const { t } = useTranslation();
   const locale = useLocale();
-  const { setValue, watch, getValues } = useFormContext<JohtoselvitysFormValues>();
-  const [drawSource] = useState<VectorSource>(new VectorSource());
+  const { watch, getValues } = useFormContext<JohtoselvitysFormValues>();
 
-  const features = useFeatures(
-    drawSource,
-    new GeoJSON().readGeometry(getValues('applicationData.geometry')) as GeometryCollection
+  const { fields: applicationAreas, append, remove } = useFieldArray<
+    JohtoselvitysFormValues,
+    'applicationData.areas'
+  >({
+    name: 'applicationData.areas',
+  });
+
+  const [drawSource] = useState<VectorSource>(() => {
+    const features = applicationAreas.flatMap((area) => (area.feature ? area.feature : []));
+    return new VectorSource({ features });
+  });
+
+  const forceUpdate = useForceUpdate();
+
+  const addressCoordinate = useAddressCoordinate(
+    getValues('applicationData.postalAddress.streetAddress.streetName')
   );
 
-  const { tabRefs } = useSelectableTabs(features.length, { selectLastTabOnChange: true });
+  useEffect(() => {
+    function handleAddFeature(e: VectorSourceEvent<Geometry>) {
+      append(getEmptyArea(e.feature));
+    }
+
+    const handleChangeFeature = debounce(() => {
+      forceUpdate();
+    }, 100);
+
+    drawSource.on('addfeature', handleAddFeature);
+    drawSource.on('changefeature', handleChangeFeature);
+
+    return function cleanup() {
+      drawSource.un('addfeature', handleAddFeature);
+      drawSource.un('changefeature', handleChangeFeature);
+    };
+  }, [drawSource, append, forceUpdate]);
+
+  const { tabRefs } = useSelectableTabs(applicationAreas.length, { selectLastTabOnChange: true });
 
   const higlightArea = useHighlightArea();
 
@@ -114,13 +91,12 @@ export const Geometries: React.FC = () => {
 
   const workTimesSet = startTime && endTime;
 
-  useEffect(() => {
-    // Update geometry collection to form state
-    const hankeGeometries: HaitatonGeometry = formatFeaturesToAlluGeoJSON(
-      features
-    ) as HaitatonGeometry;
-    setValue('applicationData.geometry', hankeGeometries);
-  }, [features, setValue]);
+  function removeArea(index: number, areaFeature?: Feature<Geometry>) {
+    remove(index);
+    if (areaFeature) {
+      drawSource.removeFeature(areaFeature);
+    }
+  }
 
   return (
     <div>
@@ -155,8 +131,10 @@ export const Geometries: React.FC = () => {
       </ResponsiveGrid>
 
       <div className={styles.mapContainer}>
-        <Map zoom={9} mapClassName={styles.mapContainer__inner}>
+        <Map zoom={9} center={addressCoordinate} mapClassName={styles.mapContainer__inner}>
           <Kantakartta />
+
+          <AddressSearchContainer position={{ top: '1rem', left: '1rem' }} zIndex={101} />
 
           <VectorLayer source={drawSource} zIndex={100} className="drawLayer" />
 
@@ -176,29 +154,39 @@ export const Geometries: React.FC = () => {
 
       <Tabs>
         <TabList>
-          {features.map((feature, index) => {
-            const geometry = feature.getGeometry();
+          {applicationAreas.map((area, index) => {
+            const geometry = area.feature?.getGeometry();
             const surfaceArea = geometry && `(${formatSurfaceArea(geometry)})`;
+            const name = watch(`applicationData.areas.${index}.name`);
+            // Make sure that area name user entered is max 30 characters
+            // If name is empty, use the default area name
+            const areaName = name.slice(0, 30) || getAreaDefaultName(t, index);
             return (
-              <Tab key={feature.getId()} onClick={() => higlightArea(feature)}>
+              <Tab key={area.id} onClick={() => higlightArea(area.feature)}>
                 <div ref={tabRefs[index]}>
-                  {t('hakemus:labels:workArea')} {index > 0 && index + 1} {surfaceArea}
+                  {areaName}&nbsp;{surfaceArea}
                 </div>
               </Tab>
             );
           })}
         </TabList>
-        {features.map((feature) => (
-          <TabPanel key={feature.getId()}>
+        {applicationAreas.map((area, index) => (
+          <TabPanel key={area.id}>
             <Fieldset
               heading={t('hakemus:labels:areaInfo')}
               border
               className={styles.areaInfoContainer}
             >
+              <TextInput
+                name={`applicationData.areas.${index}.name`}
+                label={t('form:labels:areaName')}
+                helperText={t('form:helperTexts:areaName')}
+                className={styles.nameInput}
+              />
               <Button
                 variant="supplementary"
                 iconLeft={<IconTrash aria-hidden="true" />}
-                onClick={() => drawSource.removeFeature(feature)}
+                onClick={() => removeArea(index, area.feature)}
               >
                 {t('hankeForm:hankkeenAlueForm:removeAreaButton')}
               </Button>

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -20,7 +20,7 @@ import { ReviewAndSend } from './ReviewAndSend';
 import MultipageForm from '../forms/MultipageForm';
 import FormActions from '../forms/components/FormActions';
 import { validationSchema } from './validationSchema';
-import { findOrdererKey } from './utils';
+import { convertFormStateToApplicationData, findOrdererKey } from './utils';
 import { changeFormStep } from '../forms/utils';
 import { saveApplication, sendApplication } from '../application/utils';
 import { HankeContacts, HankeData } from '../types/hanke';
@@ -68,16 +68,7 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hanke }) => {
           },
         ],
       },
-      geometry: {
-        type: 'GeometryCollection',
-        crs: {
-          type: 'name',
-          properties: {
-            name: 'EPSG:3879',
-          },
-        },
-        geometries: [],
-      },
+      areas: [],
       startTime: null,
       endTime: null,
       identificationNumber: 'HAI-123', // TODO: HAI-1160
@@ -164,7 +155,8 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hanke }) => {
   });
 
   async function saveCableApplication() {
-    return applicationSaveMutation.mutateAsync(getValues());
+    const data = convertFormStateToApplicationData(getValues());
+    return applicationSaveMutation.mutateAsync(data);
   }
 
   async function sendCableApplication() {

--- a/src/domain/johtoselvitys/components/AreaSummary.tsx
+++ b/src/domain/johtoselvitys/components/AreaSummary.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import GeoJSON from 'ol/format/GeoJSON';
-import GeometryCollection from 'ol/geom/GeometryCollection';
 import Geometry from 'ol/geom/Geometry';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@chakra-ui/react';
@@ -11,20 +9,10 @@ import {
 } from '../../forms/components/FormSummarySection';
 import { JohtoselvitysFormValues } from '../types';
 import Text from '../../../common/components/text/Text';
-import { formatSurfaceArea } from '../../map/utils';
+import { formatSurfaceArea, getTotalSurfaceArea } from '../../map/utils';
 import { formatToFinnishDate } from '../../../common/utils/date';
-import { getSurfaceArea } from '../../../common/components/map/utils';
-
-function getTotalSurfaceArea(geometries: Geometry[]) {
-  try {
-    const totalSurfaceArea = geometries.reduce((totalArea, geom) => {
-      return totalArea + Math.round(getSurfaceArea(geom));
-    }, 0);
-    return totalSurfaceArea;
-  } catch (error) {
-    return 0;
-  }
-}
+import { getAreaGeometries, getAreaGeometry } from '../utils';
+import { getAreaDefaultName } from '../../application/utils';
 
 type Props = {
   formData: JohtoselvitysFormValues;
@@ -33,10 +21,9 @@ type Props = {
 const AreaSummary: React.FC<Props> = ({ formData }) => {
   const { t } = useTranslation();
 
-  const { startTime, endTime, geometry } = formData.applicationData;
+  const { startTime, endTime, areas } = formData.applicationData;
 
-  const geometryCollection = new GeoJSON().readGeometry(geometry) as GeometryCollection;
-  const geometries = geometryCollection.getGeometries();
+  const geometries: Geometry[] = getAreaGeometries(areas);
   const totalSurfaceArea = getTotalSurfaceArea(geometries);
 
   return (
@@ -53,14 +40,13 @@ const AreaSummary: React.FC<Props> = ({ formData }) => {
       </SectionItemContent>
       <SectionItemTitle>{t('hankeForm:hankkeenAlueForm:header')}</SectionItemTitle>
       <SectionItemContent>
-        {geometries.map((geom, index) => {
+        {areas.map((area, index) => {
+          const geom = getAreaGeometry(area);
           return (
             // eslint-disable-next-line react/no-array-index-key
             <Box marginBottom="var(--spacing-m)" key={index}>
               <Text tag="p" spacingBottom="s">
-                <strong>
-                  {t('hakemus:labels:workArea')} {index > 0 && index + 1}
-                </strong>
+                <strong>{area.name || getAreaDefaultName(t, index)}</strong>
               </Text>
               <p>
                 {t('form:labels:pintaAla')}: {formatSurfaceArea(geom)}

--- a/src/domain/johtoselvitys/types.ts
+++ b/src/domain/johtoselvitys/types.ts
@@ -1,5 +1,15 @@
-import { Application, JohtoselvitysData } from '../application/types/application';
+import { Feature } from 'ol';
+import Geometry from 'ol/geom/Geometry';
+import { Application, ApplicationArea, JohtoselvitysData } from '../application/types/application';
+
+export interface JohtoselvitysArea extends ApplicationArea {
+  feature?: Feature<Geometry>;
+}
+
+export interface JohtoselvitysFormData extends JohtoselvitysData {
+  areas: JohtoselvitysArea[];
+}
 
 export interface JohtoselvitysFormValues extends Application {
-  applicationData: JohtoselvitysData;
+  applicationData: JohtoselvitysFormData;
 }

--- a/src/domain/johtoselvitys/utils.ts
+++ b/src/domain/johtoselvitys/utils.ts
@@ -1,9 +1,15 @@
-import { findKey } from 'lodash';
+import { cloneDeep, findKey } from 'lodash';
+import Geometry from 'ol/geom/Geometry';
+import Polygon from 'ol/geom/Polygon';
 import {
+  Application,
+  ApplicationArea,
+  ApplicationGeometry,
   CustomerType,
   isCustomerWithContacts,
   JohtoselvitysData,
 } from '../application/types/application';
+import { JohtoselvitysArea, JohtoselvitysFormValues } from './types';
 
 /**
  * Find the contact key that has orderer field true
@@ -17,4 +23,44 @@ export function findOrdererKey(data: JohtoselvitysData): CustomerType {
   });
 
   return ordererRole as CustomerType;
+}
+
+export function getAreaGeometry(area: JohtoselvitysArea): Geometry {
+  if (area.feature) {
+    const featureGeometry = area.feature.getGeometry();
+    if (featureGeometry) {
+      return featureGeometry;
+    }
+  }
+  return new Polygon(area.geometry.coordinates);
+}
+
+export function getAreaGeometries(areas: JohtoselvitysArea[]) {
+  return areas.map(getAreaGeometry);
+}
+
+/**
+ * Convert cable report application form state to application data.
+ * Make sure that each areas geometry coordinates are updated to
+ * latest OpenLayers feature coordinates.
+ */
+export function convertFormStateToApplicationData(formState: JohtoselvitysFormValues): Application {
+  const data: Application = cloneDeep(formState);
+
+  const updatedAreas: ApplicationArea[] = formState.applicationData.areas.map(
+    function mapToApplicationArea({ name, geometry, feature }): ApplicationArea {
+      const coordinates = feature
+        ? (feature.getGeometry() as Polygon).getCoordinates()
+        : geometry.coordinates;
+
+      return {
+        name,
+        geometry: new ApplicationGeometry(coordinates),
+      };
+    }
+  );
+
+  data.applicationData.areas = updatedAreas;
+
+  return data;
 }

--- a/src/domain/map/hooks/useAddressCoordinate.ts
+++ b/src/domain/map/hooks/useAddressCoordinate.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { Coordinate } from 'ol/coordinate';
+import { doAddressSearch } from '../utils';
+
+/**
+ * Get coordinate for given address
+ * @param address Address to get coordinates for
+ * @returns Coordinate for address
+ */
+function useAddressCoordinate(address?: string | null) {
+  const [addressCoordinate, setAddressCoordinate] = useState<Coordinate | undefined>();
+
+  useEffect(() => {
+    if (address) {
+      doAddressSearch(address).then(({ data }) => {
+        setAddressCoordinate(data.features[0]?.geometry.coordinates);
+      });
+    }
+  }, [address]);
+
+  return addressCoordinate;
+}
+
+export default useAddressCoordinate;

--- a/src/domain/map/utils.ts
+++ b/src/domain/map/utils.ts
@@ -154,6 +154,20 @@ export function formatSurfaceArea(geometry: Geometry | undefined) {
 }
 
 /**
+ * Calculate total surface area for array of geometries
+ */
+export function getTotalSurfaceArea(geometries: Geometry[]): number {
+  try {
+    const totalSurfaceArea = geometries.reduce((totalArea, geom) => {
+      return totalArea + Math.round(getSurfaceArea(geom));
+    }, 0);
+    return totalSurfaceArea;
+  } catch (error) {
+    return 0;
+  }
+}
+
+/**
  * Get OpenLayers Feature from Hanke geometry
  * @param geometry Hanke area geometry
  * @returns OpenLayers Feature

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -81,10 +81,12 @@
       "roleHelper": "EN:Pääasiallinen roolisi työssä",
       "fromHelsinkiProfile": "EN:Haettu Helsinki-profiilin perusteella",
       "addressInformation": "EN:Osoitetiedot",
-      "kokonaisAla": "EN:Alueiden kokonaispinta-ala"
+      "kokonaisAla": "EN:Alueiden kokonaispinta-ala",
+      "areaName": "EN:Alueen nimi"
     },
     "helperTexts": {
-      "dateInForm": "EN:Anna muodossa P.K.VVVV"
+      "dateInForm": "EN:Anna muodossa P.K.VVVV",
+      "areaName": "EN:Halutessasi voit nimetä alueen"
     },
     "requiredInstruction": "EN:Kaikki tähdellä * merkityt kentät ovat pakollisia.",
     "yhteystiedot": {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -81,10 +81,12 @@
       "roleHelper": "Pääasiallinen roolisi työssä",
       "fromHelsinkiProfile": "Haettu Helsinki-profiilin perusteella",
       "addressInformation": "Osoitetiedot",
-      "kokonaisAla": "Alueiden kokonaispinta-ala"
+      "kokonaisAla": "Alueiden kokonaispinta-ala",
+      "areaName": "Alueen nimi"
     },
     "helperTexts": {
-      "dateInForm": "Anna muodossa P.K.VVVV"
+      "dateInForm": "Anna muodossa P.K.VVVV",
+      "areaName": "Halutessasi voit nimetä alueen"
     },
     "requiredInstruction": "Kaikki tähdellä * merkityt kentät ovat pakollisia.",
     "yhteystiedot": {

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -81,10 +81,12 @@
       "roleHelper": "SV:Pääasiallinen roolisi työssä",
       "fromHelsinkiProfile": "SV:Haettu Helsinki-profiilin perusteella",
       "addressInformation": "SV:Osoitetiedot",
-      "kokonaisAla": "SV:Alueiden kokonaispinta-ala"
+      "kokonaisAla": "SV:Alueiden kokonaispinta-ala",
+      "areaName": "SV:Alueen nimi"
     },
     "helperTexts": {
-      "dateInForm": "SV:Anna muodossa P.K.VVVV"
+      "dateInForm": "SV:Anna muodossa P.K.VVVV",
+      "areaName": "SV:Halutessasi voit nimetä alueen"
     },
     "requiredInstruction": "SV:Kaikki tähdellä * merkityt kentät ovat pakollisia.",
     "yhteystiedot": {


### PR DESCRIPTION
# Description

User can name application areas and the name is displayed as that areas tab name. Name can be maximum 30 characters long and if it is longer than that it will be shortened to 30. If no name is given, a default name will be used.

geometry field in applicationData is changed to areas field which contains a list of areas. Each area has a name and geometry fields.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1455

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Draw area in cable report application areas page and enter a name for it in the text input. Tab name should be changed to that name.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
