### PR TITLE
HAI-1456 User can cancel new application

### DIFF
--- a/src/common/components/app/App.tsx
+++ b/src/common/components/app/App.tsx
@@ -7,6 +7,8 @@ import AppRoutes from '../../routes/AppRoutes';
 import Layout from './Layout';
 import { store } from '../../redux/store';
 import theme from './theme';
+import { GlobalNotificationProvider } from '../globalNotification/GlobalNotificationContext';
+import GlobalNotification from '../globalNotification/GlobalNotification';
 import './app.scss';
 import '../../../assets/styles/reset.css';
 
@@ -24,7 +26,10 @@ const App: React.FC = () => (
       <QueryClientProvider client={queryClient}>
         <ChakraProvider theme={theme}>
           <Layout>
-            <AppRoutes />
+            <GlobalNotificationProvider>
+              <AppRoutes />
+              <GlobalNotification />
+            </GlobalNotificationProvider>
           </Layout>
         </ChakraProvider>
       </QueryClientProvider>

--- a/src/common/components/globalNotification/GlobalNotification.tsx
+++ b/src/common/components/globalNotification/GlobalNotification.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Notification } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { useGlobalNotification } from './GlobalNotificationContext';
+
+export default function GlobalNotification() {
+  const { t } = useTranslation();
+  const { isOpen, options, setNotification } = useGlobalNotification();
+
+  if (!isOpen || options === undefined) {
+    return null;
+  }
+
+  const {
+    message,
+    position,
+    dismissible,
+    displayAutoCloseProgress,
+    autoClose,
+    autoCloseDuration,
+    label,
+    type,
+    closeButtonLabelText,
+  } = options;
+
+  const defaultCloseButtonLabelText = t('common:components:notification:closeButtonLabelText');
+
+  function closeNotification() {
+    setNotification(false);
+  }
+
+  return (
+    <Notification
+      position={position || 'top-right'}
+      dismissible={dismissible}
+      displayAutoCloseProgress={displayAutoCloseProgress}
+      autoClose={autoClose}
+      autoCloseDuration={autoCloseDuration}
+      label={label}
+      type={type}
+      closeButtonLabelText={closeButtonLabelText || defaultCloseButtonLabelText}
+      onClose={closeNotification}
+    >
+      {message}
+    </Notification>
+  );
+}

--- a/src/common/components/globalNotification/GlobalNotificationContext.tsx
+++ b/src/common/components/globalNotification/GlobalNotificationContext.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, ReactNode, useContext, useState } from 'react';
+import { NotificationProps } from 'hds-react';
+
+type GlobalNotificationProviderProps = {
+  children: ReactNode;
+};
+
+type NotificationOptions = NotificationProps & {
+  message: string;
+};
+
+type NotificationContextProps = {
+  isOpen: boolean;
+  options?: NotificationOptions;
+  setNotification: (open: boolean, options?: NotificationOptions) => void;
+};
+
+const GlobalNotificationContext = createContext<NotificationContextProps | undefined>(undefined);
+
+export function GlobalNotificationProvider({ children }: GlobalNotificationProviderProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [notificationOptions, setNotificationOptions] = useState<NotificationOptions | undefined>(
+    undefined
+  );
+
+  function setNotification(open: boolean, options?: NotificationOptions) {
+    setIsOpen(open);
+    setNotificationOptions(options);
+  }
+
+  const value = {
+    isOpen,
+    options: notificationOptions,
+    setNotification,
+  };
+
+  return (
+    <GlobalNotificationContext.Provider value={value}>
+      {children}
+    </GlobalNotificationContext.Provider>
+  );
+}
+
+export function useGlobalNotification() {
+  const context = useContext(GlobalNotificationContext);
+
+  if (context === undefined) {
+    throw new Error('useGlobalNotification must be used within a GlobalNotificationProvider');
+  }
+
+  return context;
+}

