### PR TITLE
HAI-1707 Prevent navigation away from invalid step in cable report application

### DIFF
--- a/src/domain/forms/MultipageForm.tsx
+++ b/src/domain/forms/MultipageForm.tsx
@@ -4,7 +4,7 @@ import styles from './MultipageForm.module.scss';
 import useLocale from '../../common/hooks/useLocale';
 import Text from '../../common/components/text/Text';
 import { createStepReducer } from './formStepReducer';
-import { ACTION_TYPE, StepperStep } from './types';
+import { Action, ACTION_TYPE, StepperStep } from './types';
 import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
 
 interface FormStep extends StepperStep {
@@ -32,6 +32,11 @@ interface Props {
   /** Function that is called when step is changed */
   onStepChange?: () => void;
   onSubmit?: () => void;
+  /**
+   * Function that is called with a function that changes step and current step index,
+   * and should validate the step and execute the given function if step is valid.
+   */
+  stepChangeValidator?: (changeStep: () => void, stepIndex: number) => void;
 }
 
 /**
@@ -45,6 +50,7 @@ const MultipageForm: React.FC<Props> = ({
   formSteps,
   onStepChange,
   onSubmit,
+  stepChangeValidator,
 }) => {
   const locale = useLocale();
 
@@ -55,28 +61,34 @@ const MultipageForm: React.FC<Props> = ({
   };
   const [state, dispatch] = useReducer(stepReducer, initialState);
 
+  function handleStepChange(value: Action) {
+    function changeStep() {
+      dispatch(value);
+      if (onStepChange) {
+        onStepChange();
+      }
+    }
+
+    if (stepChangeValidator) {
+      stepChangeValidator(changeStep, state.activeStepIndex);
+    } else {
+      changeStep();
+    }
+  }
+
   function handleStepClick(
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
     stepIndex: number
   ) {
-    if (onStepChange) {
-      onStepChange();
-    }
-    dispatch({ type: ACTION_TYPE.SET_ACTIVE, payload: stepIndex });
+    handleStepChange({ type: ACTION_TYPE.SET_ACTIVE, payload: stepIndex });
   }
 
   function handlePrevious() {
-    if (onStepChange) {
-      onStepChange();
-    }
-    dispatch({ type: ACTION_TYPE.SET_ACTIVE, payload: state.activeStepIndex - 1 });
+    handleStepChange({ type: ACTION_TYPE.SET_ACTIVE, payload: state.activeStepIndex - 1 });
   }
 
   function handleNext() {
-    if (onStepChange) {
-      onStepChange();
-    }
-    dispatch({ type: ACTION_TYPE.COMPLETE_STEP, payload: state.activeStepIndex });
+    handleStepChange({ type: ACTION_TYPE.COMPLETE_STEP, payload: state.activeStepIndex });
   }
 
   return (

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -402,6 +402,10 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
     </div>
   );
 
+  function validateStepChange(changeStep: () => void, stepIndex: number) {
+    return changeFormStep(changeStep, pageFieldsToValidate[stepIndex], trigger);
+  }
+
   return (
     <FormProvider {...formContext}>
       {/* Notification for saving application */}
@@ -418,6 +422,7 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
         formSteps={formSteps}
         onStepChange={handleStepChange}
         onSubmit={handleSubmit(sendCableApplication)}
+        stepChangeValidator={validateStepChange}
       >
         {function renderFormActions(activeStepIndex, handlePrevious, handleNext) {
           async function handlePageChange(handlerFunction: () => void): Promise<void> {
@@ -436,10 +441,7 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
           }
 
           async function handleNextPage() {
-            function nextPageHandler() {
-              changeFormStep(handleNext, pageFieldsToValidate[activeStepIndex], trigger);
-            }
-            await handlePageChange(nextPageHandler);
+            await handlePageChange(handleNext);
           }
 
           async function handleSaveAndQuit() {

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -467,3 +467,27 @@ test('Should show send button when application is edited in draft state', async 
 
   expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).toBeInTheDocument();
 });
+
+test('Should not allow step change when current step is invalid', async () => {
+  const { user } = render(<JohtoselvitysContainer application={applications[0]} />);
+
+  // Move to contacts page
+  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+  // Change registry key to be invalid
+  fireEvent.change(
+    screen.getByTestId('applicationData.customerWithContacts.customer.registryKey'),
+    {
+      target: { value: '1234567-8' },
+    }
+  );
+
+  // Try to move previous, next and basic information page
+  await user.click(screen.getByRole('button', { name: /edellinen/i }));
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
+  await user.click(screen.getByRole('button', { name: /perustiedot/i }));
+
+  // Expect to still be in the same page
+  expect(screen.queryByText('Vaihe 3/5: Yhteystiedot')).toBeInTheDocument();
+  expect(screen.queryByText('Kentän arvo on virheellinen')).toBeInTheDocument();
+});


### PR DESCRIPTION
# Description

Make sure that user can not change form step if there are invalid fields in the current step. Now moving to previous step or any other step by clicking the stepper buttons is not allowed along with the next step.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1707

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Go to for example areas page of cable report application form and leave start or end date empty or draw area that self intersects. Now it should not be possible to change to another page and validation errors should be visible.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
