### PR TITLE
HAI-1704 Add validation to application area dates

### DIFF
--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -14,6 +14,11 @@ afterEach(cleanup);
 
 jest.setTimeout(40000);
 
+interface DateOptions {
+  start?: string;
+  end?: string;
+}
+
 const application: JohtoselvitysFormValues = {
   id: null,
   alluStatus: null,
@@ -138,12 +143,14 @@ function fillBasicInformation() {
   });
 }
 
-function fillAreasInformation() {
+function fillAreasInformation(options: DateOptions = {}) {
+  const { start = '1.4.2024', end = '1.6.2024' } = options;
+
   fireEvent.change(screen.getByLabelText(/työn arvioitu alkupäivä/i), {
-    target: { value: '1.4.2024' },
+    target: { value: start },
   });
   fireEvent.change(screen.getByLabelText(/työn arvioitu loppupäivä/i), {
-    target: { value: '1.6.2024' },
+    target: { value: end },
   });
 }
 
@@ -466,4 +473,35 @@ test('Should show send button when application is edited in draft state', async 
   await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
 
   expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).toBeInTheDocument();
+});
+
+test('Should not allow start date be after end date', async () => {
+  const hankeData = hankkeet[1] as HankeData;
+
+  const { user } = render(
+    <JohtoselvitysContainer hankeData={hankeData} application={application} />
+  );
+
+  expect(
+    screen.queryByText('Aidasmäentien vesihuollon rakentaminen (HAI22-2)')
+  ).toBeInTheDocument();
+
+  // Fill basic information page
+  fillBasicInformation();
+
+  // Move to areas page
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+  expect(screen.queryByText(/hakemus tallennettu/i)).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /sulje ilmoitus/i }));
+
+  expect(screen.queryByText('Vaihe 2/5: Alueet')).toBeInTheDocument();
+
+  // Fill areas page with start time after end time
+  fillAreasInformation({ start: '1.6.2024', end: '1.4.2024' });
+
+  // Should not be able to move to next page
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+  expect(screen.queryByText('Vaihe 2/5: Alueet')).toBeInTheDocument();
 });

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -477,24 +477,15 @@ test('Should show send button when application is edited in draft state', async 
 
 test('Should not allow start date be after end date', async () => {
   const hankeData = hankkeet[1] as HankeData;
-
   const { user } = render(
     <JohtoselvitysContainer hankeData={hankeData} application={application} />
   );
-
-  expect(
-    screen.queryByText('Aidasmäentien vesihuollon rakentaminen (HAI22-2)')
-  ).toBeInTheDocument();
 
   // Fill basic information page
   fillBasicInformation();
 
   // Move to areas page
   await user.click(screen.getByRole('button', { name: /seuraava/i }));
-
-  expect(screen.queryByText(/hakemus tallennettu/i)).toBeInTheDocument();
-  fireEvent.click(screen.getByRole('button', { name: /sulje ilmoitus/i }));
-
   expect(screen.queryByText('Vaihe 2/5: Alueet')).toBeInTheDocument();
 
   // Fill areas page with start time after end time
@@ -502,6 +493,5 @@ test('Should not allow start date be after end date', async () => {
 
   // Should not be able to move to next page
   await user.click(screen.getByRole('button', { name: /seuraava/i }));
-
   expect(screen.queryByText('Vaihe 2/5: Alueet')).toBeInTheDocument();
 });

--- a/src/domain/johtoselvitys/validationSchema.ts
+++ b/src/domain/johtoselvitys/validationSchema.ts
@@ -61,7 +61,17 @@ export const validationSchema = yup.object().shape({
     propertyDeveloperWithContacts: customerWithContactsSchema.nullable(),
     representativeWithContacts: customerWithContactsSchema.nullable(),
     startTime: yup.date().nullable().required(),
-    endTime: yup.date().nullable().required(),
+    endTime: yup
+      .date()
+      .when('startTime', (startTime: Date, schema: yup.DateSchema) => {
+        try {
+          return startTime ? schema.min(startTime) : schema;
+        } catch (error) {
+          return schema;
+        }
+      })
+      .nullable()
+      .required(),
     areas: yup.array(areaSchema).min(1),
   }),
   selfIntersectingPolygon: yup.boolean().isFalse(),


### PR DESCRIPTION
# Description

Prevent startTime to be after endTime.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1704

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Trying to set wrong dates will not allow moving on to next page. Instead a warning is shown.

<img width="878" alt="image" src="https://github.com/City-of-Helsinki/haitaton-ui/assets/78962935/b7ab7d43-e5f7-4eb8-8223-bc02cc1b0d2f">

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
