### PR TITLE
HAI-1741 Hide delete buttons for uploaded attachments if application has been sent

### DIFF
--- a/src/common/components/fileList/FileList.test.tsx
+++ b/src/common/components/fileList/FileList.test.tsx
@@ -53,3 +53,20 @@ test('files can be deleted from the list', async () => {
   expect(screen.getByTestId('file-list').childElementCount).toBe(1);
   expect(screen.queryByText('TestFile1.pdf')).not.toBeInTheDocument();
 });
+
+test('delete button can be hidden for files', () => {
+  const handleFileDelete = jest.fn();
+
+  render(
+    <FileList
+      files={files}
+      onDeleteFile={handleFileDelete}
+      showDeleteButton={(file) => file.fileName === 'TestFile1.pdf'}
+    />
+  );
+
+  expect(screen.queryByTestId('delete-4f08ce3f-a0de-43c6-8ccc-9fe93822ed18')).toBeInTheDocument();
+  expect(
+    screen.queryByTestId('delete-d8e43d5a-ac40-448b-ad35-92120a7f2377')
+  ).not.toBeInTheDocument();
+});

--- a/src/common/components/fileList/FileList.tsx
+++ b/src/common/components/fileList/FileList.tsx
@@ -11,14 +11,19 @@ import FileDownloadLink from '../fileDownloadLink/FileDownloadLink';
 type Props = {
   files: ApplicationAttachmentMetadata[];
   onDeleteFile: (file: ApplicationAttachmentMetadata) => void;
+  // eslint-disable-next-line react/require-default-props
+  showDeleteButton?: (file: ApplicationAttachmentMetadata) => boolean;
 };
 
-function FileList({ files, onDeleteFile }: Props) {
+function FileList({ files, onDeleteFile, showDeleteButton }: Props) {
   const { t } = useTranslation();
 
   return (
     <ul data-testid="file-list">
       {files.map((fileMetadata) => {
+        const showDeleteButtonForFile =
+          showDeleteButton === undefined || showDeleteButton(fileMetadata);
+
         return (
           <Flex
             as="li"
@@ -41,16 +46,18 @@ function FileList({ files, onDeleteFile }: Props) {
               {t('form:labels:added')}{' '}
               {format(new Date(fileMetadata.createdAt), 'd.M.yyyy kk:mm', { locale: fi })}
             </Box>
-            <Button
-              iconLeft={<IconCross aria-hidden />}
-              variant="supplementary"
-              size="small"
-              style={{ color: 'var(--color-error)' }}
-              onClick={() => onDeleteFile(fileMetadata)}
-              data-testid={`delete-${fileMetadata.id}`}
-            >
-              {t('common:buttons:remove')}
-            </Button>
+            {showDeleteButtonForFile && (
+              <Button
+                iconLeft={<IconCross aria-hidden />}
+                variant="supplementary"
+                size="small"
+                style={{ color: 'var(--color-error)' }}
+                onClick={() => onDeleteFile(fileMetadata)}
+                data-testid={`delete-${fileMetadata.id}`}
+              >
+                {t('common:buttons:remove')}
+              </Button>
+            )}
           </Flex>
         );
       })}

--- a/src/domain/johtoselvitys/Attachments.tsx
+++ b/src/domain/johtoselvitys/Attachments.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FileInput, IconTrash, Notification } from 'hds-react';
 import { Box } from '@chakra-ui/react';
@@ -30,6 +30,8 @@ function Attachments({
   const { t } = useTranslation();
   const locale = useLocale();
   const { getValues } = useFormContext<JohtoselvitysFormValues>();
+
+  const alluStatus = getValues('alluStatus');
 
   const [fileToDelete, setFileToDelete] = useState<ApplicationAttachmentMetadata | null>(null);
   const [showFileDeleteDialog, setShowFileDeleteDialog] = useState(false);
@@ -66,6 +68,10 @@ function Attachments({
     attachmentDeleteMutation.reset();
   }
 
+  const showDeleteButton = useCallback(() => {
+    return alluStatus === null;
+  }, [alluStatus]);
+
   return (
     <Box mb="var(--spacing-l)">
       <Text tag="p" spacingBottom="l">
@@ -84,7 +90,11 @@ function Attachments({
           {attachmentsLoadError ? (
             <ErrorLoadingText />
           ) : (
-            <FileList files={existingAttachments} onDeleteFile={handleFileDelete} />
+            <FileList
+              files={existingAttachments}
+              onDeleteFile={handleFileDelete}
+              showDeleteButton={showDeleteButton}
+            />
           )}
         </Box>
       )}


### PR DESCRIPTION
# Description

If cable report application has already been sent to Allu, hide delete buttons for uploaded attachments because they can not be deleted in Allu.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1741

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Check that delete buttons for uploaded attachments are hidden in application that has been sent to Allu, and are shown for application that has not been sent.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