--- a/src/domain/application/components/ApplicationCancel.test.tsx
+++ b/src/domain/application/components/ApplicationCancel.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../../../testUtils/render';
+import { ApplicationCancel } from './ApplicationCancel';
+import GlobalNotification from '../../../common/components/globalNotification/GlobalNotification';
+import mockApplications from '../../mocks/data/hakemukset-data';
+
+test('Cancel application when it has not been saved', async () => {
+  const user = userEvent.setup();
+
+  render(
+    <>
+      <GlobalNotification />
+      <ApplicationCancel applicationId={null} alluStatus={null} hankeTunnus="HAI22-2" />
+    </>
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
+
+  // Click cancel button in the confirmation dialog
+  await user.click(screen.getAllByRole('button', { name: 'Peru hakemus' })[1]);
+
+  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2');
+  expect(screen.queryByText('Hakemus peruttiin onnistuneesti')).toBeInTheDocument();
+});
+
+test('Cancel application when it has been saved, but not sent to Allu', async () => {
+  const user = userEvent.setup();
+
+  const application = mockApplications[0];
+
+  render(
+    <>
+      <GlobalNotification />
+      <ApplicationCancel
+        applicationId={application.id}
+        alluStatus={application.alluStatus}
+        hankeTunnus="HAI22-2"
+      />
+    </>
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
+
+  // Click cancel button in the confirmation dialog
+  await user.click(screen.getAllByRole('button', { name: 'Peru hakemus' })[1]);
+
+  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2');
+  expect(screen.queryByText('Hakemus peruttiin onnistuneesti')).toBeInTheDocument();
+});
+
+test('Cancel application when it has been saved and sent to Allu but is still pending', async () => {
+  const user = userEvent.setup();
+
+  const application = mockApplications[1];
+
+  render(
+    <>
+      <GlobalNotification />
+      <ApplicationCancel
+        applicationId={application.id}
+        alluStatus={application.alluStatus}
+        hankeTunnus="HAI22-2"
+      />
+    </>
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
+
+  // Click cancel button in the confirmation dialog
+  await user.click(screen.getAllByRole('button', { name: 'Peru hakemus' })[1]);
+
+  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2');
+  expect(screen.queryByText('Hakemus peruttiin onnistuneesti')).toBeInTheDocument();
+});
+
+test('Canceling application is not possible when it in handling in Allu', () => {
+  const application = mockApplications[2];
+
+  render(
+    <ApplicationCancel
+      applicationId={application.id}
+      alluStatus={application.alluStatus}
+      hankeTunnus="HAI22-2"
+    />
+  );
+
+  expect(screen.queryByRole('button', { name: 'Peru hakemus' })).not.toBeInTheDocument();
+});

--- a/src/domain/application/components/ApplicationCancel.tsx
+++ b/src/domain/application/components/ApplicationCancel.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import { useMutation } from 'react-query';
+import { Button, IconCross } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { AxiosError } from 'axios';
+import { AlluStatusStrings } from '../types/application';
+import { canApplicationBeCancelled, cancelApplication } from '../utils';
+import ConfirmationDialog from '../../../common/components/HDSConfirmationDialog/ConfirmationDialog';
+import useLinkPath from '../../../common/hooks/useLinkPath';
+import { ROUTES } from '../../../common/types/route';
+import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
+
+type Props = {
+  applicationId: number | null;
+  alluStatus: AlluStatusStrings | null;
+  hankeTunnus: string;
+};
+
+export const ApplicationCancel: React.FC<Props> = ({ applicationId, alluStatus, hankeTunnus }) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const getHankeViewPath = useLinkPath(ROUTES.HANKE);
+  const viewHankePath = getHankeViewPath({ hankeTunnus });
+
+  const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const isCancelPossible = canApplicationBeCancelled(alluStatus);
+
+  const { setNotification } = useGlobalNotification();
+
+  const applicationCancelMutation = useMutation(cancelApplication, {
+    onError(error: AxiosError) {
+      let message = t('common:error');
+      if (error.response?.status === 409) {
+        message = t('hakemus:errors:cancelConflict');
+      }
+      setErrorMessage(message);
+    },
+    onSuccess() {
+      const closeButtonLabelText = t('common:components:notification:closeButtonLabelText');
+      setNotification(true, {
+        label: t('hakemus:notifications:cancelSuccessLabel'),
+        message: t('hakemus:notifications:cancelSuccessText'),
+        type: 'success',
+        dismissible: true,
+        closeButtonLabelText,
+        autoClose: true,
+        autoCloseDuration: 7000,
+      });
+      // Navigate to hanke view with application list tab initially open
+      navigate(viewHankePath, { state: { initiallyActiveTab: 4 } });
+    },
+  });
+
+  function doApplicationCancel() {
+    applicationCancelMutation.mutate(applicationId);
+  }
+
+  function openConfirmationDialog() {
+    setIsConfirmationDialogOpen(true);
+  }
+
+  function closeConfirmationDialog() {
+    setErrorMessage('');
+    setIsConfirmationDialogOpen(false);
+  }
+
+  if (!isCancelPossible) {
+    return null;
+  }
+
+  return (
+    <>
+      <ConfirmationDialog
+        title={t('hakemus:labels:cancelTitle')}
+        description={t('hakemus:labels:cancelDescription')}
+        isOpen={isConfirmationDialogOpen}
+        close={closeConfirmationDialog}
+        mainAction={doApplicationCancel}
+        mainBtnLabel={t('hakemus:buttons:cancelApplication')}
+        variant="danger"
+        errorMsg={errorMessage}
+      />
+
+      <Button
+        variant="secondary"
+        iconLeft={<IconCross aria-hidden />}
+        onClick={openConfirmationDialog}
+      >
+        {t('hakemus:buttons:cancelApplication')}
+      </Button>
+    </>
+  );
+};

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -49,6 +49,30 @@ export type CustomerWithContacts = {
   contacts: Contact[];
 };
 
+export enum AlluStatus {
+  PRE_RESERVED = 'PRE_RESERVED',
+  NOTE = 'NOTE',
+  PENDING_CLIENT = 'PENDING_CLIENT',
+  PENDING = 'PENDING',
+  WAITING_INFORMATION = 'WAITING_INFORMATION',
+  INFORMATION_RECEIVED = 'INFORMATION_RECEIVED',
+  HANDLING = 'HANDLING',
+  RETURNED_TO_PREPARATION = 'RETURNED_TO_PREPARATION',
+  WAITING_CONTRACT_APPROVAL = 'WAITING_CONTRACT_APPROVAL',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+  DECISIONMAKING = 'DECISIONMAKING',
+  DECISION = 'DECISION',
+  OPERATIONAL_CONDITION = 'OPERATIONAL_CONDITION',
+  TERMINATED = 'TERMINATED',
+  FINISHED = 'FINISHED',
+  CANCELLED = 'CANCELLED',
+  ARCHIVED = 'ARCHIVED',
+  REPLACED = 'REPLACED',
+}
+
+export type AlluStatusStrings = keyof typeof AlluStatus;
+
 export type JohtoselvitysData = {
   hankeTunnus: string;
   applicationType: ApplicationType;
@@ -76,6 +100,7 @@ export type JohtoselvitysData = {
 export interface Application {
   id: number | null;
   alluid?: number | null;
+  alluStatus: AlluStatusStrings | null;
   applicationType: ApplicationType;
   applicationData: JohtoselvitysData;
 }

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -1,5 +1,5 @@
 import api from '../api/api';
-import { Application } from './types/application';
+import { AlluStatus, AlluStatusStrings, Application } from './types/application';
 
 /**
  * Save application to Haitaton backend
@@ -17,5 +17,23 @@ export async function saveApplication(data: Application) {
  */
 export async function sendApplication(applicationId: number) {
   const response = await api.post<Application>(`/hakemukset/${applicationId}/send-application`, {});
+  return response.data;
+}
+
+/**
+ * Check if it is possible to cancel application
+ */
+export function canApplicationBeCancelled(alluStatus: AlluStatusStrings | null): boolean {
+  return (
+    alluStatus === null ||
+    alluStatus === AlluStatus.PENDING_CLIENT ||
+    alluStatus === AlluStatus.PENDING
+  );
+}
+
+export async function cancelApplication(applicationId: number | null) {
+  if (applicationId === null) return null;
+
+  const response = await api.delete<Application>(`/hakemukset/${applicationId}`);
   return response.data;
 }

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -15,6 +15,7 @@ import {
 } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { Flex } from '@chakra-ui/react';
+import { useLocation } from 'react-router-dom';
 import Container from '../../../common/components/container/Container';
 import Text from '../../../common/components/text/Text';
 import { HankeAlue, HankeData, HankeIndexData } from '../../types/hanke';
@@ -113,6 +114,14 @@ type Props = {
 
 const HankeView: React.FC<Props> = ({ hankeData, onEditHanke, onDeleteHanke }) => {
   const { t } = useTranslation();
+  const location = useLocation();
+
+  // Get initially active tab from location state if there is such defined
+  const initiallyActiveTab: number | undefined =
+    location.state !== null
+      ? (location.state as { initiallyActiveTab: number | undefined }).initiallyActiveTab
+      : undefined;
+
   const [showAddApplicationDialog, setShowAddApplicationDialog] = useState(false);
 
   function addApplication() {
@@ -204,7 +213,7 @@ const HankeView: React.FC<Props> = ({ hankeData, onEditHanke, onDeleteHanke }) =
               <HankeDraftStateNotification hanke={hankeData} />
             </div>
 
-            <Tabs>
+            <Tabs initiallyActiveTab={initiallyActiveTab}>
               <TabList className={styles.tabList}>
                 <Tab>{t('hankePortfolio:tabit:perustiedot')}</Tab>
                 <Tab>{t('hankePortfolio:tabit:alueet')}</Tab>

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -1,12 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Button,
-  IconCross,
-  IconEnvelope,
-  IconSaveDiskette,
-  Notification,
-  StepState,
-} from 'hds-react';
+import { Button, IconEnvelope, IconSaveDiskette, Notification, StepState } from 'hds-react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -24,6 +17,7 @@ import { findOrdererKey } from './utils';
 import { changeFormStep } from '../forms/utils';
 import { saveApplication, sendApplication } from '../application/utils';
 import { HankeContacts, HankeData } from '../types/hanke';
+import { ApplicationCancel } from '../application/components/ApplicationCancel';
 
 type Props = {
   hanke: HankeData;
@@ -34,6 +28,7 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hanke }) => {
 
   const initialValues: JohtoselvitysFormValues = {
     id: null,
+    alluStatus: null,
     applicationType: 'CABLE_REPORT',
     applicationData: {
       hankeTunnus: hanke.hankeTunnus,
@@ -145,9 +140,8 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hanke }) => {
       setShowSaveNotification(false);
     },
     onSuccess(data) {
-      if (!getValues().id) {
-        setValue('id', data.id);
-      }
+      setValue('id', data.id);
+      setValue('alluStatus', data.alluStatus);
     },
     onSettled() {
       setShowSaveNotification(true);
@@ -301,9 +295,11 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hanke }) => {
               onPrevious={handlePrevious}
               onNext={handleNextPage}
             >
-              <Button variant="secondary" iconLeft={<IconCross aria-hidden />}>
-                {t('hankeForm:cancelButton')}
-              </Button>
+              <ApplicationCancel
+                applicationId={getValues('id')}
+                alluStatus={getValues('alluStatus')}
+                hankeTunnus={hanke.hankeTunnus}
+              />
 
               <Button
                 variant="secondary"

--- a/src/domain/mocks/apiError.ts
+++ b/src/domain/mocks/apiError.ts
@@ -1,0 +1,8 @@
+export default class ApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -1,0 +1,297 @@
+import { Application, AlluStatus } from '../../application/types/application';
+
+const hakemukset: Application[] = [
+  {
+    id: 1,
+    alluStatus: null,
+    applicationType: 'CABLE_REPORT',
+    applicationData: {
+      hankeTunnus: 'HAI22-2',
+      applicationType: 'CABLE_REPORT',
+      name: 'Mannerheimintien kaivuut',
+      customerWithContacts: {
+        customer: {
+          type: 'COMPANY',
+          name: 'Yritys Oy',
+          country: 'FI',
+          postalAddress: {
+            streetAddress: {
+              streetName: '',
+            },
+            postalCode: '',
+            city: '',
+          },
+          email: 'yritys@test.com',
+          phone: '0000000000',
+          registryKey: '',
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            email: 'matti@test.com',
+            name: 'Matti Meikäläinen',
+            orderer: true,
+            phone: '0000000000',
+            postalAddress: { city: '', postalCode: '', streetAddress: { streetName: '' } },
+          },
+        ],
+      },
+      geometry: {
+        type: 'GeometryCollection',
+        crs: {
+          type: 'name',
+          properties: {
+            name: 'EPSG:3879',
+          },
+        },
+        geometries: [],
+      },
+      startTime: null,
+      endTime: null,
+      identificationNumber: 'HAI-123',
+      clientApplicationKind: 'HAITATON',
+      workDescription: '',
+      contractorWithContacts: {
+        customer: {
+          type: null,
+          name: '',
+          country: 'FI',
+          postalAddress: {
+            streetAddress: {
+              streetName: '',
+            },
+            postalCode: '',
+            city: '',
+          },
+          email: '',
+          phone: '',
+          registryKey: '',
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            email: '',
+            name: '',
+            orderer: false,
+            phone: '',
+            postalAddress: { city: '', postalCode: '', streetAddress: { streetName: '' } },
+          },
+        ],
+      },
+      postalAddress: {
+        city: 'Helsinki',
+        postalCode: '00100',
+        streetAddress: { streetName: 'Mannerheimintie 5' },
+      },
+      representativeWithContacts: null,
+      invoicingCustomer: null,
+      customerReference: null,
+      area: null,
+      propertyDeveloperWithContacts: null,
+      constructionWork: false,
+      maintenanceWork: false,
+      emergencyWork: false,
+      propertyConnectivity: false,
+    },
+  },
+  {
+    id: 2,
+    alluStatus: AlluStatus.PENDING,
+    applicationType: 'CABLE_REPORT',
+    applicationData: {
+      hankeTunnus: 'HAI22-2',
+      applicationType: 'CABLE_REPORT',
+      name: 'Mannerheimintien kuopat',
+      customerWithContacts: {
+        customer: {
+          type: 'COMPANY',
+          name: 'Yritys Oy',
+          country: 'FI',
+          postalAddress: {
+            streetAddress: {
+              streetName: '',
+            },
+            postalCode: '',
+            city: '',
+          },
+          email: 'yritys@test.com',
+          phone: '0000000000',
+          registryKey: '',
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            email: 'matti@test.com',
+            name: 'Matti Meikäläinen',
+            orderer: true,
+            phone: '0000000000',
+            postalAddress: { city: '', postalCode: '', streetAddress: { streetName: '' } },
+          },
+        ],
+      },
+      geometry: {
+        type: 'GeometryCollection',
+        crs: {
+          type: 'name',
+          properties: {
+            name: 'EPSG:3879',
+          },
+        },
+        geometries: [],
+      },
+      startTime: '2023-07-13T21:59:59.999Z',
+      endTime: '2023-09-31T21:59:59.999Z',
+      identificationNumber: 'HAI-123',
+      clientApplicationKind: 'HAITATON',
+      workDescription: 'Kaivetaan kuoppia Mannerheimintiellä',
+      contractorWithContacts: {
+        customer: {
+          type: 'COMPANY',
+          name: 'Yritys 2 Oy',
+          country: 'FI',
+          postalAddress: {
+            streetAddress: {
+              streetName: '',
+            },
+            postalCode: '',
+            city: '',
+          },
+          email: 'yritys2@test.com',
+          phone: '0000000000',
+          registryKey: '',
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            email: 'matti@test.com',
+            name: 'Matti Meikäläinen',
+            orderer: true,
+            phone: '0000000000',
+            postalAddress: { city: '', postalCode: '', streetAddress: { streetName: '' } },
+          },
+        ],
+      },
+      postalAddress: {
+        city: 'Helsinki',
+        postalCode: '00100',
+        streetAddress: { streetName: 'Mannerheimintie 5' },
+      },
+      representativeWithContacts: null,
+      invoicingCustomer: null,
+      customerReference: null,
+      area: null,
+      propertyDeveloperWithContacts: null,
+      constructionWork: false,
+      maintenanceWork: false,
+      emergencyWork: false,
+      propertyConnectivity: false,
+    },
+  },
+  {
+    id: 3,
+    alluStatus: AlluStatus.HANDLING,
+    applicationType: 'CABLE_REPORT',
+    applicationData: {
+      hankeTunnus: 'HAI22-2',
+      applicationType: 'CABLE_REPORT',
+      name: 'Mannerheimintien kuopat',
+      customerWithContacts: {
+        customer: {
+          type: 'COMPANY',
+          name: 'Yritys Oy',
+          country: 'FI',
+          postalAddress: {
+            streetAddress: {
+              streetName: '',
+            },
+            postalCode: '',
+            city: '',
+          },
+          email: 'yritys@test.com',
+          phone: '0000000000',
+          registryKey: '',
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            email: 'matti@test.com',
+            name: 'Matti Meikäläinen',
+            orderer: true,
+            phone: '0000000000',
+            postalAddress: { city: '', postalCode: '', streetAddress: { streetName: '' } },
+          },
+        ],
+      },
+      geometry: {
+        type: 'GeometryCollection',
+        crs: {
+          type: 'name',
+          properties: {
+            name: 'EPSG:3879',
+          },
+        },
+        geometries: [],
+      },
+      startTime: '2023-07-13T21:59:59.999Z',
+      endTime: '2023-09-31T21:59:59.999Z',
+      identificationNumber: 'HAI-123',
+      clientApplicationKind: 'HAITATON',
+      workDescription: 'Kaivetaan kuoppia Mannerheimintiellä',
+      contractorWithContacts: {
+        customer: {
+          type: 'COMPANY',
+          name: 'Yritys 2 Oy',
+          country: 'FI',
+          postalAddress: {
+            streetAddress: {
+              streetName: '',
+            },
+            postalCode: '',
+            city: '',
+          },
+          email: 'yritys2@test.com',
+          phone: '0000000000',
+          registryKey: '',
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            email: 'matti@test.com',
+            name: 'Matti Meikäläinen',
+            orderer: true,
+            phone: '0000000000',
+            postalAddress: { city: '', postalCode: '', streetAddress: { streetName: '' } },
+          },
+        ],
+      },
+      postalAddress: {
+        city: 'Helsinki',
+        postalCode: '00100',
+        streetAddress: { streetName: 'Mannerheimintie 5' },
+      },
+      representativeWithContacts: null,
+      invoicingCustomer: null,
+      customerReference: null,
+      area: null,
+      propertyDeveloperWithContacts: null,
+      constructionWork: false,
+      maintenanceWork: false,
+      emergencyWork: false,
+      propertyConnectivity: false,
+    },
+  },
+];
+
+export default hakemukset;

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -1,7 +1,10 @@
 import { uniqueId } from 'lodash';
 import { Application } from '../../application/types/application';
