### PR TITLE
HAI-1570 Enable creating cable report application without hanke existing first

### DIFF
--- a/src/domain/application/components/ApplicationCancel.tsx
+++ b/src/domain/application/components/ApplicationCancel.tsx
@@ -12,7 +12,7 @@ import useNavigateToApplicationList from '../../hanke/hooks/useNavigateToApplica
 type Props = {
   applicationId: number | null;
   alluStatus: AlluStatusStrings | null;
-  hankeTunnus: string;
+  hankeTunnus?: string;
 };
 
 export const ApplicationCancel: React.FC<Props> = ({ applicationId, alluStatus, hankeTunnus }) => {

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -40,7 +40,7 @@ export type Customer = {
   postalAddress: PostalAddress;
   email: string;
   phone: string;
-  registryKey: string;
+  registryKey: string | null;
   ovt: string | null;
   invoicingOperator: string | null;
   sapCustomerNumber: string | null;
@@ -130,7 +130,7 @@ export interface Application {
   applicationType: ApplicationType;
   applicationData: JohtoselvitysData;
   applicationIdentifier?: string | null;
-  hankeTunnus: string;
+  hankeTunnus: string | null;
 }
 
 export function isCustomerWithContacts(value: unknown): value is CustomerWithContacts {

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -10,7 +10,7 @@ export async function saveApplication(data: Application) {
   // call /hakemukset/luo-hanke endpoint, so that hanke is generated in the backend
   const postUrl: string =
     data.hankeTunnus === null && data.applicationType === 'CABLE_REPORT'
-      ? `/hakemukset/luo-hanke`
+      ? `/hakemukset/johtoselvitys`
       : '/hakemukset';
 
   const response = data.id

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -6,9 +6,16 @@ import { AlluStatus, AlluStatusStrings, Application } from './types/application'
  * Save application to Haitaton backend
  */
 export async function saveApplication(data: Application) {
+  // If there is no hankeTunnus when creating new cable report application
+  // call /hakemukset/luo-hanke endpoint, so that hanke is generated in the backend
+  const postUrl: string =
+    data.hankeTunnus === null && data.applicationType === 'CABLE_REPORT'
+      ? `/hakemukset/luo-hanke`
+      : '/hakemukset';
+
   const response = data.id
     ? await api.put<Application>(`/hakemukset/${data.id}`, data)
-    : await api.post<Application>('/hakemukset', data);
+    : await api.post<Application>(postUrl, data);
 
   return response.data;
 }

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -10,7 +10,7 @@ export async function saveApplication(data: Application) {
   // call /hakemukset/luo-hanke endpoint, so that hanke is generated in the backend
   const postUrl: string =
     data.hankeTunnus === null && data.applicationType === 'CABLE_REPORT'
-      ? `/hakemukset/johtoselvitys`
+      ? '/hakemukset/johtoselvitys'
       : '/hakemukset';
 
   const response = data.id

--- a/src/domain/forms/MultipageForm.tsx
+++ b/src/domain/forms/MultipageForm.tsx
@@ -26,7 +26,7 @@ interface Props {
   ) => React.ReactNode;
   /** Heading of the form */
   heading: string;
-  subHeading?: string;
+  subHeading?: string | JSX.Element;
   /** Array of form steps to render */
   formSteps: FormStep[];
   /** Function that is called when step is changed */

--- a/src/domain/hanke/edit/HankeFormPerustiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormPerustiedot.tsx
@@ -17,10 +17,12 @@ import { useFormPage } from './hooks/useFormPage';
 import DropdownMultiselect from '../../../common/components/dropdown/DropdownMultiselect';
 import Checkbox from '../../../common/components/checkbox/Checkbox';
 import { getInputErrorText } from '../../../common/utils/form';
+import { useLocalizedRoutes } from '../../../common/hooks/useLocalizedRoutes';
 
 const HankeFormPerustiedot: React.FC<FormProps> = ({ errors, register, formData }) => {
   const { t } = useTranslation();
   const { watch, setValue } = useFormContext();
+  const { JOHTOSELVITYSHAKEMUS } = useLocalizedRoutes();
   useFormPage();
 
   // Subscribe to vaihe changes
@@ -41,9 +43,8 @@ const HankeFormPerustiedot: React.FC<FormProps> = ({ errors, register, formData 
           <p>Hankkeen luonnin kautta pääset lähettämään myös hakemuksia.</p>
           <p>
             <strong>HUOM!</strong> Mikäli teet pelkkää johtoselvitystä yksityiselle alueelle,
-            {/* TODO: Link href to actual hakemus page when that's implemented */}
-            <Link href="/">täytä hakemus</Link>. Yleisten alueiden johtoselvitykset haetaan hankkeen
-            luonnin jälkeen kaivuilmoituksen kautta.
+            <Link href={JOHTOSELVITYSHAKEMUS.path}>täytä hakemus</Link>. Yleisten alueiden
+            johtoselvitykset haetaan hankkeen luonnin jälkeen kaivuilmoituksen kautta.
           </p>
           <p>Lisäämällä hankkeen tiedot, pystyt kopioimaan ne lopuksi tarvitsemiisi hakemuksiin.</p>
         </Trans>

--- a/src/domain/hanke/edit/components/BasicInformationSummary.tsx
+++ b/src/domain/hanke/edit/components/BasicInformationSummary.tsx
@@ -58,7 +58,7 @@ const BasicInformationSummary: React.FC<Props> = ({ formData, children }) => {
       </SectionItemContent>
       <SectionItemTitle>{t('hankeForm:labels:vaihe')}</SectionItemTitle>
       <SectionItemContent>
-        <p>{t(`hanke:vaihe:${formData.vaihe}`)}</p>
+        {formData.vaihe !== null && <p>{t(`hanke:vaihe:${formData.vaihe}`)}</p>}
       </SectionItemContent>
       <SectionItemTitle>{t('hankeForm:labels:tyomaaTyyppi')}</SectionItemTitle>
       <SectionItemContent>

--- a/src/domain/hanke/hooks/useNavigateToApplicationList.ts
+++ b/src/domain/hanke/hooks/useNavigateToApplicationList.ts
@@ -1,17 +1,21 @@
 import { useNavigate } from 'react-router-dom';
 import useLinkPath from '../../../common/hooks/useLinkPath';
+import { useLocalizedRoutes } from '../../../common/hooks/useLocalizedRoutes';
 import { ROUTES } from '../../../common/types/route';
 
 /**
- * Returns a function to navigate to hanke view with application list tab initially open
+ * Returns a function to navigate to hanke view with application list tab initially open.
+ * If there is no hankeTunnus, returned function navigates to hanke portfolio as a fallback.
  */
-export default function useNavigateToApplicationList(hankeTunnus: string) {
+export default function useNavigateToApplicationList(hankeTunnus?: string) {
   const navigate = useNavigate();
   const getHankeViewPath = useLinkPath(ROUTES.HANKE);
-  const hankeViewPath = getHankeViewPath({ hankeTunnus });
+  const { HANKEPORTFOLIO } = useLocalizedRoutes();
+
+  const path = hankeTunnus ? getHankeViewPath({ hankeTunnus }) : HANKEPORTFOLIO.path;
 
   function navigateToApplicationList() {
-    navigate(hankeViewPath, { state: { initiallyActiveTab: 4 } });
+    navigate(path, { state: { initiallyActiveTab: 4 } });
   }
 
   return navigateToApplicationList;

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -79,16 +79,20 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke }) => {
               <Text tag="p" styleAs="body-xl" weight="bold">
                 {hanke.nimi}
               </Text>
-              <HankeVaiheTag tagName={hanke.vaihe}>{hanke.vaihe}</HankeVaiheTag>
+              <HankeVaiheTag tagName={hanke.vaihe} />
             </div>
             <div className={styles.hankeDates}>
-              <Text tag="p" styleAs="body-m">
-                {formatToFinnishDate(hanke.alkuPvm)}
-              </Text>
-              -
-              <Text tag="p" styleAs="body-m">
-                {formatToFinnishDate(hanke.loppuPvm)}
-              </Text>
+              {hanke.alkuPvm && hanke.loppuPvm ? (
+                <>
+                  <Text tag="p" styleAs="body-m">
+                    {formatToFinnishDate(hanke.alkuPvm)}
+                  </Text>
+                  -
+                  <Text tag="p" styleAs="body-m">
+                    {formatToFinnishDate(hanke.loppuPvm)}
+                  </Text>
+                </>
+              ) : null}
             </div>
           </div>
           <div className={styles.actions}>
@@ -165,7 +169,7 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke }) => {
               {t('hankeForm:labels:vaihe')}
             </Text>
             <Text tag="p" styleAs="body-m" className={styles.infoContent}>
-              {t(`hanke:vaihe:${hanke.vaihe}`)}
+              {hanke.vaihe !== null && t(`hanke:vaihe:${hanke.vaihe}`)}
             </Text>
           </div>
           <div className={styles.gridBasicInfo}>

--- a/src/domain/hanke/vaiheTag/HankeVaiheTag.tsx
+++ b/src/domain/hanke/vaiheTag/HankeVaiheTag.tsx
@@ -6,7 +6,7 @@ import { HANKE_VAIHE, HANKE_VAIHE_KEY } from '../../types/hanke';
 import styles from './HankeVaiheTag.module.scss';
 
 type TagProps = {
-  tagName: HANKE_VAIHE_KEY;
+  tagName: HANKE_VAIHE_KEY | null;
   uppercase?: boolean;
 };
 
@@ -24,6 +24,10 @@ const themes = {
 
 const HankeVaiheTag: React.FC<TagProps> = ({ tagName, uppercase }) => {
   const { t } = useTranslation();
+
+  if (tagName === null) {
+    return null;
+  }
 
   return (
     <Tag theme={themes[tagName]} className={clsx({ [styles.uppercase]: uppercase })}>

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -144,6 +144,7 @@ test('Cable report application form can be filled and saved and sent to Allu', a
 
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
   expect(screen.queryByText(/hakemus lähetetty/i)).toBeInTheDocument();
+  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2');
 });
 
 test('Should show error message when saving fails', async () => {
@@ -190,4 +191,62 @@ test('Should show error message when sending fails', async () => {
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
 
   expect(screen.queryByText(/lähettäminen epäonnistui/i)).toBeInTheDocument();
+});
+
+test('Form can be saved without hanke existing first', async () => {
+  const user = userEvent.setup();
+
+  render(<Johtoselvitys />, undefined, '/fi/johtoselvityshakemus');
+
+  // Fill basic information page
+  fillBasicInformation();
+
+  // Move to areas page
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+  expect(screen.queryByText(/hakemus tallennettu/i)).toBeInTheDocument();
+  expect(screen.queryByText('Johtoselvitys (HAI22-12)')).toBeInTheDocument();
+  expect(screen.queryByText('Vaihe 2/4: Alueet')).toBeInTheDocument();
+});
+
+test('Save and quit works', async () => {
+  const user = userEvent.setup();
+
+  render(<Johtoselvitys />, undefined, '/fi/johtoselvityshakemus?hanke=HAI22-2');
+
+  await waitForLoadingToFinish();
+
+  // Fill basic information page
+  fillBasicInformation();
+
+  // Move to areas page
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+  expect(screen.queryByText(/hakemus tallennettu/i)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /sulje ilmoitus/i }));
+  await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
+
+  expect(screen.queryAllByText(/hakemus tallennettu/i).length).toBe(2);
+  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2');
+});
+
+test('Save and quit works without hanke existing first', async () => {
+  const user = userEvent.setup();
+
+  render(<Johtoselvitys />, undefined, '/fi/johtoselvityshakemus');
+
+  // Fill basic information page
+  fillBasicInformation();
+
+  // Move to areas page
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+  expect(screen.queryByText(/hakemus tallennettu/i)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /sulje ilmoitus/i }));
+  await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
+
+  expect(screen.queryAllByText(/hakemus tallennettu/i).length).toBe(2);
+  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-13');
 });

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -91,7 +91,7 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(hakemus));
   }),
 
-  rest.post(`${apiUrl}/hakemukset/luo-hanke`, async (req, res, ctx) => {
+  rest.post(`${apiUrl}/hakemukset/johtoselvitys`, async (req, res, ctx) => {
     const reqBody: JohtoselvitysFormValues = await req.json();
     const hanke = await hankkeetDB.create({
       nimi: reqBody.applicationData.name,

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -91,6 +91,20 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(hakemus));
   }),
 
+  rest.post(`${apiUrl}/hakemukset/luo-hanke`, async (req, res, ctx) => {
+    const reqBody: JohtoselvitysFormValues = await req.json();
+    const hanke = await hankkeetDB.create({
+      nimi: reqBody.applicationData.name,
+      alkuPvm: '',
+      loppuPvm: '',
+      vaihe: 'SUUNNITTELU',
+      kuvaus: '',
+    });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const hakemus = await hakemuksetDB.create({ ...reqBody, hankeTunnus: hanke.hankeTunnus! });
+    return res(ctx.status(200), ctx.json(hakemus));
+  }),
+
   rest.put(`${apiUrl}/hakemukset/:id`, async (req, res, ctx) => {
     const { id } = req.params;
     const reqBody: JohtoselvitysFormValues = await req.json();

--- a/src/pages/Johtoselvitys.tsx
+++ b/src/pages/Johtoselvitys.tsx
@@ -12,15 +12,7 @@ const Johtoselvitys: React.FC = () => {
 
   const result = useHankeDataInApplication();
 
-  // TODO: Case where there is no related hanke for new
-  // cable application, will be implemented later
-  if (result === null) {
-    // eslint-disable-next-line no-console
-    console.error('Provide hankeTunnus in URL search params, e.g. ?hanke=HAI22-1');
-    return null;
-  }
-
-  if (result.isLoading) {
+  if (result?.isLoading) {
     return (
       <Flex justify="center" mt="var(--spacing-xl)">
         <LoadingSpinner />
@@ -28,12 +20,10 @@ const Johtoselvitys: React.FC = () => {
     );
   }
 
-  if (!result.data) return null;
-
   return (
     <Container>
       <PageMeta routeData={JOHTOSELVITYSHAKEMUS} />
-      <JohtoselvitysContainer hanke={result.data} />
+      <JohtoselvitysContainer hankeData={result?.data} />
     </Container>
   );
 };


### PR DESCRIPTION
# Description

User can create cable report application without creating hanke first by going to first page of hanke form and clicking a link to fill application. After first save, hanke for the new application is created in the backend.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1570

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Go to create new hanke, but on the first page of the hanke form click "täytä hakemus" link.
2. Fill out the cable report application form and check that it can be saved and sent.
3. Check from the hanke list that new hanke is displayed with the name of the new application.
4. Go to the hanke page of the new hanke to check that the new application is found in the application list.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: