### PR TITLE
HAI-1507 Save cable report application only if something has changed

### DIFF
--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -122,7 +122,14 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
     resolver: yupResolver(validationSchema),
   });
 
-  const { getValues, setValue, handleSubmit, trigger } = formContext;
+  const {
+    getValues,
+    setValue,
+    handleSubmit,
+    trigger,
+    formState: { isDirty },
+    reset,
+  } = formContext;
 
   // If application is created without hanke existing first, get generated hanke data
   // after first save when hankeTunnus is available
@@ -143,6 +150,7 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
       setValue('id', data.id);
       setValue('alluStatus', data.alluStatus);
       setValue('hankeTunnus', data.hankeTunnus);
+      reset({}, { keepValues: true });
     },
     onSettled() {
       setShowSaveNotification(true);
@@ -186,20 +194,30 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
     applicationSendMutation.mutate(id);
   }
 
+  function saveOnPageChange() {
+    // Save application when page is changed
+    // only if something has changed
+    if (isDirty) {
+      saveCableApplication();
+    }
+  }
+
   function saveAndQuit() {
-    saveCableApplication();
+    applicationSaveMutation.mutate(convertFormStateToApplicationData(getValues()), {
+      onSuccess() {
+        navigateToApplicationList();
 
-    navigateToApplicationList();
-
-    setNotification(true, {
-      position: 'top-right',
-      dismissible: true,
-      autoClose: true,
-      autoCloseDuration: 5000,
-      label: t('hakemus:notifications:saveSuccessLabel'),
-      message: t('hakemus:notifications:saveSuccessText'),
-      type: 'success',
-      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+        setNotification(true, {
+          position: 'top-right',
+          dismissible: true,
+          autoClose: true,
+          autoCloseDuration: 5000,
+          label: t('hakemus:notifications:saveSuccessLabel'),
+          message: t('hakemus:notifications:saveSuccessText'),
+          type: 'success',
+          closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+        });
+      },
     });
   }
 
@@ -302,7 +320,7 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
         heading={t('johtoselvitysForm:pageHeader')}
         subHeading={hankeNameText}
         formSteps={formSteps}
-        onStepChange={saveCableApplication}
+        onStepChange={saveOnPageChange}
         onSubmit={handleSubmit(sendCableApplication)}
       >
         {function renderFormActions(activeStepIndex, handlePrevious, handleNext) {

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -7,6 +7,7 @@ import { waitForLoadingToFinish } from '../../testUtils/helperFunctions';
 import { server } from '../mocks/test-server';
 import { HankeData } from '../types/hanke';
 import hankkeet from '../mocks/data/hankkeet-data';
+import applications from '../mocks/data/hakemukset-data';
 import { JohtoselvitysFormValues } from './types';
 
 afterEach(cleanup);
@@ -336,4 +337,49 @@ test('Save and quit works without hanke existing first', async () => {
 
   expect(screen.queryAllByText(/hakemus tallennettu/i).length).toBe(2);
   expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-13');
+});
+
+test('Should show error message and not navigate away when save and quit fails', async () => {
+  server.use(
+    rest.put('/api/hakemukset/:id', async (req, res, ctx) => {
+      return res(ctx.status(500), ctx.json({ errorMessage: 'Failed for testing purposes' }));
+    })
+  );
+
+  const { user } = render(<Johtoselvitys />, undefined, '/fi/johtoselvityshakemus');
+
+  fillBasicInformation();
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
+  await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
+
+  expect(screen.queryAllByText(/tallentaminen epäonnistui/i)[0]).toBeInTheDocument();
+  expect(window.location.pathname).toBe('/fi/johtoselvityshakemus');
+});
+
+test('Should not save application between page changes when nothing is changed', async () => {
+  const { user } = render(<JohtoselvitysContainer application={applications[3]} />);
+
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+  expect(screen.queryByText(/hakemus tallennettu/i)).not.toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+  expect(screen.queryByText(/hakemus tallennettu/i)).not.toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+  expect(screen.queryByText(/hakemus tallennettu/i)).not.toBeInTheDocument();
+});
+
+test('Should save existing application between page changes when there is changes', async () => {
+  const { user } = render(<JohtoselvitysContainer application={applications[3]} />);
+
+  fireEvent.change(screen.getByLabelText(/työn kuvaus/i), {
+    target: { value: 'Muokataan johtoselvitystä' },
+  });
+
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+  expect(screen.queryByText(/hakemus tallennettu/i)).toBeInTheDocument();
 });

--- a/src/domain/johtoselvitys/types.ts
+++ b/src/domain/johtoselvitys/types.ts
@@ -12,4 +12,5 @@ export interface JohtoselvitysFormData extends JohtoselvitysData {
 
 export interface JohtoselvitysFormValues extends Application {
   applicationData: JohtoselvitysFormData;
+  geometriesChanged?: boolean; // virtualField
 }

--- a/src/domain/johtoselvitys/utils.ts
+++ b/src/domain/johtoselvitys/utils.ts
@@ -46,6 +46,8 @@ export function getAreaGeometries(areas: JohtoselvitysArea[]) {
  * latest OpenLayers feature coordinates.
  */
 export function convertFormStateToApplicationData(formState: JohtoselvitysFormValues): Application {
+  // eslint-disable-next-line no-param-reassign
+  delete formState.geometriesChanged;
   const data: Application = cloneDeep(formState);
 
   const updatedAreas: ApplicationArea[] = formState.applicationData.areas.map(

--- a/src/pages/EditJohtoselvitysPage.tsx
+++ b/src/pages/EditJohtoselvitysPage.tsx
@@ -6,8 +6,8 @@ import Container from '../common/components/container/Container';
 import PageMeta from './components/PageMeta';
 import { useLocalizedRoutes } from '../common/hooks/useLocalizedRoutes';
 import JohtoselvitysContainer from '../domain/johtoselvitys/JohtoselvitysContainer';
-import { useHankeDataInApplication } from '../domain/application/hooks/useHankeDataInApplication';
 import { useApplication } from '../domain/application/hooks/useApplication';
+import useHanke from '../domain/hanke/hooks/useHanke';
 import ErrorLoadingText from '../common/components/errorLoadingText/ErrorLoadingText';
 
 const EditJohtoselvitysPage: React.FC = () => {
@@ -15,7 +15,7 @@ const EditJohtoselvitysPage: React.FC = () => {
   const { EDIT_JOHTOSELVITYSHAKEMUS } = useLocalizedRoutes();
 
   const applicationQueryResult = useApplication(Number(id));
-  const hankeQueryResult = useHankeDataInApplication();
+  const hankeQueryResult = useHanke(applicationQueryResult.data?.hankeTunnus);
 
   if (applicationQueryResult.isLoading || hankeQueryResult?.isLoading) {
     return (


### PR DESCRIPTION
# Description

Cable report application is only saved when page is changed if user has made changes since the last save.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1507

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Create or edit cable report application and note that application should only be saved on page change when there are changes made to the fields or application areas.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
