### PR TITLE
HAI-1351 Fix title and subtitle for logged in users

### DIFF
--- a/src/domain/homepage/HomepageComponent.tsx
+++ b/src/domain/homepage/HomepageComponent.tsx
@@ -70,6 +70,8 @@ const Homepage: React.FC = () => {
 
   const links = isAuthenticated ? loggedInLinks : loggedOutLinks;
 
+  const pageTitle = isAuthenticated ? t('homepage:pageTitle_loggedIn') : t('homepage:pageTitle');
+
   const pageSubtitle = isAuthenticated
     ? t('homepage:pageSubTitle_loggedIn')
     : t('homepage:pageSubTitle');
@@ -86,7 +88,7 @@ const Homepage: React.FC = () => {
             id={SKIP_TO_ELEMENT_ID}
             tabIndex={-1}
           >
-            {t('homepage:pageTitle')}
+            {pageTitle}
           </Text>
           <Text tag="h2" styleAs="h3" spacing="s" weight="bold">
             {pageSubtitle}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -548,8 +548,9 @@
   },
   "homepage": {
     "pageTitle": "Welcome to the Haitaton service",
-    "pageSubTitle_loggedIn": "Service for the promotion of projects and management of nuisances in public areas",
-    "pageSubTitle": "Service for monitoring projects and their negative impacts in public areas ",
+    "pageTitle_loggedIn": "EN:Tervetuloa Haitaton-asiointiin",
+    "pageSubTitle_loggedIn": "EN:Asiointijärjestelmä yleisille alueille sijoittuvien hankkeiden edistämiseen ja haittojen hallintaan",
+    "pageSubTitle": "Service for monitoring projects and their negative impacts in public areas",
     "info": "In the Haitaton service, you can learn about and give feedback on all ongoing and upcoming projects in public areas. You can view projects on a map or in a list. Are you starting a project or submitting applications?",
     "info_link": "Go to the Haitaton service",
     "hanke": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -548,8 +548,6 @@
   },
   "homepage": {
     "pageTitle": "Welcome to the Haitaton service",
-    "pageTitle_loggedIn": "EN:Tervetuloa Haitaton-asiointiin",
-    "pageSubTitle_loggedIn": "EN:Asiointijärjestelmä yleisille alueille sijoittuvien hankkeiden edistämiseen ja haittojen hallintaan",
     "pageSubTitle": "Service for monitoring projects and their negative impacts in public areas",
     "info": "In the Haitaton service, you can learn about and give feedback on all ongoing and upcoming projects in public areas. You can view projects on a map or in a list. Are you starting a project or submitting applications?",
     "info_link": "Go to the Haitaton service",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -548,8 +548,9 @@
   },
   "homepage": {
     "pageTitle": "Tervetuloa Haitaton-palveluun",
-    "pageSubTitle_loggedIn": "Palvelu yleisille alueille sijoittuvien hankkeiden edistämiseen ja haittojen hallintaan",
-    "pageSubTitle": "Palvelu yleisille alueille sijoittuvien hankkeiden ja niiden haittojen seurantaan ",
+    "pageTitle_loggedIn": "Tervetuloa Haitaton-asiointiin",
+    "pageSubTitle_loggedIn": "Asiointijärjestelmä yleisille alueille sijoittuvien hankkeiden edistämiseen ja haittojen hallintaan",
+    "pageSubTitle": "Palvelu yleisille alueille sijoittuvien hankkeiden ja niiden haittojen seurantaan",
     "info": "Haitaton-palvelussa pääset tutustumaan kaikkiin yleisillä alueilla käynnissä oleviin ja tuleviin hankkeisiin sekä antamaan niille palautetta. Voit tarkastella hankkeita kartalla tai listalla. Oletko perustamassa hanketta tai tekemässä hakemuksia?",
     "info_link": "Siirry Haitaton-asiointiin",
     "hanke": {

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -548,8 +548,9 @@
   },
   "homepage": {
     "pageTitle": "Välkommen till tjänsten Haitaton",
-    "pageSubTitle_loggedIn": "En tjänst för främjande av projekt på allmänna områden och för hantering av olägenheterna",
-    "pageSubTitle": "En tjänst för uppföljning av projekt på allmänna områden och uppföljning av deras olägenheter ",
+    "pageTitle_loggedIn": "SV:Tervetuloa Haitaton-asiointiin",
+    "pageSubTitle_loggedIn": "SV:Asiointijärjestelmä yleisille alueille sijoittuvien hankkeiden edistämiseen ja haittojen hallintaan",
+    "pageSubTitle": "En tjänst för uppföljning av projekt på allmänna områden och uppföljning av deras olägenheter",
     "info": "I tjänsten Haitaton kan du bekanta dig med alla pågående och kommande projekt på allmänna områden samt ge respons på dem. Du kan granska projekt på kartan eller i en lista. Ska du starta ett projekt eller lämna ansökningar?",
     "info_link": "Gå till ärendehantering i Haitaton",
     "hanke": {

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -548,8 +548,6 @@
   },
   "homepage": {
     "pageTitle": "Välkommen till tjänsten Haitaton",
-    "pageTitle_loggedIn": "SV:Tervetuloa Haitaton-asiointiin",
-    "pageSubTitle_loggedIn": "SV:Asiointijärjestelmä yleisille alueille sijoittuvien hankkeiden edistämiseen ja haittojen hallintaan",
     "pageSubTitle": "En tjänst för uppföljning av projekt på allmänna områden och uppföljning av deras olägenheter",
     "info": "I tjänsten Haitaton kan du bekanta dig med alla pågående och kommande projekt på allmänna områden samt ge respons på dem. Du kan granska projekt på kartan eller i en lista. Ska du starta ett projekt eller lämna ansökningar?",
     "info_link": "Gå till ärendehantering i Haitaton",


### PR DESCRIPTION
# Description

Add a welcome text for logged in users. The title of the software should be different depending on whether the is logged in or not, though I don't know why.

The difference is whether Haitaton is called 'palvelu' or 'asiointi'/'asiointijärjestelmä'.

The new titles should match the ones in Figma.

### Jira Issue:

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Other

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: