### PR TITLE
HAI-1440: Add heading for public hanke pages

### DIFF
--- a/src/domain/map/HankeMap.tsx
+++ b/src/domain/map/HankeMap.tsx
@@ -32,7 +32,6 @@ const HankeMap: React.FC = () => {
 
   return (
     <div className={styles.mapContainer} id="hankemap">
-      <h1 className={styles.allyHeader}>Karttasivu</h1> {/* For a11y */}
       <Map zoom={zoom} mapClassName={styles.mapContainer__inner}>
         <AddressSearchContainer position={{ top: '1rem', left: '1rem' }} />
 

--- a/src/domain/map/Map.module.scss
+++ b/src/domain/map/Map.module.scss
@@ -17,11 +17,6 @@
   }
 }
 
-.allyHeader {
-  position: absolute;
-  top: -5000px;
-}
-
 .hiddenTestDiv {
   display: none;
 }

--- a/src/domain/mapAndList/MapAndListContainer.tsx
+++ b/src/domain/mapAndList/MapAndListContainer.tsx
@@ -19,6 +19,12 @@ const MapAndListContainer: React.FC = () => {
       id={SKIP_TO_ELEMENT_ID}
       tabIndex={-1}
     >
+      <Flex
+        margin="var(--spacing-xl) var(--spacing-xl) var(--spacing-l) var(--spacing-xl)"
+        justify="center"
+      >
+        <h1 className="heading-xl">{t('publicHankkeet:pageHeader')}</h1>
+      </Flex>
       <Flex justify="center" align="center" margin="var(--spacing-m)">
         <div>
           <NavLink to={PUBLIC_HANKKEET_MAP.path}>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -674,6 +674,7 @@
     }
   },
   "publicHankkeet": {
+    "pageHeader": "Hankkeet yleisillä alueilla",
     "buttons": {
       "map": "Kartta",
       "list": "Lista"


### PR DESCRIPTION
# Description

Added missing heading for public hanke map and list pages since it was raised in the accessibility evaluation.

### Jira Issue: HAI-1440

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Go to public hanke pages. There should be a heading.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

