### PR TITLE
Make hanke list cards expand button focusable

### DIFF
--- a/src/domain/hanke/portfolio/HankePortfolio.module.scss
+++ b/src/domain/hanke/portfolio/HankePortfolio.module.scss
@@ -54,6 +54,10 @@
       .iconWrapper {
         flex-grow: 0;
       }
+
+      .iconWrapper:focus {
+        outline: 2px solid var(--color-coat-of-arms);
+      }
     }
 
     .draftNotification {

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -67,7 +67,7 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke }) => {
   }
 
   return (
-    <Card className={styles.hankeCard} border>
+    <Card className={styles.hankeCard} aria-label={hanke.nimi} border>
       <>
         <div
           className={clsx([styles.hankeCardHeader, styles.hankeCardFlexContainer])}
@@ -120,7 +120,9 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke }) => {
               <IconPen aria-hidden />
             </Link>
           </div>
-          <div className={styles.iconWrapper}>{icon}</div>
+          <button type="button" className={styles.iconWrapper}>
+            {icon}
+          </button>
         </div>
         <HankeDraftStateNotification hanke={hanke} className={styles.draftNotification} />
       </>


### PR DESCRIPTION
# Description

Make hanke list cards expand button focusable for it to be more accessible to keyboard user.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1420

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Go to hanke portfolio. Scroll though elements with tab key.. The hanke card expand button should be focusable.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

