### PR TITLE
HAI-1159 Show error message to user if saving application fails

### DIFF
--- a/src/common/components/globalNotification/GlobalNotification.tsx
+++ b/src/common/components/globalNotification/GlobalNotification.tsx
@@ -40,6 +40,7 @@ export default function GlobalNotification() {
       type={type}
       closeButtonLabelText={closeButtonLabelText || defaultCloseButtonLabelText}
       onClose={closeNotification}
+      style={{ zIndex: 100 }}
     >
       {message}
     </Notification>

--- a/src/common/components/globalNotification/GlobalNotificationContext.tsx
+++ b/src/common/components/globalNotification/GlobalNotificationContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useContext, useState } from 'react';
+import React, { createContext, ReactNode, useCallback, useContext, useState } from 'react';
 import { NotificationProps } from 'hds-react';
 
 type GlobalNotificationProviderProps = {
@@ -23,10 +23,10 @@ export function GlobalNotificationProvider({ children }: GlobalNotificationProvi
     undefined
   );
 
-  function setNotification(open: boolean, options?: NotificationOptions) {
+  const setNotification = useCallback((open: boolean, options?: NotificationOptions) => {
     setIsOpen(open);
     setNotificationOptions(options);
-  }
+  }, []);
 
   const value = {
     isOpen,

--- a/src/domain/application/components/ApplicationCancel.tsx
+++ b/src/domain/application/components/ApplicationCancel.tsx
@@ -2,14 +2,12 @@ import React, { useState } from 'react';
 import { useMutation } from 'react-query';
 import { Button, IconCross } from 'hds-react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import { AlluStatusStrings } from '../types/application';
 import { canApplicationBeCancelled, cancelApplication } from '../utils';
 import ConfirmationDialog from '../../../common/components/HDSConfirmationDialog/ConfirmationDialog';
-import useLinkPath from '../../../common/hooks/useLinkPath';
-import { ROUTES } from '../../../common/types/route';
 import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
+import useNavigateToApplicationList from '../../hanke/hooks/useNavigateToApplicationList';
 
 type Props = {
   applicationId: number | null;
@@ -19,10 +17,7 @@ type Props = {
 
 export const ApplicationCancel: React.FC<Props> = ({ applicationId, alluStatus, hankeTunnus }) => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
-
-  const getHankeViewPath = useLinkPath(ROUTES.HANKE);
-  const viewHankePath = getHankeViewPath({ hankeTunnus });
+  const navigateToApplicationList = useNavigateToApplicationList(hankeTunnus);
 
   const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -50,8 +45,7 @@ export const ApplicationCancel: React.FC<Props> = ({ applicationId, alluStatus, 
         autoClose: true,
         autoCloseDuration: 7000,
       });
-      // Navigate to hanke view with application list tab initially open
-      navigate(viewHankePath, { state: { initiallyActiveTab: 4 } });
+      navigateToApplicationList();
     },
   });
 

--- a/src/domain/application/components/ApplicationSaveNotification.tsx
+++ b/src/domain/application/components/ApplicationSaveNotification.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Link, Notification } from 'hds-react';
+import { Trans, useTranslation } from 'react-i18next';
+
+type Props = {
+  saveSuccess: boolean;
+  onClose: () => void;
+};
+
+function ApplicationSaveNotification({ saveSuccess, onClose }: Props) {
+  const { t } = useTranslation();
+
+  if (saveSuccess) {
+    return (
+      <Notification
+        position="top-right"
+        dismissible
+        autoClose
+        autoCloseDuration={5000}
+        label={t('hakemus:notifications:saveSuccessLabel')}
+        type="success"
+        closeButtonLabelText={t('common:components:notification:closeButtonLabelText')}
+        onClose={onClose}
+      >
+        {t('hakemus:notifications:saveSuccessText')}
+      </Notification>
+    );
+  }
+
+  const saveErrorText = (
+    <Trans i18nKey="hakemus:notifications:saveErrorText">
+      <p>
+        Hakemuksen tallentaminen epäonnistui. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman
+        tekniseen tukeen sähköpostiosoitteessa
+        <Link href="mailto:haitatontuki@hel.fi">haitatontuki@hel.fi</Link>.
+      </p>
+    </Trans>
+  );
+
+  return (
+    <Notification
+      position="top-right"
+      dismissible
+      label={t('hakemus:notifications:saveErrorLabel')}
+      type="error"
+      closeButtonLabelText={t('common:components:notification:closeButtonLabelText')}
+      onClose={onClose}
+    >
+      {saveErrorText}
+    </Notification>
+  );
+}
+
+export default ApplicationSaveNotification;

