### PR TITLE
HAI-1604 Fix own role selection in cable report application form

### DIFF
--- a/src/domain/johtoselvitys/BasicInfo.tsx
+++ b/src/domain/johtoselvitys/BasicInfo.tsx
@@ -3,7 +3,7 @@ import { Checkbox, Select, SelectionGroup } from 'hds-react';
 import { useFormContext } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import { isEqual } from 'lodash';
-import { ApplicationType, CustomerType } from '../application/types/application';
+import { ApplicationType, Contact, Customer, CustomerType } from '../application/types/application';
 import styles from './BasicInfo.module.scss';
 import TextInput from '../../common/components/textInput/TextInput';
 import TextArea from '../../common/components/textArea/TextArea';
@@ -48,6 +48,32 @@ export const initialValues: InitialValueTypes = {
     propertyConnectivity: false,
   },
 };
+
+const emptyCustomer: Customer = {
+  type: null,
+  name: '',
+  country: 'FI',
+  email: '',
+  phone: '',
+  registryKey: null,
+  ovt: null,
+  invoicingOperator: null,
+  sapCustomerNumber: null,
+};
+
+const emptyContact: Contact = {
+  email: '',
+  name: '',
+  orderer: false,
+  phone: '',
+};
+
+const customerTypes: CustomerType[] = [
+  'customerWithContacts',
+  'contractorWithContacts',
+  'propertyDeveloperWithContacts',
+  'representativeWithContacts',
+];
 
 type Option = { value: CustomerType; label: string };
 
@@ -108,25 +134,10 @@ export const BasicHankeInfo: React.FC = () => {
   ];
 
   function handleRoleChange(role: Option) {
-    const emptyContact = {
-      email: '',
-      name: '',
-      orderer: false,
-      phone: '',
-      postalAddress: { city: '', postalCode: '', streetAddress: { streetName: '' } },
-    };
-
     const previousRoleContacts = getValues(`applicationData.${selectedRole}.contacts`);
-
-    // Remove moved contact from previous selected role contacts
-    setValue(
-      `applicationData.${selectedRole}.contacts`,
-      previousRoleContacts.length > 1 ? previousRoleContacts.slice(1) : []
-    );
+    const contactToMove = previousRoleContacts.slice(0, 1);
 
     let selectedRoleContacts = getValues(`applicationData.${role.value}.contacts`);
-
-    const contactToMove = previousRoleContacts.slice(0, 1);
 
     selectedRoleContacts =
       selectedRoleContacts === null ||
@@ -134,7 +145,19 @@ export const BasicHankeInfo: React.FC = () => {
         ? contactToMove
         : contactToMove.concat(selectedRoleContacts);
 
-    setValue(`applicationData.${role.value}.contacts`, selectedRoleContacts);
+    // Remove moved contact from previous selected role contacts
+    setValue(
+      `applicationData.${selectedRole}.contacts`,
+      previousRoleContacts.length > 1 ? previousRoleContacts.slice(1) : [emptyContact]
+    );
+
+    if (!getValues(`applicationData.${role.value}.customer`)) {
+      setValue(`applicationData.${role.value}.customer`, emptyCustomer);
+    }
+
+    setValue(`applicationData.${role.value}.contacts`, selectedRoleContacts, {
+      shouldDirty: true,
+    });
 
     setSelectedRole(role.value);
   }
@@ -286,26 +309,35 @@ export const BasicHankeInfo: React.FC = () => {
           {t('form:labels:fromHelsinkiProfile')}
         </Box>
       </Text> */}
-      <ResponsiveGrid>
-        <TextInput
-          name={`applicationData.${selectedRole}.contacts.0.name`}
-          label={t('form:yhteystiedot:labels:nimi')}
-          required
-        />
-      </ResponsiveGrid>
+      {customerTypes.map((customerType) => {
+        if (customerType === selectedRole) {
+          return (
+            <React.Fragment key={customerType}>
+              <ResponsiveGrid>
+                <TextInput
+                  name={`applicationData.${customerType}.contacts.0.name`}
+                  label={t('form:yhteystiedot:labels:nimi')}
+                  required
+                />
+              </ResponsiveGrid>
 
-      <ResponsiveGrid className={styles.formRow}>
-        <TextInput
-          name={`applicationData.${selectedRole}.contacts.0.email`}
-          label={t('form:yhteystiedot:labels:email')}
-          required
-        />
-        <TextInput
-          name={`applicationData.${selectedRole}.contacts.0.phone`}
-          label={t('form:yhteystiedot:labels:puhelinnumero')}
-          required
-        />
-      </ResponsiveGrid>
+              <ResponsiveGrid className={styles.formRow}>
+                <TextInput
+                  name={`applicationData.${customerType}.contacts.0.email`}
+                  label={t('form:yhteystiedot:labels:email')}
+                  required
+                />
+                <TextInput
+                  name={`applicationData.${customerType}.contacts.0.phone`}
+                  label={t('form:yhteystiedot:labels:puhelinnumero')}
+                  required
+                />
+              </ResponsiveGrid>
+            </React.Fragment>
+          );
+        }
+        return null;
+      })}
     </div>
   );
 };

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -221,6 +221,8 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
     });
   }
 