+import hakemuksetData from './hakemukset-data';
+import { canApplicationBeCancelled } from '../../application/utils';
+import ApiError from '../apiError';
 
-const hakemukset: Application[] = [];
+let hakemukset: Application[] = [...hakemuksetData];
 
 export async function read(id: number) {
   return hakemukset.find((hakemus) => hakemus.id === id);
@@ -23,8 +26,19 @@ export async function create(data: Application) {
 export async function update(id: number, updates: Application) {
   let hakemus = await read(id);
   if (!hakemus) {
-    throw new Error(`No hakemus with id ${id}`);
+    throw new Error(`No application with id ${id}`);
   }
   hakemus = Object.assign(hakemus, updates);
   return hakemus;
+}
+
+export async function remove(id: number) {
+  const hakemusToRemove = await read(id);
+  if (!hakemusToRemove) {
+    throw new ApiError(`No application with id ${id}`, 404);
+  }
+  if (!canApplicationBeCancelled(hakemusToRemove.alluStatus)) {
+    throw new ApiError(`Application can not be cancelled`, 409);
+  }
+  hakemukset = hakemukset.filter((hakemus) => hakemus.id !== id);
 }

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -3,6 +3,7 @@ import { JohtoselvitysFormValues } from '../johtoselvitys/types';
 import { HankeDataDraft } from '../types/hanke';
 import * as hankkeetDB from './data/hankkeet';
 import * as hakemuksetDB from './data/hakemukset';
+import ApiError from './apiError';
 
 const apiUrl = '/api';
 
@@ -110,5 +111,22 @@ export const handlers = [
     }
 
     return res(ctx.status(200), ctx.json(hakemus));
+  }),
+
+  rest.delete(`${apiUrl}/hakemukset/:id`, async (req, res, ctx) => {
+    const { id } = req.params;
+    try {
+      await hakemuksetDB.remove(Number(id));
+      return res(ctx.status(200), ctx.json(null));
+    } catch (error) {
+      const { status, message } = error as ApiError;
+      return res(
+        ctx.status(status),
+        ctx.json({
+          errorMessage: message,
+          errorCode: 'HAI1001',
+        })
+      );
+    }
   }),
 ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -501,7 +501,9 @@
       "areaInfo": "Alueen tiedot",
       "checkInfo": "Tarkista antamasi tiedot ja lähetä hakemus.",
       "preFilledInfo": "Esitäytetyt tiedot",
