### PR TITLE
HAI-1632 Fix attachments not uploaded when creating new cable report application

### DIFF
--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -48,9 +48,6 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
   const { setNotification } = useGlobalNotification();
   const { showSendSuccess, showSendError } = useApplicationSendNotification();
   const queryClient = useQueryClient();
-  const { data: existingAttachments, isError: attachmentsLoadError } = useAttachments(
-    application?.id
-  );
   const [newAttachments, setNewAttachments] = useState<File[]>([]);
   const [attachmentUploadErrors, setAttachmentUploadErrors] = useState<JSX.Element[]>([]);
 
@@ -150,6 +147,10 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
   if (generatedHanke) {
     hanke = generatedHanke;
   }
+
+  const { data: existingAttachments, isError: attachmentsLoadError } = useAttachments(
+    getValues('id')
+  );
 
   const navigateToApplicationList = useNavigateToApplicationList(hanke?.hankeTunnus);
 
@@ -257,14 +258,15 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
   }
 
   async function saveAttachments() {
-    if (!application) {
+    const applicationId = getValues('id');
+
+    if (!applicationId) {
       return Promise.resolve();
     }
 
     const mutations = newAttachments.map((file) =>
       attachmentUploadMutation.mutateAsync({
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        applicationId: application.id!,
+        applicationId,
         attachmentType: 'MUU',
         file,
       })


### PR DESCRIPTION
# Description

Fixed problem where attachments could not be uploaded while creating new cable report application.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1632

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Create new cable report application, fill the form and add attachments and check in the summary page that attachments have been added.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
