### PR TITLE
Add fieldsets to forms to make them more helpful for screen readers

### DIFF
--- a/src/domain/forms/components/Contact.tsx
+++ b/src/domain/forms/components/Contact.tsx
@@ -4,13 +4,11 @@ import { Flex } from '@chakra-ui/react';
 import { Button, IconCross, IconPlusCircle, Tab, TabList, TabPanel, Tabs } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { useFieldArray, UseFieldArrayRemove } from 'react-hook-form';
-import Text from '../../../common/components/text/Text';
 import styles from './Contact.module.scss';
 
 interface Props<T> {
   contactType: T;
   index?: number;
-  showContactTitle?: boolean;
   onRemoveContact?: UseFieldArrayRemove;
   renderSubContact?: (subContactIndex: number, remove: UseFieldArrayRemove) => JSX.Element;
   subContactPath: string;
@@ -21,7 +19,6 @@ interface Props<T> {
 const Contact = <T extends unknown>({
   contactType,
   index,
-  showContactTitle = true,
   onRemoveContact,
   renderSubContact,
   subContactPath,
@@ -46,12 +43,7 @@ const Contact = <T extends unknown>({
 
   return (
     <>
-      <Flex justify="space-between" align="center" mb="var(--spacing-s)">
-        {showContactTitle && (
-          <Text tag="h3" styleAs="body-l" weight="bold">
-            {t(`form:yhteystiedot:titles:${contactType}`)}
-          </Text>
-        )}
+      <Flex justify="right" align="center" mb="var(--spacing-s)">
         {onRemoveContact && (
           <Button
             variant="supplementary"

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -51,7 +51,7 @@ async function setupYhteystiedotPage(jsx: JSX.Element) {
 
   await waitFor(() => expect(screen.queryByText('Perustiedot')).toBeInTheDocument());
   await renderResult.user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
-  await waitFor(() => expect(screen.queryByText(/hankkeen omistaja/i)).toBeInTheDocument());
+  await waitFor(() => expect(screen.queryByText(/hankkeen omistajan tiedot/i)).toBeInTheDocument());
 
   return renderResult;
 }
@@ -157,7 +157,7 @@ describe('HankeForm', () => {
       target: { value: 'yhteyshenkilo@mail.com' },
     });
 
-    await user.click(screen.getByText(/lisää rakennuttajia/i));
+    await user.click(screen.getByText(/Rakennuttajan tiedot/i));
     await user.click(screen.getByText(/lisää rakennuttaja/i));
     expect(screen.getAllByText('Rakennuttaja')).toHaveLength(1);
 

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -199,15 +199,20 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
       <Text tag="p" styleAs="body-m" spacingBottom="s">
         {t(`form:yhteystiedot:instructions`)}
       </Text>
-      <Text tag="h3" styleAs="h4" weight="bold" spacingBottom="xs">
-        {t(`form:yhteystiedot:titles:omistaja`)}
+      <Text tag="h3" styleAs="h3" weight="light" spacingBottom="xs">
+        {t(`form:yhteystiedot:titles:omistajaInfo`)}
       </Text>
-      <ResponsiveGrid className="formWpr">
-        {CONTACT_FIELDS.map((contactField) => {
-          const fieldName = `${FORMFIELD.OMISTAJAT}.0.${contactField}`;
-          return <ContactField key={contactField} field={contactField} fieldName={fieldName} />;
-        })}
-      </ResponsiveGrid>
+      <Fieldset
+        heading={t(`form:yhteystiedot:titles:omistaja`)}
+        style={{ paddingTop: 'var(--spacing-s)' }}
+      >
+        <ResponsiveGrid className="formWpr">
+          {CONTACT_FIELDS.map((contactField) => {
+            const fieldName = `${FORMFIELD.OMISTAJAT}.0.${contactField}`;
+            return <ContactField key={contactField} field={contactField} fieldName={fieldName} />;
+          })}
+        </ResponsiveGrid>
+      </Fieldset>
       <div className="formWpr">
         <ToggleButton
           id="erillinen-yhteyshenkilo"
@@ -251,7 +256,11 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
         </Fieldset>
       )}
 
-      <Accordion language={locale} heading={t('form:yhteystiedot:titles:lisaaRakennuttajia')}>
+      <Accordion
+        language={locale}
+        headingLevel={3}
+        heading={t('form:yhteystiedot:titles:propertyDeveloperInfo')}
+      >
         {rakennuttajat.map((item, index) => {
           return (
             <Contact<HankeContactTypeKey>
@@ -271,14 +280,19 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
                 );
               }}
             >
-              <ResponsiveGrid>
-                {CONTACT_FIELDS.map((contactField) => {
-                  const fieldName = `${FORMFIELD.RAKENNUTTAJAT}.${index}.${contactField}`;
-                  return (
-                    <ContactField key={contactField} field={contactField} fieldName={fieldName} />
-                  );
-                })}
-              </ResponsiveGrid>
+              <Fieldset
+                heading={t('form:yhteystiedot:titles:rakennuttajat')}
+                style={{ paddingTop: 'var(--spacing-s)' }}
+              >
+                <ResponsiveGrid>
+                  {CONTACT_FIELDS.map((contactField) => {
+                    const fieldName = `${FORMFIELD.RAKENNUTTAJAT}.${index}.${contactField}`;
+                    return (
+                      <ContactField key={contactField} field={contactField} fieldName={fieldName} />
+                    );
+                  })}
+                </ResponsiveGrid>
+              </Fieldset>
             </Contact>
           );
         })}
@@ -292,7 +306,11 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
         </Button>
       </Accordion>
 
-      <Accordion language={locale} heading={t('form:yhteystiedot:titles:lisaaToteuttajia')}>
+      <Accordion
+        language={locale}
+        headingLevel={3}
+        heading={t('form:yhteystiedot:titles:implementerInfo')}
+      >
         {toteuttajat.map((item, index) => {
           return (
             <Contact<HankeContactTypeKey>
@@ -312,14 +330,19 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
                 );
               }}
             >
-              <ResponsiveGrid>
-                {CONTACT_FIELDS.map((contactField) => {
-                  const fieldName = `${FORMFIELD.TOTEUTTAJAT}.${index}.${contactField}`;
-                  return (
-                    <ContactField key={contactField} field={contactField} fieldName={fieldName} />
-                  );
-                })}
-              </ResponsiveGrid>
+              <Fieldset
+                heading={t('form:yhteystiedot:titles:toteuttajat')}
+                style={{ paddingTop: 'var(--spacing-s)' }}
+              >
+                <ResponsiveGrid>
+                  {CONTACT_FIELDS.map((contactField) => {
+                    const fieldName = `${FORMFIELD.TOTEUTTAJAT}.${index}.${contactField}`;
+                    return (
+                      <ContactField key={contactField} field={contactField} fieldName={fieldName} />
+                    );
+                  })}
+                </ResponsiveGrid>
+              </Fieldset>
             </Contact>
           );
         })}
@@ -333,7 +356,11 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
         </Button>
       </Accordion>
 
-      <Accordion language={locale} heading={t('form:yhteystiedot:titles:lisaaMuitaTahoja')}>
+      <Accordion
+        language={locale}
+        headingLevel={3}
+        heading={t('form:yhteystiedot:titles:otherInfo')}
+      >
         {muutTahot.map((item, index) => {
           const fieldPath = `${FORMFIELD.MUUTTAHOT}.${index}`;
 
@@ -355,39 +382,44 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
                 );
               }}
             >
-              <ResponsiveGrid>
-                <TextInput
-                  name={`${fieldPath}.${CONTACT_FORMFIELD.ROOLI}`}
-                  label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.ROOLI}`)}
-                  required
-                  placeholder={t('form:yhteystiedot:placeholders:otherPartyRole')}
-                  helperText={t('form:yhteystiedot:helperTexts:otherPartyRole')}
-                />
-              </ResponsiveGrid>
-              <ResponsiveGrid>
-                <TextInput
-                  name={`${fieldPath}.${CONTACT_FORMFIELD.NIMI}`}
-                  label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.NIMI}`)}
-                  required
-                />
-                <TextInput
-                  name={`${fieldPath}.${CONTACT_FORMFIELD.ORGANISAATIO}`}
-                  label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.ORGANISAATIO}`)}
-                />
-                <TextInput
-                  name={`${fieldPath}.${CONTACT_FORMFIELD.OSASTO}`}
-                  label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.OSASTO}`)}
-                />
-                <TextInput
-                  name={`${fieldPath}.${CONTACT_FORMFIELD.EMAIL}`}
-                  label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.EMAIL}`)}
-                  required
-                />
-                <TextInput
-                  name={`${fieldPath}.${CONTACT_FORMFIELD.PUHELINNUMERO}`}
-                  label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.PUHELINNUMERO}`)}
-                />
-              </ResponsiveGrid>
+              <Fieldset
+                heading={t('form:yhteystiedot:titles:muut')}
+                style={{ paddingTop: 'var(--spacing-s)' }}
+              >
+                <ResponsiveGrid>
+                  <TextInput
+                    name={`${fieldPath}.${CONTACT_FORMFIELD.ROOLI}`}
+                    label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.ROOLI}`)}
+                    required
+                    placeholder={t('form:yhteystiedot:placeholders:otherPartyRole')}
+                    helperText={t('form:yhteystiedot:helperTexts:otherPartyRole')}
+                  />
+                </ResponsiveGrid>
+                <ResponsiveGrid>
+                  <TextInput
+                    name={`${fieldPath}.${CONTACT_FORMFIELD.NIMI}`}
+                    label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.NIMI}`)}
+                    required
+                  />
+                  <TextInput
+                    name={`${fieldPath}.${CONTACT_FORMFIELD.ORGANISAATIO}`}
+                    label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.ORGANISAATIO}`)}
+                  />
+                  <TextInput
+                    name={`${fieldPath}.${CONTACT_FORMFIELD.OSASTO}`}
+                    label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.OSASTO}`)}
+                  />
+                  <TextInput
+                    name={`${fieldPath}.${CONTACT_FORMFIELD.EMAIL}`}
+                    label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.EMAIL}`)}
+                    required
+                  />
+                  <TextInput
+                    name={`${fieldPath}.${CONTACT_FORMFIELD.PUHELINNUMERO}`}
+                    label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.PUHELINNUMERO}`)}
+                  />
+                </ResponsiveGrid>
+              </Fieldset>
             </Contact>
           );
         })}

