### PR TITLE
HAI-1667 Remove unsupported filetypes

### DIFF
--- a/src/domain/johtoselvitys/Attachments.tsx
+++ b/src/domain/johtoselvitys/Attachments.tsx
@@ -91,7 +91,7 @@ function Attachments({
 
       <FileInput
         id="cable-report-file-input"
-        accept=".pdf,.jpg,.jpeg,.png,.dgn,.dwg,.docx,.txt,.gt"
+        accept=".pdf,.jpg,.jpeg,.png,.docx,.txt"
         label={t('form:labels:dragAttachments')}
         dragAndDropLabel={t('form:labels:dragAttachments')}
         language={locale}


### PR DESCRIPTION
# Description

Remove .gt, .dgn and .dwg files from supported types.

<img width="906" alt="image" src="https://github.com/City-of-Helsinki/haitaton-ui/assets/78962935/585bfd83-0543-4850-97c6-464d429cd9c9">



### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1667

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