--- a/src/domain/hanke/hooks/useNavigateToApplicationList.ts
+++ b/src/domain/hanke/hooks/useNavigateToApplicationList.ts
@@ -1,0 +1,18 @@
+import { useNavigate } from 'react-router-dom';
+import useLinkPath from '../../../common/hooks/useLinkPath';
+import { ROUTES } from '../../../common/types/route';
+
+/**
+ * Returns a function to navigate to hanke view with application list tab initially open
+ */
+export default function useNavigateToApplicationList(hankeTunnus: string) {
+  const navigate = useNavigate();
+  const getHankeViewPath = useLinkPath(ROUTES.HANKE);
+  const hankeViewPath = getHankeViewPath({ hankeTunnus });
+
+  function navigateToApplicationList() {
+    navigate(hankeViewPath, { state: { initiallyActiveTab: 4 } });
+  }
+
+  return navigateToApplicationList;
+}

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -10,18 +10,7 @@ afterEach(cleanup);
 
 jest.setTimeout(30000);
 
-test('Cable report application form can be filled and saved and sent to Allu', async () => {
-  const user = userEvent.setup();
-
-  render(<Johtoselvitys />, undefined, '/fi/johtoselvityshakemus?hanke=HAI22-2');
-
-  await waitForLoadingToFinish();
-
-  expect(
-    screen.queryByText('Aidasmäentien vesihuollon rakentaminen (HAI22-2)')
-  ).toBeInTheDocument();
-
-  // Fill basic information page
+function fillBasicInformation() {
   fireEvent.change(screen.getByLabelText(/työn nimi/i), {
     target: { value: 'Johtoselvitys' },
   });
@@ -53,6 +42,21 @@ test('Cable report application form can be filled and saved and sent to Allu', a
   fireEvent.change(screen.getByLabelText(/puhelinnumero/i), {
     target: { value: '0000000000' },
   });
+}
+
+test('Cable report application form can be filled and saved and sent to Allu', async () => {
+  const user = userEvent.setup();
+
+  render(<Johtoselvitys />, undefined, '/fi/johtoselvityshakemus?hanke=HAI22-2');
+
+  await waitForLoadingToFinish();
+
+  expect(
+    screen.queryByText('Aidasmäentien vesihuollon rakentaminen (HAI22-2)')
+  ).toBeInTheDocument();
+
+  // Fill basic information page
+  fillBasicInformation();
 
   // Move to areas page
   await user.click(screen.getByRole('button', { name: /seuraava/i }));
@@ -147,32 +151,7 @@ test('Should show error message when saving fails', async () => {
   render(<Johtoselvitys />, undefined, '/fi/johtoselvityshakemus?hanke=HAI22-2');
 
   // Fill basic information page, so that form can be saved for the first time
-  fireEvent.change(screen.getByLabelText(/työn nimi/i), {
-    target: { value: 'Mannerheimintien johdot' },
-  });
-  fireEvent.change(screen.getAllByLabelText(/katuosoite/i)[0], {
-    target: { value: 'Mannerheimintie 50' },
-  });
-  fireEvent.change(screen.getAllByLabelText(/postinumero/i)[0], {
-    target: { value: '00100' },
-  });
-  fireEvent.change(screen.getAllByLabelText(/postitoimipaikka/i)[0], {
-    target: { value: 'Helsinki' },
-  });
-  fireEvent.click(screen.getByLabelText(/kiinteistöliittymien rakentamisesta/i));
-  fireEvent.click(screen.getByTestId('excavationYes'));
-  fireEvent.change(screen.getByLabelText(/työn kuvaus/i), {
-    target: { value: 'Kaivetaan Mannerheimintiellä' },
-  });
-  fireEvent.change(screen.getByLabelText(/Nimi/), {
-    target: { value: 'Matti Meikäläinen' },
-  });
-  fireEvent.change(screen.getByLabelText(/sähköposti/i), {
-    target: { value: 'matti.meikalainen@test.com' },
-  });
-  fireEvent.change(screen.getByLabelText(/puhelinnumero/i), {
-    target: { value: '0000000000' },
-  });
+  fillBasicInformation();
 
   // Move to next page to save form
   await user.click(screen.getByRole('button', { name: /seuraava/i }));

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -510,9 +510,9 @@
     },
     "notifications": {
       "saveSuccessLabel": "Hakemus tallennettu",
-      "saveErrorLabel": "Hakemuksen tallennus epäonnistui",
+      "saveErrorLabel": "Tallentaminen epäonnistui",
       "saveSuccessText": "Hakemuksen tallentaminen onnistui",
-      "saveErrorText": "Hakemusta ei voitu tallentaa. Tarkista hakemuksen oikea sisältö ja että olet kirjautunut.",
+      "saveErrorText": "<0>Hakemuksen tallentaminen epäonnistui. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>",
       "sendSuccessLabel": "Hakemus lähetetty",
       "sendErrorLabel": "Hakemuksen lähetys epäonnistui",
       "sendSuccessText": "Hakemuksen lähetys onnistui",


### PR DESCRIPTION
# Description

There was already error message shown to user if saving application fails, but updated it to match the design and also made it to stay on screen until user dismisses it, so that it won't be missed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1159

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