--- a/src/domain/johtoselvitys/Contacts.tsx
+++ b/src/domain/johtoselvitys/Contacts.tsx
@@ -93,41 +93,46 @@ const CustomerFields: React.FC<{ customerType: CustomerType; hankeContacts?: Han
           onChange={handlePreFilledContactChange}
         />
       )}
-      <ResponsiveGrid>
-        <Dropdown
-          id={`applicationData.${customerType}.customer.type`}
-          name={`applicationData.${customerType}.customer.type`}
-          required
-          defaultValue={null}
-          label={t('form:yhteystiedot:labels:tyyppi')}
-          options={$enum(ContactType).map((value) => {
-            return {
-              value,
-              label: t(`form:yhteystiedot:contactType:${value}`),
-            };
-          })}
-        />
-        <TextInput
-          name={`applicationData.${customerType}.customer.name`}
-          label={t('form:yhteystiedot:labels:nimi')}
-          required
-        />
-        <TextInput
-          name={`applicationData.${customerType}.customer.registryKey`}
-          label={t('form:yhteystiedot:labels:ytunnus')}
-          disabled={selectedContactType !== 'COMPANY'}
-        />
-        <TextInput
-          name={`applicationData.${customerType}.customer.email`}
-          label={t('form:yhteystiedot:labels:email')}
-          required
-        />
-        <TextInput
-          name={`applicationData.${customerType}.customer.phone`}
-          label={t('form:yhteystiedot:labels:puhelinnumero')}
-          required
-        />
-      </ResponsiveGrid>
+      <Fieldset
+        heading={t(`form:yhteystiedot:titles:${customerType}`)}
+        style={{ paddingTop: 'var(--spacing-s)' }}
+      >
+        <ResponsiveGrid>
+          <Dropdown
+            id={`applicationData.${customerType}.customer.type`}
+            name={`applicationData.${customerType}.customer.type`}
+            required
+            defaultValue={null}
+            label={t('form:yhteystiedot:labels:tyyppi')}
+            options={$enum(ContactType).map((value) => {
+              return {
+                value,
+                label: t(`form:yhteystiedot:contactType:${value}`),
+              };
+            })}
+          />
+          <TextInput
+            name={`applicationData.${customerType}.customer.name`}
+            label={t('form:yhteystiedot:labels:nimi')}
+            required
+          />
+          <TextInput
+            name={`applicationData.${customerType}.customer.registryKey`}
+            label={t('form:yhteystiedot:labels:ytunnus')}
+            disabled={selectedContactType !== 'COMPANY'}
+          />
+          <TextInput
+            name={`applicationData.${customerType}.customer.email`}
+            label={t('form:yhteystiedot:labels:email')}
+            required
+          />
+          <TextInput
+            name={`applicationData.${customerType}.customer.phone`}
+            label={t('form:yhteystiedot:labels:puhelinnumero')}
+            required
+          />
+        </ResponsiveGrid>
+      </Fieldset>
     </>
   );
 };
