### PR TITLE
Add loading spinner for fetching the file download link

### DIFF
--- a/src/common/components/fileDownloadLink/FileDownloadLink.tsx
+++ b/src/common/components/fileDownloadLink/FileDownloadLink.tsx
@@ -1,4 +1,5 @@
-import { Link, Notification } from 'hds-react';
+import { Box } from '@chakra-ui/react';
+import { Link, LoadingSpinner, Notification } from 'hds-react';
 import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { QueryFunction, QueryKey, useQueryClient } from 'react-query';
@@ -18,6 +19,7 @@ function FileDownloadLink({ linkText, fileName, queryKey, queryFunction, linkIco
   const [fileUrl, setFileUrl] = useState('');
   const linkRef = useRef<HTMLAnchorElement>(null);
   const [errorText, setErrorText] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
   async function fetchFile(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
     setErrorText(null);
@@ -26,14 +28,17 @@ function FileDownloadLink({ linkText, fileName, queryKey, queryFunction, linkIco
       setFileUrl(cachedUrl);
     } else {
       event.preventDefault();
+      setLoading(true);
       try {
         const url = await queryClient.fetchQuery(queryKey, queryFunction, {
           staleTime: Infinity,
           cacheTime: Infinity,
         });
         setFileUrl(url);
+        setLoading(false);
         linkRef.current?.click();
       } catch (error) {
+        setLoading(false);
         setErrorText(t('common:error'));
       }
     }
@@ -41,6 +46,14 @@ function FileDownloadLink({ linkText, fileName, queryKey, queryFunction, linkIco
 
   function closeErrorNotification() {
     setErrorText(null);
+  }
+
+  if (loading) {
+    return (
+      <Box display="flex" alignItems="center">
+        <LoadingSpinner small />
+      </Box>
+    );
   }
 
   return (

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -94,16 +94,18 @@ function ApplicationView({ application, hanke, onEditApplication }: Props) {
           </SectionItemContent>
           <SectionItemTitle>{t('hakemus:labels:applicationState')}:</SectionItemTitle>
           <SectionItemContent>
-            <Box as="span" mr="var(--spacing-2-xs)">
-              <ApplicationStatusTag status={alluStatus} />
+            <Box display="flex">
+              <Box as="span" mr="var(--spacing-2-xs)">
+                <ApplicationStatusTag status={alluStatus} />
+              </Box>
+              {alluStatus === AlluStatus.DECISION && (
+                <DecisionLink
+                  applicationId={id}
+                  linkText={t('hakemus:labels:downloadDecisionShort')}
+                  filename={applicationIdentifier}
+                />
+              )}
             </Box>
-            {alluStatus === AlluStatus.DECISION && (
-              <DecisionLink
-                applicationId={id}
-                linkText={t('hakemus:labels:downloadDecisionShort')}
-                filename={applicationIdentifier}
-              />
-            )}
           </SectionItemContent>
           <SectionItemTitle>{t('hakemus:labels:relatedHanke')}:</SectionItemTitle>
           <SectionItemContent>


### PR DESCRIPTION
# Description

Add loading spinner for fetching the file download link, so the UI does not feel unresponsive when downloading.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1711

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Go to an application that is in decision state. Click the pdf download link. The link should turn into a spinner while the link is being created.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