+  const ordererKey = findOrdererKey(getValues('applicationData'));
+
   // Fields that are validated in each page when moving forward in form
   const pageFieldsToValidate: FieldPath<JohtoselvitysFormValues>[][] = useMemo(
     () => [
@@ -229,7 +231,7 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
         'applicationData.name',
         'applicationData.postalAddress',
         'applicationData.workDescription',
-        `applicationData.${findOrdererKey(getValues('applicationData'))}.contacts`,
+        `applicationData.${ordererKey}.contacts`,
         'applicationData.rockExcavation',
         'applicationData.constructionWork',
       ],
@@ -243,7 +245,7 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
         'applicationData.representativeWithContacts',
       ],
     ],
-    [getValues]
+    [ordererKey]
   );
 
   const formSteps = useMemo(() => {

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -383,3 +383,43 @@ test('Should save existing application between page changes when there is change
 
   expect(screen.queryByText(/hakemus tallennettu/i)).toBeInTheDocument();
 });
+
+test('Should change users own role and its fields correctly', async () => {
+  const { user } = render(<JohtoselvitysContainer application={applications[3]} />);
+
+  const name = 'Tauno Työmies';
+  const email = 'tauno@test.com';
+  const phone = '0401234567';
+
+  fireEvent.click(screen.getByRole('button', { name: /rooli/i }));
+  fireEvent.click(screen.getByText(/työn suorittaja/i));
+  fireEvent.change(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.name'), {
+    target: { value: name },
+  });
+  fireEvent.change(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.email'), {
+    target: { value: email },
+  });
+  fireEvent.change(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.phone'), {
+    target: { value: phone },
+  });
+  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+  expect(screen.getByTestId('applicationData.customerWithContacts.contacts.0.name')).toHaveValue(
+    ''
+  );
+  expect(screen.getByTestId('applicationData.customerWithContacts.contacts.0.email')).toHaveValue(
+    ''
+  );
+  expect(screen.getByTestId('applicationData.customerWithContacts.contacts.0.phone')).toHaveValue(
+    ''
+  );
+  expect(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.name')).toHaveValue(
+    name
+  );
+  expect(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.email')).toHaveValue(
+    email
+  );
+  expect(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.phone')).toHaveValue(
+    phone
+  );
+});

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -149,7 +149,7 @@ const hakemukset: Application[] = [
           {
             email: 'matti@test.com',
             name: 'Matti Meikäläinen',
-            orderer: true,
+            orderer: false,
             phone: '0000000000',
           },
         ],
@@ -223,7 +223,7 @@ const hakemukset: Application[] = [
           {
             email: 'matti@test.com',
             name: 'Matti Meikäläinen',
-            orderer: true,
+            orderer: false,
             phone: '0000000000',
           },
         ],
@@ -320,7 +320,7 @@ const hakemukset: Application[] = [
           {
             email: 'matti@test.com',
             name: 'Matti Meikäläinen',
-            orderer: true,
+            orderer: false,
             phone: '0000000000',
           },
         ],


### PR DESCRIPTION
# Description

Fixed problems that changing own role in cable report application forms first page had in some cases. For example when changing role from applicant (hakija) to contractor (työn suorittaja) caused situation where in contacts page applicant would not have any contacts when it should have one with empty fields.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1604

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Try changing your own role and try different roles and check that everything is correct in contacts page.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

#279 should to be merged before this one.