@@ -244,14 +249,13 @@ export const Contacts: React.FC<{ hankeContacts?: HankeContacts }> = ({ hankeCon
         {t('form:requiredInstruction')}
       </Text>
 
-      <Text tag="h2" styleAs="h4" weight="bold" spacingBottom="s">
-        {t('form:yhteystiedot:titles:customerWithContacts')}
+      <Text tag="h3" styleAs="h3" weight="light" spacingBottom="s">
+        {t('form:yhteystiedot:titles:customerWithContactsInfo')}
       </Text>
 
       {/* Hakija */}
       <Contact<CustomerType>
         contactType="customerWithContacts"
-        showContactTitle={false}
         subContactPath="applicationData.customerWithContacts.contacts"
         emptySubContact={getEmptyContact()}
         renderSubContact={(subContactIndex, removeSubContact) => {
@@ -270,7 +274,8 @@ export const Contacts: React.FC<{ hankeContacts?: HankeContacts }> = ({ hankeCon
       {/* Työn suorittaja */}
       <Accordion
         language={locale}
-        heading={t('form:yhteystiedot:titles:addContractor')}
+        heading={t('form:yhteystiedot:titles:contractorInfo')}
+        headingLevel={3}
         initiallyOpen
       >
         <Contact<CustomerType>
@@ -294,7 +299,8 @@ export const Contacts: React.FC<{ hankeContacts?: HankeContacts }> = ({ hankeCon
       {/* Rakennuttaja */}
       <Accordion
         language={locale}
-        heading={t('form:yhteystiedot:titles:lisaaRakennuttaja')}
+        heading={t('form:yhteystiedot:titles:propertyDeveloperInfo')}
+        headingLevel={3}
         initiallyOpen={isPropertyDeveloper}
       >
         {isPropertyDeveloper && (
@@ -334,7 +340,8 @@ export const Contacts: React.FC<{ hankeContacts?: HankeContacts }> = ({ hankeCon
       {/* Asianhoitaja */}
       <Accordion
         language={locale}
-        heading={t('form:yhteystiedot:titles:addRepresentative')}
+        heading={t('form:yhteystiedot:titles:representativeInfo')}
+        headingLevel={3}
         initiallyOpen={isRepresentative}
       >
         {isRepresentative && (

--- a/src/domain/johtoselvitys/Geometries.tsx
+++ b/src/domain/johtoselvitys/Geometries.tsx
@@ -120,28 +120,30 @@ export const Geometries: React.FC = () => {
         {t('form:requiredInstruction')}
       </Text>
 
-      <Text tag="h2" styleAs="h4" weight="bold" spacingBottom="s">
+      <Text tag="h3" styleAs="h4" weight="bold" spacingBottom="s">
         {t('form:headers:alueet')}
       </Text>
 
-      <ResponsiveGrid>
-        <DatePicker
-          name="applicationData.startTime"
-          label={t('hakemus:labels:startDate')}
-          locale={locale}
-          required
-          helperText={t('form:helperTexts:dateInForm')}
-        />
-        <DatePicker
-          name="applicationData.endTime"
-          label={t('hakemus:labels:endDate')}
-          locale={locale}
-          required
-          minDate={minEndDate}
-          initialMonth={minEndDate}
-          helperText={t('form:helperTexts:dateInForm')}
-        />
-      </ResponsiveGrid>
+      <Fieldset heading={t('form:labels:timespan')}>
+        <ResponsiveGrid>
+          <DatePicker
+            name="applicationData.startTime"
+            label={t('hakemus:labels:startDate')}
+            locale={locale}
+            required
+            helperText={t('form:helperTexts:dateInForm')}
+          />
+          <DatePicker
+            name="applicationData.endTime"
+            label={t('hakemus:labels:endDate')}
+            locale={locale}
+            required
+            minDate={minEndDate}
+            initialMonth={minEndDate}
+            helperText={t('form:helperTexts:dateInForm')}
+          />
+        </ResponsiveGrid>
+      </Fieldset>
 
       <div className={styles.mapContainer}>
         <Map zoom={9} center={addressCoordinate} mapClassName={styles.mapContainer__inner}>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -85,7 +85,8 @@
       "fromHelsinkiProfile": "Haettu Helsinki-profiilin perusteella",
       "addressInformation": "Osoitetiedot",
       "kokonaisAla": "Alueiden kokonaispinta-ala",
-      "areaName": "Alueen nimi"
+      "areaName": "Alueen nimi",
+      "timespan": "Ajanjakso"
     },
     "helperTexts": {
       "dateInForm": "Anna muodossa P.K.VVVV",
@@ -97,17 +98,15 @@
       "instructions": "Hankkeelle lisättävät tahot saavat sähköpostiinsa linkin, jonka kautta he pystyvät liittymään hankkeeseeen Haitattomassa. Tämän jälkeen he pystyvät tarkastelemaan hanketta ja luomaan hankkeelle hakemuksia.",
       "titles": {
         "omistaja": "Hankkeen omistaja",
+        "omistajaInfo": "Hankkeen omistajan tiedot",
         "rakennuttajat": "Rakennuttaja",
         "rakennuttajatPlural": "Rakennuttajat",
         "toteuttajat": "Toteuttaja",
         "toteuttajatPlural": "Toteuttajat",
         "muut": "Muu taho",
         "muutPlural": "Muut tahot",
-        "lisaaRakennuttajia": "Lisää rakennuttajia",
         "lisaaRakennuttaja": "Lisää rakennuttaja",
-        "lisaaToteuttajia": "Lisää toteuttajia",
         "lisaaToteuttaja": "Lisää toteuttaja",
-        "lisaaMuitaTahoja": "Lisää muita tahoja",
         "lisaaMuuTaho": "Lisää muu taho",
         "subContact": "Yhteyshenkilö",
         "subContacts": "Yhteyshenkilöt",
@@ -120,7 +119,12 @@
         "representativeWithContactsPlural": "Asianhoitajat",
         "addContractor": "Lisää työn suorittaja",
         "addRepresentative": "Lisää asianhoitaja",
-        "addRepresentatives": "Lisää asianhoitajia"
+        "customerWithContactsInfo": "Hakijan tiedot",
+        "representativeInfo": "Asianhoitajan tiedot",
+        "contractorInfo": "Työn suorittajan tiedot",
+        "implementerInfo": "Toteuttajan tiedot",
+        "otherInfo": "Muiden tahojen tiedot",
+        "propertyDeveloperInfo": "Rakennuttajan tiedot"
       },
       "labels": {
         "tyyppi": "Tyyppi",


### PR DESCRIPTION
# Description

Made contact pages in forms to be more accessible by moving fields under fieldsets: 
* Moved contact information under fieldsets to be more understandable to screen reader. 
* Changed their headings and heading levels to match the changes.
* Moved date pickers in johtoselvitys also under a fieldset

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/jira/software/projects/HAI/boards/116?selectedIssue=HAI-1428

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Go over the hanke and johtoselvitys forms. The screenreader should read the headings in correct order and pronounce the fieldset heading when going over the fields.

Tested with MacOS and VoiceOver in Firefox.

# Checklist:

- [ ] I have written new tests (if applicable)
- x ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

