### PR TITLE
HAI-1531 Fix hankeTunnus in wrong place when creating new application

### DIFF
--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -100,7 +100,6 @@ export type ApplicationArea = {
 };
 
 export type JohtoselvitysData = {
-  hankeTunnus: string;
   applicationType: ApplicationType;
   name: string;
   customerWithContacts: CustomerWithContacts;
@@ -130,6 +129,7 @@ export interface Application {
   alluStatus: AlluStatusStrings | null;
   applicationType: ApplicationType;
   applicationData: JohtoselvitysData;
+  hankeTunnus: string;
 }
 
 export function isCustomerWithContacts(value: unknown): value is CustomerWithContacts {

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -30,8 +30,8 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hanke }) => {
     id: null,
     alluStatus: null,
     applicationType: 'CABLE_REPORT',
+    hankeTunnus: hanke.hankeTunnus,
     applicationData: {
-      hankeTunnus: hanke.hankeTunnus,
       applicationType: 'CABLE_REPORT',
       name: '',
       customerWithContacts: {

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -5,8 +5,8 @@ const hakemukset: Application[] = [
     id: 1,
     alluStatus: null,
     applicationType: 'CABLE_REPORT',
+    hankeTunnus: 'HAI22-2',
     applicationData: {
-      hankeTunnus: 'HAI22-2',
       applicationType: 'CABLE_REPORT',
       name: 'Mannerheimintien kaivuut',
       customerWithContacts: {
@@ -94,8 +94,8 @@ const hakemukset: Application[] = [
     id: 2,
     alluStatus: AlluStatus.PENDING,
     applicationType: 'CABLE_REPORT',
+    hankeTunnus: 'HAI22-2',
     applicationData: {
-      hankeTunnus: 'HAI22-2',
       applicationType: 'CABLE_REPORT',
       name: 'Mannerheimintien kuopat',
       customerWithContacts: {
@@ -183,8 +183,8 @@ const hakemukset: Application[] = [
     id: 3,
     alluStatus: AlluStatus.HANDLING,
     applicationType: 'CABLE_REPORT',
+    hankeTunnus: 'HAI22-2',
     applicationData: {
-      hankeTunnus: 'HAI22-2',
       applicationType: 'CABLE_REPORT',
       name: 'Mannerheimintien kuopat',
       customerWithContacts: {


### PR DESCRIPTION
# Description

When creating new application hankeTunnus of the hanke for which the application belongs to was part of applicationData of the request body when it should be in the upper level of the body so fixed that.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1531

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
