### PR TITLE
HAI-1629 Fix address search showing swedish results when searching in finnish

### DIFF
--- a/src/domain/map/components/AddressSearch/AddressSearch.test.tsx
+++ b/src/domain/map/components/AddressSearch/AddressSearch.test.tsx
@@ -59,3 +59,30 @@ test('Finnish address labels are returned when search term is incomplete and can
   expect(screen.getByText('Elielinaukio 3')).toBeInTheDocument();
   expect(screen.getByText('Elielinaukio 5')).toBeInTheDocument();
 });
+
+test('Finnish address labels are returned when search term is in Finnish and has trailing white space', async () => {
+  const handleAddressSelect = jest.fn();
+  const { user } = render(<AddressSearch onAddressSelect={handleAddressSelect} />);
+
+  const searchInput = screen.getByPlaceholderText('Etsi osoitteella');
+  user.type(searchInput, 'elielinaukio ');
+
+  await waitFor(() => screen.getByText('Elielinaukio 1'));
+
+  expect(screen.getByText('Elielinaukio 1')).toBeInTheDocument();
+  expect(screen.getByText('Elielinaukio 2')).toBeInTheDocument();
+  expect(screen.getByText('Elielinaukio 3')).toBeInTheDocument();
+  expect(screen.getByText('Elielinaukio 5')).toBeInTheDocument();
+});
+
+test('Finnish address label is returned when search term is in Finnish and has street number after street name', async () => {
+  const handleAddressSelect = jest.fn();
+  const { user } = render(<AddressSearch onAddressSelect={handleAddressSelect} />);
+
+  const searchInput = screen.getByPlaceholderText('Etsi osoitteella');
+  user.type(searchInput, 'Elielinaukio 3');
+
+  await waitFor(() => screen.getByText('Elielinaukio 3'));
+
+  expect(screen.getByText('Elielinaukio 3')).toBeInTheDocument();
+});

--- a/src/domain/map/components/AddressSearch/AddressSearch.tsx
+++ b/src/domain/map/components/AddressSearch/AddressSearch.tsx
@@ -3,7 +3,7 @@ import { SearchInput } from 'hds-react';
 import { uniqBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Coordinate } from 'ol/coordinate';
-import { doAddressSearch } from '../../utils';
+import { doAddressSearch, getStreetName } from '../../utils';
 
 type Props = {
   onAddressSelect: (coordinate: Coordinate | undefined) => void;
@@ -30,7 +30,8 @@ const AddressSearch: React.FC<Props> = ({ onAddressSelect }) => {
       const suggestionItems: Address[] = data.features.map((feature: any) => {
         // Use Finnish street name as a label if it seems that user was searching for that,
         // otherwise use Swedish street name
-        let label = feature.properties.katunimi.toLowerCase().includes(searchValue.toLowerCase())
+        const searchedStreetName = getStreetName(searchValue).toLowerCase();
+        let label = feature.properties.katunimi.toLowerCase().includes(searchedStreetName)
           ? feature.properties.katunimi
           : feature.properties.gatan;
 

--- a/src/domain/map/utils.ts
+++ b/src/domain/map/utils.ts
@@ -104,7 +104,7 @@ export const byAllHankeFilters = (hankeFilters: HankeFilters) => (hanke: HankeDa
   hankeHasGeometry(hanke) &&
   hankeIsBetweenDates(hankeFilters)({ startDate: hanke.alkuPvm, endDate: hanke.loppuPvm });
 
-function getStreetName(input: string) {
+export function getStreetName(input: string) {
   const matches = input.match(/^\D+/);
   if (matches) {
     return matches[0].trimEnd();


### PR DESCRIPTION
# Description

Fixed a problem where address search showed results in swedish when typing a finnish search term with trailing whitespace or street number after street name.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1629

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