-      "preFilledInfoHelp": "Valitse nimi hankkeen tiedoista"
+      "preFilledInfoHelp": "Valitse nimi hankkeen tiedoista",
+      "cancelTitle": "Oletko varma että haluat perua hakemuksen",
+      "cancelDescription": "Hakemuksen peruminen on pysyvä toiminto ja hakemuksen tietoja ei voi palauttaa perumisen jälkeen."
     },
     "notifications": {
       "saveSuccessLabel": "Hakemus tallennettu",
@@ -511,11 +513,17 @@
       "sendSuccessLabel": "Hakemus lähetetty",
       "sendErrorLabel": "Hakemuksen lähetys epäonnistui",
       "sendSuccessText": "Hakemuksen lähetys onnistui",
-      "sendErrorText": "Hakemusta ei voitu lähettää. Tarkista hakemuksen oikea sisältö ja että olet kirjautunut."
+      "sendErrorText": "Hakemusta ei voitu lähettää. Tarkista hakemuksen oikea sisältö ja että olet kirjautunut.",
+      "cancelSuccessLabel": "Hakemus peruttiin",
+      "cancelSuccessText": "Hakemus peruttiin onnistuneesti"
     },
     "buttons": {
       "continueToApplication": "Jatka hakemukseen",
-      "sendApplication": "Lähetä hakemus"
+      "sendApplication": "Lähetä hakemus",
+      "cancelApplication": "Peru hakemus"
+    },
+    "errors": {
+      "cancelConflict": "Hakemusta ei voida perua, koska se on edennyt käsittelyyn"
     },
     "headers": {
       "pickApplication": "Valitse luotava hakemus"

--- a/src/testUtils/render.tsx
+++ b/src/testUtils/render.tsx
@@ -6,6 +6,7 @@ import { I18nextProvider } from 'react-i18next';
 import { BrowserRouter } from 'react-router-dom';
 import i18n from '../locales/i18nForTests';
 import { store } from '../common/redux/store';
+import { GlobalNotificationProvider } from '../common/components/globalNotification/GlobalNotificationContext';
 
 const queryClient = new QueryClient();
 
@@ -17,7 +18,9 @@ const AllTheProviders = ({ children }: Props) => (
   <BrowserRouter>
     <ReduxProvider store={store}>
       <QueryClientProvider client={queryClient}>
-        <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+        <I18nextProvider i18n={i18n}>
+          <GlobalNotificationProvider>{children}</GlobalNotificationProvider>
+        </I18nextProvider>
       </QueryClientProvider>
     </ReduxProvider>
   </BrowserRouter>


### PR DESCRIPTION
# Description

Implemented functionality that user can cancel new application if it is possible, meaning it is not yet in Allu or if the status is still pending.

If cancelling is not possible, cancel button is not displayed.

After successful cancellation, user is taken in to application list and success notification is shown. If something goes wrong, error message is shown.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1456

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new cable report application and save it but don't send it to Allu: (http://localhost:3001/fi/johtoselvityshakemus?hanke=xxxxx-x for example http://localhost:3001/fi/johtoselvityshakemus?hanke=HAI23-1)
2. Click "Peru hakemus" button and confirm the cancellation in confirmation dialog
3. You should be taken to application list tab in hanke page and success notification should be shown
4. Create new application and send it to Allu
5. Repeat steps 2 and 3 and make sure that cancellation is successful

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
