### PR TITLE
HAI-1625 Remove postal code and city fields from cable report application forms first page

### DIFF
--- a/src/domain/application/components/BasicInformationSummary.tsx
+++ b/src/domain/application/components/BasicInformationSummary.tsx
@@ -57,9 +57,6 @@ const BasicInformationSummary: React.FC<Props> = ({ formData, children }) => {
       <SectionItemTitle>{t('form:labels:addressInformation')}</SectionItemTitle>
       <SectionItemContent>
         <p>{postalAddress?.streetAddress.streetName}</p>
-        <p>
-          {postalAddress?.postalCode} {postalAddress?.city}
-        </p>
       </SectionItemContent>
       <SectionItemTitle>{t('hakemus:labels:tyossaKyse')}</SectionItemTitle>
       <SectionItemContent>

--- a/src/domain/johtoselvitys/BasicInfo.tsx
+++ b/src/domain/johtoselvitys/BasicInfo.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Checkbox, Select, SelectionGroup } from 'hds-react';
+import { Checkbox, Link, Select, SelectionGroup } from 'hds-react';
 import { useFormContext } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import { isEqual } from 'lodash';
@@ -177,19 +177,16 @@ export const BasicHankeInfo: React.FC = () => {
   return (
     <div>
       <div className={styles.formInstructions}>
-        <Trans i18nKey="johtoselvitysForm:perustiedot:instructions">
-          <p>
-            Huomioithan, että johtoselvitys on voimassa 1 kuukauden. Johtoselvityksen tulee olla
-            voimassa johtojen maastonäyttöjä tilattaessa sekä Johtoselvitysta tehdessä.
-            Johtoselvitys on tarvittaessa päivitettävä.
-          </p>
-          <p>
-            Yleisellä alueella tehtävästä työstä on tehtävä erillinen ilmoitus kaupungille. Mikäli
-            joudut rajoittamaan liikennettä esimerkiksi työkoneiden kuljetuksen vuoksi tai
-            poistamaan pysäköintipaikkoja kadun varresta, tulee sinun tehdä myös aluevuokraushakemus
-            liikennejärjestelysuunnitelmineen.
-          </p>
-        </Trans>
+        <Trans
+          i18nKey="johtoselvitysForm:perustiedot:instructions"
+          components={{
+            a: (
+              <Link href="https://www.hel.fi" openInNewTab>
+                hel.fi
+              </Link>
+            ),
+          }}
+        />
       </div>
 
       <Text tag="p" spacingBottom="l">
@@ -207,23 +204,12 @@ export const BasicHankeInfo: React.FC = () => {
         required
       />
 
-      <ResponsiveGrid className={styles.formRow}>
-        <TextInput
-          name="applicationData.postalAddress.streetAddress.streetName"
-          label={t('form:yhteystiedot:labels:osoite')}
-          required
-        />
-        <TextInput
-          name="applicationData.postalAddress.postalCode"
-          label={t('form:yhteystiedot:labels:postinumero')}
-          required
-        />
-        <TextInput
-          name="applicationData.postalAddress.city"
-          label={t('form:yhteystiedot:labels:postitoimipaikka')}
-          required
-        />
-      </ResponsiveGrid>
+      <TextInput
+        className={styles.formRow}
+        name="applicationData.postalAddress.streetAddress.streetName"
+        label={t('form:yhteystiedot:labels:osoite')}
+        required
+      />
 
       <SelectionGroup
         label={t('hakemus:labels:tyossaKyse')}

--- a/src/domain/johtoselvitys/Contacts.tsx
+++ b/src/domain/johtoselvitys/Contacts.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Accordion, Button, Fieldset, IconCross, IconPlusCircle } from 'hds-react';
 import { $enum } from 'ts-enum-util';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { useFormContext } from 'react-hook-form';
 import {
   ContactType,
@@ -229,22 +229,6 @@ export const Contacts: React.FC<{ hankeContacts?: HankeContacts }> = ({ hankeCon
 
   return (
     <div>
-      <div className={styles.formInstructions}>
-        <Trans i18nKey="johtoselvitysForm:yhteystiedot:instructions">
-          <p>
-            Hakemukselle lisättävät tahot saavat sähköpostiinsa linkin, jonka kautta he pystyvät
-            liittymään hakemukseen Haitattomassa. Tämän jälkeen he pystyvät tarkastelemaan
-            hakemusta. Tarvittaessa voit antaa heille laajemmat käyttöoikeudet Omat hankkeet
-            -näkymässä.
-          </p>
-          <p>
-            Hakijan yhteyshenkilö on oletuksena johtoselvityksen tilaaja. Tarvittaessa voit vaihtaa
-            jonkun muista yhteyshenkilöistä tilaajaksi. Huomioithan, että johtoselvityksen tilaaja
-            voi olla vain yksi henkilö.
-          </p>
-        </Trans>
-      </div>
-
       <Text tag="p" spacingBottom="l">
         {t('form:requiredInstruction')}
       </Text>

--- a/src/domain/johtoselvitys/Geometries.tsx
+++ b/src/domain/johtoselvitys/Geometries.tsx
@@ -125,8 +125,11 @@ export const Geometries: React.FC = () => {
 
   return (
     <div>
+      <Text tag="p" spacingBottom="m">
+        {t('johtoselvitysForm:alueet:instructions1')}
+      </Text>
       <Text tag="p" spacingBottom="s">
-        {t('johtoselvitysForm:alueet:instructions')}
+        {t('johtoselvitysForm:alueet:instructions2')}
       </Text>
       <Text tag="p" spacingBottom="m">
         {t('form:requiredInstruction')}

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -112,7 +112,7 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
           },
         ],
       },
-      postalAddress: null,
+      postalAddress: { streetAddress: { streetName: '' }, city: '', postalCode: '' },
       representativeWithContacts: null,
       invoicingCustomer: null,
       customerReference: null,

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -116,12 +116,6 @@ function fillBasicInformation() {
   fireEvent.change(screen.getAllByLabelText(/katuosoite/i)[0], {
     target: { value: 'Mannerheimintie 5' },
   });
-  fireEvent.change(screen.getAllByLabelText(/postinumero/i)[0], {
-    target: { value: '00100' },
-  });
-  fireEvent.change(screen.getAllByLabelText(/postitoimipaikka/i)[0], {
-    target: { value: 'Helsinki' },
-  });
 
   fireEvent.click(screen.getByLabelText(/uuden rakenteen tai johdon rakentamisesta/i));
 

--- a/src/domain/johtoselvitys/validationSchema.ts
+++ b/src/domain/johtoselvitys/validationSchema.ts
@@ -1,12 +1,10 @@
 import yup from '../../common/utils/yup';
 import isValidBusinessId from '../../common/utils/isValidBusinessId';
 
-const requiredAddressSchema = yup.object().shape({
+const addressSchema = yup.object().shape({
   streetAddress: yup.object().shape({
     streetName: yup.string().nullable().required(),
   }),
-  postalCode: yup.string().nullable().required(),
-  city: yup.string().nullable().required(),
 });
 
 const contactSchema = yup
@@ -46,7 +44,7 @@ const areaSchema = yup.object().shape({
 export const validationSchema = yup.object().shape({
   applicationData: yup.object().shape({
     name: yup.string().required(),
-    postalAddress: requiredAddressSchema,
+    postalAddress: addressSchema,
     workDescription: yup.string().required(),
     rockExcavation: yup.boolean().nullable().required(),
     constructionWork: yup

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -467,15 +467,8 @@
   },
   "johtoselvitysForm": {
     "pageHeader": "EN:Johtoselvityshakemus",
-    "perustiedot": {
-      "instructions": "EN:<0>Huomioithan, että johtoselvitys on voimassa 1 kuukauden. Johtoselvityksen tulee olla voimassa johtojen maastonäyttöjä tilattaessa sekä Johtoselvitysta tehdessä. Johtoselvitys on tarvittaessa päivitettävä.</0><0>Yleisellä alueella tehtävästä työstä on tehtävä erillinen ilmoitus kaupungille. Mikäli joudut rajoittamaan liikennettä esimerkiksi työkoneiden kuljetuksen vuoksi tai poistamaan pysäköintipaikkoja kadun varresta, tulee sinun tehdä myös aluevuokraushakemus liikennejärjestelysuunnitelmineen.</0>"
-    },
     "alueet": {
-      "instructions": "EN:Voit lisätä selvitettävän alueen piirtämällä sen kartalle. Voit lisätä samalle hakemukselle useampia alueita, mikäli niitä koskeva aikaväli on sama.",
       "giveDates": "EN:Valitse työn päivämäärät piirtääksesi selvitettävät alueet kartalle."
-    },
-    "yhteystiedot": {
-      "instructions": "EN:<0>Hakemukselle lisättävät tahot saavat sähköpostiinsa linkin, jonka kautta he pystyvät liittymään hakemukseen Haitattomassa. Tämän jälkeen he pystyvät tarkastelemaan hakemusta. Tarvittaessa voit antaa heille laajemmat käyttöoikeudet Omat hankkeet -näkymässä.</0><0>Hakijan yhteyshenkilö on oletuksena johtoselvityksen tilaaja. Tarvittaessa voit vaihtaa jonkun muista yhteyshenkilöistä tilaajaksi. Huomioithan, että johtoselvityksen tilaaja voi olla vain yksi henkilö.</0>"
     }
   },
   "hakemus": {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -528,17 +528,15 @@
   "johtoselvitysForm": {
     "pageHeader": "Johtoselvityshakemus",
     "perustiedot": {
-      "instructions": "<0>Huomioithan, että johtoselvitys on voimassa 1 kuukauden. Johtoselvityksen tulee olla voimassa johtojen maastonäyttöjä tilattaessa sekä Johtoselvitysta tehdessä. Johtoselvitys on tarvittaessa päivitettävä.</0><0>Yleisellä alueella tehtävästä työstä on tehtävä erillinen ilmoitus kaupungille. Mikäli joudut rajoittamaan liikennettä esimerkiksi työkoneiden kuljetuksen vuoksi tai poistamaan pysäköintipaikkoja kadun varresta, tulee sinun tehdä myös aluevuokraushakemus liikennejärjestelysuunnitelmineen.</0>"
+      "instructions": "<p>Huomioithan, että johtoselvitys on voimassa 1 kuukauden. Johtoselvityksen tulee olla voimassa johtojen maastonäyttöjä tilattaessa sekä kaivuilmoitusta tehdessä. Johtoselvitys on tarvittaessa päivitettävä.</p><p>Yleisellä alueella tehtävästä työstä on tehtävä erillinen ilmoitus kaupungille. Katso tarkemmat ohjeet: <a>hel.fi</a></p>"
     },
     "alueet": {
-      "instructions": "Voit lisätä selvitettävän alueen piirtämällä sen kartalle. Voit lisätä samalle hakemukselle useampia alueita, mikäli niitä koskeva aikaväli on sama.",
+      "instructions1": "Aloita selvitettävän alueen piirtäminen lisäämällä työn alku- ja loppupäivämäärät, jolloin piirtotyökalut ilmestyvät kartan vasempaan alanurkkaan. Tämän jälkeen voit piirtää selvitettävät alueet kartalle. Voit lisätä samalle hakemukselle useampia alueita, mikäli niitä koskeva aikaväli on sama.",
+      "instructions2": "Piirtämäsi alueet näkyvät listana kartan alapuolella. Listasta pääset myös poistamaan alueita.",
       "giveDates": "Valitse työn päivämäärät piirtääksesi selvitettävät alueet kartalle."
     },
-    "yhteystiedot": {
-      "instructions": "<0>Hakemukselle lisättävät tahot saavat sähköpostiinsa linkin, jonka kautta he pystyvät liittymään hakemukseen Haitattomassa. Tämän jälkeen he pystyvät tarkastelemaan hakemusta. Tarvittaessa voit antaa heille laajemmat käyttöoikeudet Omat hankkeet -näkymässä.</0><0>Hakijan yhteyshenkilö on oletuksena johtoselvityksen tilaaja. Tarvittaessa voit vaihtaa jonkun muista yhteyshenkilöistä tilaajaksi. Huomioithan, että johtoselvityksen tilaaja voi olla vain yksi henkilö.</0>"
-    },
     "liitteet": {
-      "instructions": "Lisää hakemukselle liitteet, kuten työsuunnitelma."
+      "instructions": "Lisää hakemukselle liitteet, kuten työsuunnitelma. Liitteet tallentuvat lomakkeelle sivun alaosan sivunvaihto- ja tallennuspainikkeista."
     }
   },
   "hakemus": {

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -467,15 +467,8 @@
   },
   "johtoselvitysForm": {
     "pageHeader": "SV:Johtoselvityshakemus",
-    "perustiedot": {
-      "instructions": "SV:<0>Huomioithan, että johtoselvitys on voimassa 1 kuukauden. Johtoselvityksen tulee olla voimassa johtojen maastonäyttöjä tilattaessa sekä Johtoselvitysta tehdessä. Johtoselvitys on tarvittaessa päivitettävä.</0><0>Yleisellä alueella tehtävästä työstä on tehtävä erillinen ilmoitus kaupungille. Mikäli joudut rajoittamaan liikennettä esimerkiksi työkoneiden kuljetuksen vuoksi tai poistamaan pysäköintipaikkoja kadun varresta, tulee sinun tehdä myös aluevuokraushakemus liikennejärjestelysuunnitelmineen.</0>"
-    },
     "alueet": {
-      "instructions": "SV:Voit lisätä selvitettävän alueen piirtämällä sen kartalle. Voit lisätä samalle hakemukselle useampia alueita, mikäli niitä koskeva aikaväli on sama.",
       "giveDates": "SV:Valitse työn päivämäärät piirtääksesi selvitettävät alueet kartalle."
-    },
-    "yhteystiedot": {
-      "instructions": "SV:<0>Hakemukselle lisättävät tahot saavat sähköpostiinsa linkin, jonka kautta he pystyvät liittymään hakemukseen Haitattomassa. Tämän jälkeen he pystyvät tarkastelemaan hakemusta. Tarvittaessa voit antaa heille laajemmat käyttöoikeudet Omat hankkeet -näkymässä.</0><0>Hakijan yhteyshenkilö on oletuksena johtoselvityksen tilaaja. Tarvittaessa voit vaihtaa jonkun muista yhteyshenkilöistä tilaajaksi. Huomioithan, että johtoselvityksen tilaaja voi olla vain yksi henkilö.</0>"
     }
   },
   "hakemus": {


### PR DESCRIPTION
# Description

Made modifications to cable report application form by removing postal code and city fields from basic information page. Also updated instruction texts in basic information, areas, and contacts pages.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1625

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Make sure that postal code and city fields have been removed from basic information page and that form can be filled and saved.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
