### PR TITLE
HAI-1404 Show error if area is self-intersecting in cable report application

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@reduxjs/toolkit": "^1.5.0",
     "@sentry/react": "^6.2.0",
     "@sentry/tracing": "^6.2.0",
+    "@turf/helpers": "^6.5.0",
+    "@turf/unkink-polygon": "^6.5.0",
     "@types/cypress-axe": "^0.8.0",
     "@types/geojson": "^7946.0.7",
     "@types/jest": "^24.0.0",

--- a/src/common/components/map/modules/draw/DrawModule.tsx
+++ b/src/common/components/map/modules/draw/DrawModule.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
 import { Vector as VectorSource } from 'ol/source';
+import { Feature } from 'ol';
+import Geometry from 'ol/geom/Geometry';
 import DrawControl from './DrawControl';
 import DrawIntercation from './DrawInteraction';
 import DrawProvider from './DrawProvider';
 
 type Props = {
   source: VectorSource;
+  /**
+   * Function that is called when drawing or modifying ends or when feature is removed from source.
+   * It is called with the self-intersecting polygon or null if there is no self-intersection.
+   */
+  onSelfIntersectingPolygon?: (feature: Feature<Geometry> | null) => void;
 };
 
-const DrawModule: React.FC<Props> = ({ source }) => (
+const DrawModule: React.FC<Props> = ({ source, onSelfIntersectingPolygon }) => (
   <DrawProvider source={source}>
-    <DrawIntercation />
+    <DrawIntercation onSelfIntersectingPolygon={onSelfIntersectingPolygon} />
     <DrawControl />
   </DrawProvider>
 );

--- a/src/common/components/map/utils.ts
+++ b/src/common/components/map/utils.ts
@@ -3,6 +3,9 @@ import { register } from 'ol/proj/proj4';
 import { get as getProjection } from 'ol/proj';
 import { getArea } from 'ol/sphere';
 import Geometry from 'ol/geom/Geometry';
+import Polygon from 'ol/geom/Polygon';
+import { polygon } from '@turf/helpers';
+import unkinkPolygon from '@turf/unkink-polygon';
 
 // https://dev.hel.fi/maps
 proj4.defs(
@@ -16,4 +19,17 @@ projection.setExtent([25440000, 6630000, 25571072, 6761072]);
 
 export function getSurfaceArea(geometry: Geometry) {
   return getArea(geometry, { projection });
+}
+
+/**
+ * Check if polygon is self-intersecting
+ */
+export function isPolygonSelfIntersecting(polygonToCheck: Polygon): boolean {
+  try {
+    const turfPolygon = polygon(polygonToCheck.getCoordinates());
+    const unkinkedPolygon = unkinkPolygon(turfPolygon);
+    return unkinkedPolygon.features.length > 1;
+  } catch (error) {
+    return false;
+  }
 }

--- a/src/domain/johtoselvitys/Geometries.tsx
+++ b/src/domain/johtoselvitys/Geometries.tsx
@@ -41,6 +41,16 @@ import { ApplicationGeometry } from '../application/types/application';
 import useForceUpdate from '../../common/hooks/useForceUpdate';
 import { getAreaDefaultName } from '../application/utils';
 
+function ErrorText({ children }: { children: string }) {
+  return (
+    <Box px="var(--spacing-l)" pb="var(--spacing-xl)" textAlign="center" color="var(--color-error)">
+      <Text tag="p">
+        <IconAlertCircleFill /> {children}
+      </Text>
+    </Box>
+  );
+}
+
 function getEmptyArea(feature: Feature<Geometry>): JohtoselvitysArea {
   return {
     name: '',
@@ -123,6 +133,14 @@ export const Geometries: React.FC = () => {
     }
   }
 
+  function handleSelfIntersectingPolygon(feature: Feature<Geometry> | null) {
+    if (feature) {
+      setValue('selfIntersectingPolygon', true, { shouldValidate: true });
+    } else {
+      setValue('selfIntersectingPolygon', false, { shouldValidate: true });
+    }
+  }
+
   return (
     <div>
       <Text tag="p" spacingBottom="s">
@@ -169,7 +187,14 @@ export const Geometries: React.FC = () => {
 
           <OverviewMapControl />
 
-          <Controls>{workTimesSet && <DrawModule source={drawSource} />}</Controls>
+          <Controls>
+            {workTimesSet && (
+              <DrawModule
+                source={drawSource}
+                onSelfIntersectingPolygon={handleSelfIntersectingPolygon}
+              />
+            )}
+          </Controls>
         </Map>
       </div>
 
@@ -179,17 +204,10 @@ export const Geometries: React.FC = () => {
         </Box>
       )}
 
-      {errors.applicationData?.areas && (
-        <Box
-          px="var(--spacing-l)"
-          pb="var(--spacing-xl)"
-          textAlign="center"
-          color="var(--color-error)"
-        >
-          <Text tag="p">
-            <IconAlertCircleFill /> {t('form:errors:areaRequired')}
-          </Text>
-        </Box>
+      {errors.applicationData?.areas && <ErrorText>{t('form:errors:areaRequired')}</ErrorText>}
+
+      {errors.selfIntersectingPolygon && (
+        <ErrorText>{t('form:errors:selfIntersectingArea')}</ErrorText>
       )}
 
       <Tabs>

--- a/src/domain/johtoselvitys/Geometries.tsx
+++ b/src/domain/johtoselvitys/Geometries.tsx
@@ -6,7 +6,7 @@ import Geometry from 'ol/geom/Geometry';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Box, Flex } from '@chakra-ui/react';
-import { Button, Fieldset, IconAlertCircleFill, IconCross } from 'hds-react';
+import { Button, Fieldset, IconAlertCircleFill, IconCross, Notification } from 'hds-react';
 import { debounce } from 'lodash';
 
 import VectorLayer from '../../common/components/map/layers/VectorLayer';
@@ -124,6 +124,8 @@ export const Geometries: React.FC = () => {
 
   const [areaToRemove, setAreaToRemove] = useState<AreaToRemove | null>(null);
 
+  const [showSelfIntersectingNotification, setShowSelfIntersectingNotification] = useState(false);
+
   function removeArea(index: number, areaFeature?: Feature<Geometry>) {
     if (areaFeature !== undefined) {
       setAreaToRemove({ index, areaFeature });
@@ -145,9 +147,11 @@ export const Geometries: React.FC = () => {
 
   function handleSelfIntersectingPolygon(feature: Feature<Geometry> | null) {
     if (feature) {
-      setValue('selfIntersectingPolygon', true, { shouldValidate: true });
+      setValue('selfIntersectingPolygon', true);
+      setShowSelfIntersectingNotification(true);
     } else {
       setValue('selfIntersectingPolygon', false, { shouldValidate: true });
+      setShowSelfIntersectingNotification(false);
     }
   }
 
@@ -225,6 +229,19 @@ export const Geometries: React.FC = () => {
       )}
 
       {errors.applicationData?.areas && <ErrorText>{t('form:errors:areaRequired')}</ErrorText>}
+
+      {showSelfIntersectingNotification && !errors.selfIntersectingPolygon && (
+        <Notification
+          type="error"
+          label={t('form:errors:selfIntersectingArea')}
+          notificationAriaLabel={t('common:components:notification:notification')}
+          autoClose={false}
+          dismissible
+          closeButtonLabelText={`${t('common:components:notification:closeButtonLabelText')}`}
+          onClose={() => setShowSelfIntersectingNotification(false)}
+          style={{ marginBottom: 'var(--spacing-s)' }}
+        />
+      )}
 
       {errors.selfIntersectingPolygon && (
         <ErrorText>{t('form:errors:selfIntersectingArea')}</ErrorText>

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -299,7 +299,12 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
         'applicationData.constructionWork',
       ],
       // Areas page
-      ['applicationData.startTime', 'applicationData.endTime', 'applicationData.areas'],
+      [
+        'applicationData.startTime',
+        'applicationData.endTime',
+        'applicationData.areas',
+        'selfIntersectingPolygon',
+      ],
       // Contacts page
       [
         'applicationData.customerWithContacts',

--- a/src/domain/johtoselvitys/types.ts
+++ b/src/domain/johtoselvitys/types.ts
@@ -13,4 +13,5 @@ export interface JohtoselvitysFormData extends JohtoselvitysData {
 export interface JohtoselvitysFormValues extends Application {
   applicationData: JohtoselvitysFormData;
   geometriesChanged?: boolean; // virtualField
+  selfIntersectingPolygon?: boolean; // virtualField
 }

--- a/src/domain/johtoselvitys/utils.ts
+++ b/src/domain/johtoselvitys/utils.ts
@@ -48,6 +48,9 @@ export function getAreaGeometries(areas: JohtoselvitysArea[]) {
 export function convertFormStateToApplicationData(formState: JohtoselvitysFormValues): Application {
   // eslint-disable-next-line no-param-reassign
   delete formState.geometriesChanged;
+  // eslint-disable-next-line no-param-reassign
+  delete formState.selfIntersectingPolygon;
+
   const data: Application = cloneDeep(formState);
 
   const updatedAreas: ApplicationArea[] = formState.applicationData.areas.map(

--- a/src/domain/johtoselvitys/validationSchema.ts
+++ b/src/domain/johtoselvitys/validationSchema.ts
@@ -66,4 +66,5 @@ export const validationSchema = yup.object().shape({
     endTime: yup.date().nullable().required(),
     areas: yup.array(areaSchema).min(1),
   }),
+  selfIntersectingPolygon: yup.boolean().isFalse(),
 });

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -69,7 +69,8 @@
     },
     "errors": {
       "areaRequired": "Vähintään yksi alue vaaditaan",
-      "fileLoadError": "Tiedoston latauksessa tapahtui virhe"
+      "fileLoadError": "Tiedoston latauksessa tapahtui virhe",
+      "selfIntersectingArea": "Alueen reunat eivät saa leikata toisiaan"
     },
     "headers": {
       "perustiedot": "Perustiedot",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3440,6 +3440,52 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@turf/area@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/area/-/area-6.5.0.tgz#1d0d7aee01d8a4a3d4c91663ed35cc615f36ad56"
+  integrity sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+
+"@turf/boolean-point-in-polygon@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz#6d2e9c89de4cd2e4365004c1e51490b7795a63cf"
+  integrity sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/helpers@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.5.0.tgz#f79af094bd6b8ce7ed2bd3e089a8493ee6cae82e"
+  integrity sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==
+
+"@turf/invariant@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.5.0.tgz#970afc988023e39c7ccab2341bd06979ddc7463f"
+  integrity sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/meta@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.5.0.tgz#b725c3653c9f432133eaa04d3421f7e51e0418ca"
+  integrity sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/unkink-polygon@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/unkink-polygon/-/unkink-polygon-6.5.0.tgz#9e54186dcce08d7e62f608c8fa2d3f0342ebe826"
+  integrity sha512-8QswkzC0UqKmN1DT6HpA9upfa1HdAA5n6bbuzHy8NJOX8oVizVAqfEPY0wqqTgboDjmBR4yyImsdPGUl3gZ8JQ==
+  dependencies:
+    "@turf/area" "^6.5.0"
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    rbush "^2.0.1"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -14120,6 +14166,11 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
+quickselect@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-1.1.1.tgz#852e412ce418f237ad5b660d70cffac647ae94c2"
+  integrity sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==
+
 quickselect@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-2.0.0.tgz#f19680a486a5eefb581303e023e98faaf25dd018"
@@ -14176,6 +14227,13 @@ raw-body@^2.3.3:
     http-errors "1.7.3"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+rbush@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/rbush/-/rbush-2.0.2.tgz#bb6005c2731b7ba1d5a9a035772927d16a614605"
+  integrity sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==
+  dependencies:
+    quickselect "^1.0.1"
 
 rbush@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
# Description

When user draws or modifies work area in cable report application form, it is checked if the area is self-intersecting and if it is, an error is displayed. Also user can not move forward in the form in that case.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1404

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

In cable report application form draw new area or modify existing area so that it's self-intersecting. Check that there is an error text and that it's not possible to move to next page.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
