### PR TITLE
Add useSelectable hooks to Contact tabs so that tabs stay open upon r…

### DIFF
--- a/src/domain/forms/components/Contact.tsx
+++ b/src/domain/forms/components/Contact.tsx
@@ -5,6 +5,7 @@ import { Button, IconCross, IconPlusCircle, Tab, TabList, TabPanel, Tabs } from 
 import { useTranslation } from 'react-i18next';
 import { useFieldArray, UseFieldArrayRemove } from 'react-hook-form';
 import styles from './Contact.module.scss';
+import useSelectableTabs from '../../../common/hooks/useSelectableTabs';
 
 interface Props<T> {
   contactType: T;
@@ -40,6 +41,7 @@ const Contact = <T extends unknown>({
   }
 
   const renderSubContacts = subContactFields.length > 0 && renderSubContact;
+  const { tabRefs } = useSelectableTabs(subContactFields.length, { selectLastTabOnChange: true });
 
   return (
     <>
@@ -63,8 +65,13 @@ const Contact = <T extends unknown>({
             {subContactFields.map((subContact, subContactIndex) => {
               return (
                 <Tab key={subContact.id}>
-                  {t('hankePortfolio:labels:yhteyshenkilo')}{' '}
-                  {subContactIndex > 0 && subContactIndex + 1}
+                  <div
+                    data-testid={`${contactType}-${subContactIndex}`}
+                    ref={tabRefs[subContactIndex]}
+                  >
+                    {t('hankePortfolio:labels:yhteyshenkilo')}{' '}
+                    {subContactIndex > 0 && subContactIndex + 1}
+                  </div>
                 </Tab>
               );
             })}

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -423,6 +423,7 @@ test('Should change users own role and its fields correctly', async () => {
     target: { value: phone },
   });
   await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+  await user.click(screen.getByTestId('contractorWithContacts-0'));
 
   expect(
     screen.getByTestId('applicationData.customerWithContacts.contacts.0.firstName')


### PR DESCRIPTION
# Description

Add useSelectable hooks to Contact tabs so that tabs stay open upon removing the last tab

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1588

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Go to johtoselvitys form yhteystiedot step. Add multiple sub contacts to a contact. Remove the last subcontact. The next subcontact tab should stay open.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
