### PR TITLE
HAI-1499 Add application list to hanke view

### DIFF
--- a/src/common/components/errorLoadingText/ErrorLoadingText.tsx
+++ b/src/common/components/errorLoadingText/ErrorLoadingText.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Box } from '@chakra-ui/react';
+import { IconAlertCircle } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import Text from '../text/Text';
+
+function ErrorLoadingText() {
+  const { t } = useTranslation();
+
+  return (
+    <Box textAlign="center" my="var(--spacing-2-xl)">
+      <IconAlertCircle size="l" style={{ marginBottom: 'var(--spacing-m)' }} />
+      <Text tag="p" styleAs="body-xl" weight="bold">
+        {t('common:components:errorLoadingInfo:textTop')}
+      </Text>
+      <Text tag="p" styleAs="body-xl" weight="bold">
+        {t('common:components:errorLoadingInfo:textBottom')}
+      </Text>
+    </Box>
+  );
+}
+
+export default ErrorLoadingText;

--- a/src/domain/application/components/ApplicationList.module.scss
+++ b/src/domain/application/components/ApplicationList.module.scss
@@ -1,0 +1,7 @@
+.pagination {
+  margin-bottom: var(--spacing-s);
+
+  * {
+    box-sizing: content-box;
+  }
+}

--- a/src/domain/application/components/ApplicationList.tsx
+++ b/src/domain/application/components/ApplicationList.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Box } from '@chakra-ui/react';
+import { useTable, Column, usePagination, useSortBy } from 'react-table';
+import { Pagination } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { Application } from '../types/application';
+import ApplicationListItem from './ApplicationListItem';
+import { Language } from '../../../common/types/language';
+import styles from './ApplicationList.module.scss';
+
+type Props = {
+  applications: Application[];
+};
+
+function ApplicationList({ applications }: Props) {
+  const { t, i18n } = useTranslation();
+
+  const columns: Column<Application>[] = React.useMemo(() => {
+    return [
+      {
+        id: 'name',
+        accessor: (application) => application.applicationData.name,
+        defaultCanFilter: true,
+      },
+      {
+        id: 'alluStatus',
+        accessor: 'alluStatus',
+        defaultCanFilter: true,
+      },
+    ];
+  }, []);
+
+  const {
+    page,
+    gotoPage,
+    pageCount,
+    state: { pageIndex },
+    rows,
+  } = useTable<Application>(
+    {
+      columns,
+      data: applications,
+      initialState: {
+        pageSize: 10,
+        sortBy: React.useMemo(() => [{ id: 'name', desc: false }], []),
+      },
+    },
+    useSortBy,
+    usePagination
+  );
+
+  if (rows.length === 0) {
+    return (
+      <Box textAlign="center" mt="var(--spacing-2-xl)">
+        <p>{t('hakemus:notifications:noApplications')}</p>
+      </Box>
+    );
+  }
+
+  function handlePageChange(e: React.MouseEvent, index: number) {
+    e.preventDefault();
+    gotoPage(index);
+  }
+
+  return (
+    <div>
+      {page.map((row) => {
+        return <ApplicationListItem key={row.original.id} application={row.original} />;
+      })}
+
+      <div className={styles.pagination}>
+        <Pagination
+          language={i18n.language as Language}
+          onChange={handlePageChange}
+          pageHref={() => ''}
+          pageCount={pageCount}
+          pageIndex={pageIndex}
+          paginationAriaLabel={t('hankeList:paginatioAriaLabel')}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default ApplicationList;

--- a/src/domain/application/components/ApplicationListItem.module.scss
+++ b/src/domain/application/components/ApplicationListItem.module.scss
@@ -1,0 +1,23 @@
+@import 'layout.scss';
+
+.applicationCard {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: var(--spacing-s);
+}
+
+.applicationInfoRow {
+  display: grid;
+  flex-grow: 1;
+  grid-gap: var(--spacing-2-xs);
+  margin-right: var(--spacing-2-xs);
+  margin-bottom: var(--spacing-2-xs);
+
+  @include respond-above(s) {
+    grid-template-columns: 300px 1fr;
+  }
+
+  @include respond-above(m) {
+    grid-template-columns: 300px 1fr 1fr;
+  }
+}

--- a/src/domain/application/components/ApplicationListItem.tsx
+++ b/src/domain/application/components/ApplicationListItem.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Card, IconEye } from 'hds-react';
+import { Box, Flex } from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
+import { Application } from '../types/application';
+import { formatToFinnishDate } from '../../../common/utils/date';
+import styles from './ApplicationListItem.module.scss';
+import Text from '../../../common/components/text/Text';
+import ApplicationStatusTag from './ApplicationStatusTag';
+
+function ApplicationDates({
+  startTime,
+  endTime,
+}: {
+  startTime: string | null;
+  endTime: string | null;
+}) {
+  if (startTime === null || endTime === null) {
+    return <div />;
+  }
+
+  return (
+    <p>
+      {formatToFinnishDate(startTime)}–{formatToFinnishDate(endTime)}
+    </p>
+  );
+}
+
+type Props = { application: Application };
+
+function ApplicationListItem({ application }: Props) {
+  const { t } = useTranslation();
+  const { applicationData, alluStatus, applicationIdentifier } = application;
+  const { name, applicationType, startTime, endTime } = applicationData;
+
+  const applicationId =
+    applicationIdentifier || t(`hakemus:applicationTypeDraft:${applicationType}`);
+
+  return (
+    <Card border className={styles.applicationCard} data-testid="application-card">
+      <Flex>
+        <div className={styles.applicationInfoRow}>
+          <Flex mr="var(--spacing-s)" flexWrap="wrap">
+            <Box mr="var(--spacing-s)">
+              <Text tag="p" weight="bold">
+                {applicationId}
+              </Text>
+            </Box>
+            <Text tag="p">{name}</Text>
+          </Flex>
+          <ApplicationDates startTime={startTime} endTime={endTime} />
+          <div>
+            <ApplicationStatusTag status={alluStatus} />
+          </div>
+        </div>
+        <Box flex="0 0 60px">
+          <IconEye />
+        </Box>
+      </Flex>
+      <p>{t(`hakemus:applicationTypes:${applicationType}`)}</p>
+    </Card>
+  );
+}
+
+export default ApplicationListItem;

--- a/src/domain/application/components/ApplicationStatusTag.tsx
+++ b/src/domain/application/components/ApplicationStatusTag.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { IconAlertCircle, Tag } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { AlluStatusStrings, AlluStatus } from '../types/application';
+
+/**
+ * Get theme for status tag.
+ * Grey background if there is no Allu status (meaning it's draft)
+ * or status is replaced (korvattu),
+ * green background with white text if status is decision (päätös)
+ * and yellow backround otherwise.
+ */
+function getTheme(status: AlluStatusStrings | null) {
+  if (status === null || status === AlluStatus.REPLACED) {
+    return undefined;
+  }
+
+  if (status === AlluStatus.DECISION) {
+    return { '--tag-background': 'var(--color-success)', '--tag-color': 'var(--color-white)' };
+  }
+
+  return { '--tag-background': 'var(--color-alert)' };
+}
+
+function ApplicationStatusTag({ status }: { status: AlluStatusStrings | null }) {
+  const { t } = useTranslation();
+
+  const statusText = t(`hakemus:status:${status}`);
+  // If application is in draft state or waiting information (täydennyspyyntö),
+  // display alert icon before status text
+  const icon =
+    status === null || status === AlluStatus.WAITING_INFORMATION ? <IconAlertCircle /> : null;
+
+  return (
+    <Tag theme={getTheme(status)} data-testid="application-status-tag">
+      {icon} {statusText}
+    </Tag>
+  );
+}
+
+export default ApplicationStatusTag;

--- a/src/domain/application/hooks/useApplications.ts
+++ b/src/domain/application/hooks/useApplications.ts
@@ -7,16 +7,21 @@ async function getApplications() {
   return data;
 }
 
+async function getApplicationsForHanke(hankeTunnus?: string) {
+  const { data } = await api.get<{ applications: Application[] }>(
+    `/hankkeet/${hankeTunnus}/hakemukset`
+  );
+  return data;
+}
+
 export function useApplications() {
   return useQuery<Application[]>(['applications'], getApplications);
 }
 
-export function useApplicationsForHanke(
-  hankeTunnus?: string
-): { data: Application[]; error: unknown; isLoading: boolean } {
-  const { data: allApplications, error, isLoading } = useApplications();
-  const applicationsForHanke = allApplications?.filter(
-    (application) => application.hankeTunnus === hankeTunnus
+export function useApplicationsForHanke(hankeTunnus?: string) {
+  return useQuery<{ applications: Application[] }>(
+    ['applicationsForHanke'],
+    () => getApplicationsForHanke(hankeTunnus),
+    { enabled: Boolean(hankeTunnus) }
   );
-  return { data: applicationsForHanke || [], error, isLoading };
 }

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -129,6 +129,7 @@ export interface Application {
   alluStatus: AlluStatusStrings | null;
   applicationType: ApplicationType;
   applicationData: JohtoselvitysData;
+  applicationIdentifier?: string | null;
   hankeTunnus: string;
 }
 

--- a/src/domain/hanke/hankeView/HankeViewContainer.tsx
+++ b/src/domain/hanke/hankeView/HankeViewContainer.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useLinkPath from '../../../common/hooks/useLinkPath';
 import { ROUTES } from '../../../common/types/route';
-import { useApplicationsForHanke } from '../../application/hooks/useApplications';
 import HankeDelete from '../edit/components/HankeDelete';
 import useHanke from '../hooks/useHanke';
 import HankeView from './HankeView';
@@ -13,7 +12,6 @@ type Props = {
 
 const HankeViewContainer: React.FC<Props> = ({ hankeTunnus }) => {
   const { data: hankeData } = useHanke(hankeTunnus);
-  const { data: applications } = useApplicationsForHanke(hankeTunnus);
   const getEditHankePath = useLinkPath(ROUTES.EDIT_HANKE);
   const navigate = useNavigate();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -39,12 +37,7 @@ const HankeViewContainer: React.FC<Props> = ({ hankeTunnus }) => {
         onClose={handleDeleteDialogClose}
         hankeTunnus={hankeTunnus}
       />
-      <HankeView
-        hankeData={hankeData}
-        onEditHanke={editHanke}
-        onCancelHanke={cancelHanke}
-        applications={applications}
-      />
+      <HankeView hankeData={hankeData} onEditHanke={editHanke} onCancelHanke={cancelHanke} />
     </>
   );
 };

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -157,6 +157,8 @@ test('Should show error message when saving fails', async () => {
 
   render(<Johtoselvitys />, undefined, '/fi/johtoselvityshakemus?hanke=HAI22-2');
 
+  await waitForLoadingToFinish();
+
   // Fill basic information page, so that form can be saved for the first time
   fillBasicInformation();
 
@@ -176,6 +178,8 @@ test('Should show error message when sending fails', async () => {
   );
 
   render(<Johtoselvitys />, undefined, '/fi/johtoselvityshakemus?hanke=HAI22-2');
+
+  await waitForLoadingToFinish();
 
   fillBasicInformation();
   await user.click(screen.getByRole('button', { name: /seuraava/i }));

--- a/src/domain/map/HankeMap.test.tsx
+++ b/src/domain/map/HankeMap.test.tsx
@@ -26,6 +26,8 @@ describe('HankeMap', () => {
   test('Number of projects displayed on the map can be controlled with dateRangeControl', async () => {
     const renderedComponent = render(<HankeMap />);
 
+    await screen.findByPlaceholderText('Etsi osoitteella');
+
     expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('2');
     changeFilterDate(startDateLabel, renderedComponent, '1.1.2022');
     expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('2');

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -6,6 +6,7 @@ const hakemukset: Application[] = [
     alluStatus: null,
     applicationType: 'CABLE_REPORT',
     hankeTunnus: 'HAI22-2',
+    applicationIdentifier: null,
     applicationData: {
       applicationType: 'CABLE_REPORT',
       name: 'Mannerheimintien kaivuut',
@@ -95,6 +96,7 @@ const hakemukset: Application[] = [
     alluStatus: AlluStatus.PENDING,
     applicationType: 'CABLE_REPORT',
     hankeTunnus: 'HAI22-2',
+    applicationIdentifier: 'JS2300001',
     applicationData: {
       applicationType: 'CABLE_REPORT',
       name: 'Mannerheimintien kuopat',
@@ -184,9 +186,10 @@ const hakemukset: Application[] = [
     alluStatus: AlluStatus.HANDLING,
     applicationType: 'CABLE_REPORT',
     hankeTunnus: 'HAI22-2',
+    applicationIdentifier: 'JS2300002',
     applicationData: {
       applicationType: 'CABLE_REPORT',
-      name: 'Mannerheimintien kuopat',
+      name: 'Mannerheimintien parantaminen',
       customerWithContacts: {
         customer: {
           type: 'COMPANY',
@@ -273,6 +276,7 @@ const hakemukset: Application[] = [
     alluStatus: AlluStatus.PENDING,
     applicationType: 'CABLE_REPORT',
     hankeTunnus: 'HAI22-3',
+    applicationIdentifier: 'JS2300003',
     applicationData: {
       applicationType: 'CABLE_REPORT',
       name: 'Mannerheimintien kairaukset',

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -69,6 +69,12 @@ export const handlers = [
     }
   }),
 
+  rest.get(`${apiUrl}/hankkeet/:hankeTunnus/hakemukset`, async (req, res, ctx) => {
+    const { hankeTunnus } = req.params;
+    const hakemukset = await hakemuksetDB.readAllForHanke(hankeTunnus as string);
+    return res(ctx.status(200), ctx.json({ applications: hakemukset }));
+  }),
+
   rest.get(`${apiUrl}/public-hankkeet`, async (req, res, ctx) => {
     const hankkeet = await hankkeetDB.readAll();
     return res(ctx.status(200), ctx.json(hankkeet));

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -34,6 +34,10 @@
       },
       "notification": {
         "closeButtonLabelText": "Sulje ilmoitus"
+      },
+      "errorLoadingInfo": {
+        "textTop": "Virhe tietojen lataamisessa.",
+        "textBottom": "Yritä hetken päästä uudelleen."
       }
     },
     "error": "Tapahtui virhe. Yritä uudestaan.",
@@ -522,7 +526,24 @@
       "sendSuccessText": "Hakemus on lähetetty käsiteltäväksi.",
       "sendErrorText": "<0>Hakemus on tallennettu luonnoksena, koska hakemuksen lähettäminen käsittelyyn epäonnistui. Yritä lähettämistä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi.</1></0>",
       "cancelSuccessLabel": "Hakemus peruttiin",
-      "cancelSuccessText": "Hakemus peruttiin onnistuneesti"
+      "cancelSuccessText": "Hakemus peruttiin onnistuneesti",
+      "noApplications": "Hankkeella ei ole lisättyjä hakemuksia"
+    },
+    "status": {
+      "PENDING_CLIENT": "Näkyy viranomaiselle",
+      "PENDING": "Odottaa käsittelyä",
+      "WAITING_INFORMATION": "Täydennyspyyntö",
+      "INFORMATION_RECEIVED": "Täydennetty käsittelyyn",
+      "HANDLING": "Käsittelyssä",
+      "RETURNED_TO_PREPARATION": "Käsittelyssä",
+      "DECISIONMAKING": "Odottaa päätöstä",
+      "DECISION": "Päätös",
+      "OPERATIONAL_CONDITION": "Toiminnallinen kunto hyväksytty",
+      "FINISHED": "Työ valmis hyväksytty",
+      "CANCELLED": "Hakemus peruttu",
+      "ARCHIVED": "Työ arkistoitu",
+      "REPLACED": "Korvattu",
+      "null": "Luonnos"
     },
     "buttons": {
       "continueToApplication": "Jatka hakemukseen",
@@ -537,6 +558,9 @@
     },
     "applicationTypes": {
       "CABLE_REPORT": "Johtoselvitys"
+    },
+    "applicationTypeDraft": {
+      "CABLE_REPORT": "JS-luonnos"
     },
     "applicationTypeInstruction": "Valitse hakemustyyppi. Osaan hakemuksista voit myös kopioida aiemman hakemuksen pohjaksi. Kaivuilmoituksen kautta pääset tekemään myös johtoselvityksen, mikäli sinulla ei sellaista vielä ole."
   },

--- a/src/testUtils/render.tsx
+++ b/src/testUtils/render.tsx
@@ -9,26 +9,34 @@ import { store } from '../common/redux/store';
 import { GlobalNotificationProvider } from '../common/components/globalNotification/GlobalNotificationContext';
 import GlobalNotification from '../common/components/globalNotification/GlobalNotification';
 
-const queryClient = new QueryClient();
-
 type Props = {
   children: React.ReactChildren;
 };
 
-const AllTheProviders = ({ children }: Props) => (
-  <BrowserRouter>
-    <ReduxProvider store={store}>
-      <QueryClientProvider client={queryClient}>
-        <I18nextProvider i18n={i18n}>
-          <GlobalNotificationProvider>
-            {children}
-            <GlobalNotification />
-          </GlobalNotificationProvider>
-        </I18nextProvider>
-      </QueryClientProvider>
-    </ReduxProvider>
-  </BrowserRouter>
-);
+const AllTheProviders = ({ children }: Props) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retryDelay: 0,
+      },
+    },
+  });
+
+  return (
+    <BrowserRouter>
+      <ReduxProvider store={store}>
+        <QueryClientProvider client={queryClient}>
+          <I18nextProvider i18n={i18n}>
+            <GlobalNotificationProvider>
+              {children}
+              <GlobalNotification />
+            </GlobalNotificationProvider>
+          </I18nextProvider>
+        </QueryClientProvider>
+      </ReduxProvider>
+    </BrowserRouter>
+  );
+};
 
 const customRender = (ui: React.ReactElement, options: RenderOptions = {}, route = '/') => {
   window.history.pushState({}, 'Test page', route);


### PR DESCRIPTION
# Description

Implemented application list which shows applications for selected hanke. It can be found on applications tab in hanke view.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1499

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create application(s) for hanke
2. Navigate to view information of that hanke
3. Check that applications you have created are found in applications tab 

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Filtering and sorting of the list as well as grouping different versions of the same application will be implemented later.
