### PR TITLE
HAI-1158 Show error message to user if sending application to Allu fails

### DIFF
--- a/src/common/components/globalNotification/GlobalNotificationContext.tsx
+++ b/src/common/components/globalNotification/GlobalNotificationContext.tsx
@@ -6,7 +6,7 @@ type GlobalNotificationProviderProps = {
 };
 
 type NotificationOptions = NotificationProps & {
-  message: string;
+  message: string | React.ReactElement;
 };
 
 type NotificationContextProps = {

--- a/src/domain/application/components/ApplicationCancel.test.tsx
+++ b/src/domain/application/components/ApplicationCancel.test.tsx
@@ -2,18 +2,12 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../../testUtils/render';
 import { ApplicationCancel } from './ApplicationCancel';
-import GlobalNotification from '../../../common/components/globalNotification/GlobalNotification';
 import mockApplications from '../../mocks/data/hakemukset-data';
 
 test('Cancel application when it has not been saved', async () => {
   const user = userEvent.setup();
 
-  render(
-    <>
-      <GlobalNotification />
-      <ApplicationCancel applicationId={null} alluStatus={null} hankeTunnus="HAI22-2" />
-    </>
-  );
+  render(<ApplicationCancel applicationId={null} alluStatus={null} hankeTunnus="HAI22-2" />);
 
   await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
 
@@ -30,14 +24,11 @@ test('Cancel application when it has been saved, but not sent to Allu', async ()
   const application = mockApplications[0];
 
   render(
-    <>
-      <GlobalNotification />
-      <ApplicationCancel
-        applicationId={application.id}
-        alluStatus={application.alluStatus}
-        hankeTunnus="HAI22-2"
-      />
-    </>
+    <ApplicationCancel
+      applicationId={application.id}
+      alluStatus={application.alluStatus}
+      hankeTunnus="HAI22-2"
+    />
   );
 
   await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
@@ -55,14 +46,11 @@ test('Cancel application when it has been saved and sent to Allu but is still pe
   const application = mockApplications[1];
 
   render(
-    <>
-      <GlobalNotification />
-      <ApplicationCancel
-        applicationId={application.id}
-        alluStatus={application.alluStatus}
-        hankeTunnus="HAI22-2"
-      />
-    </>
+    <ApplicationCancel
+      applicationId={application.id}
+      alluStatus={application.alluStatus}
+      hankeTunnus="HAI22-2"
+    />
   );
 
   await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));

--- a/src/domain/application/hooks/useApplicationSendNotification.tsx
+++ b/src/domain/application/hooks/useApplicationSendNotification.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Link } from 'hds-react';
+import { Trans, useTranslation } from 'react-i18next';
+import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
+
+/**
+ * Returns functions for showing success and error notifications for sending application
+ */
+export default function useApplicationSendNotification() {
+  const { t } = useTranslation();
+  const { setNotification } = useGlobalNotification();
+
+  function showSendSuccess() {
+    setNotification(true, {
+      position: 'top-right',
+      dismissible: true,
+      autoClose: true,
+      autoCloseDuration: 8000,
+      label: t('hakemus:notifications:sendSuccessLabel'),
+      message: t('hakemus:notifications:sendSuccessText'),
+      type: 'success',
+      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+    });
+  }
+
+  function showSendError() {
+    const sendErrorMessage = (
+      <Trans i18nKey="hakemus:notifications:sendErrorText">
+        <p>
+          Hakemus on tallennettu luonnoksena, koska hakemuksen lähettäminen käsittelyyn epäonnistui.
+          Yritä lähettämistä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen
+          sähköpostiosoitteessa
+          <Link href="mailto:haitatontuki@hel.fi">haitatontuki@hel.fi</Link>.
+        </p>
+      </Trans>
+    );
+
+    setNotification(true, {
+      position: 'top-right',
+      dismissible: true,
+      label: t('hakemus:notifications:sendErrorLabel'),
+      message: sendErrorMessage,
+      type: 'alert',
+      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+    });
+  }
+
+  return { showSendSuccess, showSendError };
+}

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { cleanup, render, screen } from '../../../testUtils/render';
 import { waitForLoadingToFinish } from '../../../testUtils/helperFunctions';
 import HankeViewContainer from './HankeViewContainer';
-import GlobalNotification from '../../../common/components/globalNotification/GlobalNotification';
 
 afterEach(cleanup);
 
@@ -95,12 +94,7 @@ test('Correct information about hanke should be displayed', async () => {
 test('It is possible to delete hanke if it has no active applications', async () => {
   const user = userEvent.setup();
 
-  render(
-    <>
-      <GlobalNotification />
-      <HankeViewContainer hankeTunnus="HAI22-3" />
-    </>
-  );
+  render(<HankeViewContainer hankeTunnus="HAI22-3" />);
 
   const cancelHankeButton = screen.getByRole('button', { name: /peru hanke/i });
 

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -518,9 +518,9 @@
       "saveSuccessText": "Hakemuksen tallentaminen onnistui",
       "saveErrorText": "<0>Hakemuksen tallentaminen epäonnistui. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>",
       "sendSuccessLabel": "Hakemus lähetetty",
-      "sendErrorLabel": "Hakemuksen lähetys epäonnistui",
-      "sendSuccessText": "Hakemuksen lähetys onnistui",
-      "sendErrorText": "Hakemusta ei voitu lähettää. Tarkista hakemuksen oikea sisältö ja että olet kirjautunut.",
+      "sendErrorLabel": "Lähettäminen epäonnistui",
+      "sendSuccessText": "Hakemus on lähetetty käsiteltäväksi.",
+      "sendErrorText": "<0>Hakemus on tallennettu luonnoksena, koska hakemuksen lähettäminen käsittelyyn epäonnistui. Yritä lähettämistä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi.</1></0>",
       "cancelSuccessLabel": "Hakemus peruttiin",
       "cancelSuccessText": "Hakemus peruttiin onnistuneesti"
     },

--- a/src/testUtils/render.tsx
+++ b/src/testUtils/render.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter } from 'react-router-dom';
 import i18n from '../locales/i18nForTests';
 import { store } from '../common/redux/store';
 import { GlobalNotificationProvider } from '../common/components/globalNotification/GlobalNotificationContext';
+import GlobalNotification from '../common/components/globalNotification/GlobalNotification';
 
 const queryClient = new QueryClient();
 
@@ -19,7 +20,10 @@ const AllTheProviders = ({ children }: Props) => (
     <ReduxProvider store={store}>
       <QueryClientProvider client={queryClient}>
         <I18nextProvider i18n={i18n}>
-          <GlobalNotificationProvider>{children}</GlobalNotificationProvider>
+          <GlobalNotificationProvider>
+            {children}
+            <GlobalNotification />
+          </GlobalNotificationProvider>
         </I18nextProvider>
       </QueryClientProvider>
     </ReduxProvider>


### PR DESCRIPTION
# Description

Implemented showing better error message to user if sending application to Allu fails. Error notification also stays on screen until it is dismissed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1158

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
