### PR TITLE
HAI-1347: Update English aria labels to translated ones.

### DIFF
--- a/src/domain/homepage/HomepageComponent.tsx
+++ b/src/domain/homepage/HomepageComponent.tsx
@@ -155,7 +155,7 @@ const Homepage: React.FC = () => {
           {isAuthenticated && feedbackOpen && (
             <div className={styles.feedbackInfo}>
               <Notification
-                label="Auta meitä tekemään Haitattomasta vielä parempi!"
+                label={t('homepage:notification:heading')}
                 type="info"
                 notificationAriaLabel={t('common:components:notification:notification')}
                 autoClose={false}
@@ -164,7 +164,7 @@ const Homepage: React.FC = () => {
                 onClose={() => setFeedbackOpen(false)}
               >
                 <p>
-                  Ideoita ja havaintoja voit lähettää osoitteeseen
+                  {t('homepage:notification:text')}
                   <Link href="mailto:haitaton@hel.fi">haitaton@hel.fi</Link>
                 </p>
               </Notification>

--- a/src/domain/homepage/HomepageComponent.tsx
+++ b/src/domain/homepage/HomepageComponent.tsx
@@ -157,9 +157,10 @@ const Homepage: React.FC = () => {
               <Notification
                 label="Auta meitä tekemään Haitattomasta vielä parempi!"
                 type="info"
+                notificationAriaLabel={t('common:components:notification:notification')}
                 autoClose={false}
                 dismissible
-                closeButtonLabelText="Close"
+                closeButtonLabelText={`${t('common:components:notification:closeButtonLabelText')}`}
                 onClose={() => setFeedbackOpen(false)}
               >
                 <p>
@@ -182,7 +183,9 @@ const Homepage: React.FC = () => {
               return (
                 <div className={styles.linkboxContainer} key={item.key}>
                   <Linkbox
-                    linkboxAriaLabel={`Linkbox: ${t(`homepage:${item.key}:actionText`)}`}
+                    linkboxAriaLabel={`${t('common:components:linkbox:linkbox')}: ${t(
+                      `homepage:${item.key}:actionText`
+                    )}`}
                     linkAriaLabel={t(`homepage:${item.key}:actionText`)}
                     href={item.actionLink}
                     heading={t(`homepage:${item.key}:title`)}

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -655,6 +655,10 @@
     "pageSubTitle": "Palvelu yleisille alueille sijoittuvien hankkeiden ja niiden haittojen seurantaan",
     "info": "Haitaton-palvelussa pääset tutustumaan kaikkiin yleisillä alueilla käynnissä oleviin ja tuleviin hankkeisiin sekä antamaan niille palautetta. Voit tarkastella hankkeita kartalla tai listalla. Oletko perustamassa hanketta tai tekemässä hakemuksia?",
     "info_link": "Siirry Haitaton-asiointiin",
+    "notification": {
+      "heading": "Auta meitä tekemään Haitattomasta vielä parempi!",
+      "text": "Ideoita ja havaintoja voit lähettää osoitteeseen"
+    },
     "hanke": {
       "title": "Luo uusi hanke",
       "description": "Luomalla Haitaton-hankkeen pystyt suunnittelemaan etukäteen yleisellä alueella tapahtuvaa työtä sekä tekemään hakemuksia, kuten johtoselvityksiä.",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -20,6 +20,9 @@
       "confirmButton": "Vahvista"
     },
     "components": {
+      "linkbox": {
+        "linkbox": "Linkkialue"
+      },
       "multiselect": {
         "toggle": "Sulje ja avaa valikko",
         "removeSelected": "Poista valittu",
@@ -33,6 +36,7 @@
         "skipToContentLabel": "Siirry pääsisältöön"
       },
       "notification": {
+        "notification": "Ilmoitus",
         "closeButtonLabelText": "Sulje ilmoitus"
       },
       "errorLoadingInfo": {


### PR DESCRIPTION
# Description

Update English aria labels to translated ones. Add couple of missing translation from the home page notification area as well.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1437

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Check with screenreader that the labels on the notification and linkboxes on the homepage are read on correct language.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

