### PR TITLE
Fix auth error text translations and add styling.

### DIFF
--- a/src/domain/auth/components/OidcCallback.test.tsx
+++ b/src/domain/auth/components/OidcCallback.test.tsx
@@ -22,12 +22,28 @@ describe('<OidcCallback />', () => {
     cleanup();
   });
 
+  it('as a user I want to see an generic error message about failed authentication', async () => {
+    jest.spyOn(authService, 'endLogin').mockRejectedValue(new Error('foobar'));
+
+    const { queryByText } = getWrapper();
+
+    await waitFor(() =>
+      expect(queryByText('Kirjautumisessa tapahtui virhe. Yritä uudestaan.')).toBeInTheDocument()
+    );
+  });
+
   it('as a user I want to see an error message about incorrect device time, because only I can fix it', async () => {
     jest.spyOn(authService, 'endLogin').mockRejectedValue(new Error('iat is in the future'));
 
     const { queryByText } = getWrapper();
 
-    await waitFor(() => expect(queryByText('authentication.deviceTimeError')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        queryByText(
+          'Et voi kirjautua sisään koska laitteesi kello on yli 5 minuuttia väärässä. Säädä kelloa ja kokeile uudestaan.'
+        )
+      ).toBeInTheDocument()
+    );
   });
 
   it('as a user I want to be informed when I deny permissions, because the application is unusable due to my choice', async () => {
@@ -40,7 +56,11 @@ describe('<OidcCallback />', () => {
     const { queryByText } = getWrapper();
 
     await waitFor(() =>
-      expect(queryByText('authentication.permissionRequestDenied')).toBeInTheDocument()
+      expect(
+        queryByText(
+          'Sinun täytyy hyväksyä pyytämämme oikeudet käyttääksesi tätä palvelua. Ole hyvä ja yritä kirjautua uudelleen.'
+        )
+      ).toBeInTheDocument()
     );
   });
 

--- a/src/domain/auth/components/OidcCallback.tsx
+++ b/src/domain/auth/components/OidcCallback.tsx
@@ -1,9 +1,55 @@
 import React, { useEffect, useState } from 'react';
+import { Flex } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
+import { Link as HDSLink } from 'hds-react';
 import authService from '../authService';
+import Text from '../../../common/components/text/Text';
+import { useLocalizedRoutes } from '../../../common/hooks/useLocalizedRoutes';
+import Link from '../../../common/components/Link/Link';
 
 type AuthenticationError = 'deviceTimeError' | 'permissionDeniedByUserError' | 'unknown';
+
+type AuthErrorProps = {
+  errorText: string;
+};
+
+const AuthError = ({ errorText }: AuthErrorProps) => {
+  const { HOME } = useLocalizedRoutes();
+
+  return (
+    <Flex
+      as="article"
+      flexDirection="column"
+      alignItems="center"
+      textAlign="center"
+      maxWidth="650px"
+      mx="auto"
+      mt="var(--spacing-3-xl)"
+      px="var(--spacing-s)"
+    >
+      <Text tag="h1" styleAs="h1" weight="bold" spacingBottom="l">
+        {errorText}
+      </Text>
+      <Text tag="p" spacingBottom="m">
+        <Trans
+          i18nKey="authentication:homePageLink"
+          components={{
+            a: <Link href={HOME.path}>etusivulle</Link>,
+          }}
+        />
+      </Text>
+      <Text tag="p" spacingBottom="m">
+        <Trans
+          i18nKey="authentication:supportLink"
+          components={{
+            a: <HDSLink href="mailto:haitatontuki@hel.fi">haitatontuki@hel.fi</HDSLink>,
+          }}
+        />
+      </Text>
+    </Flex>
+  );
+};
 
 const OidcCallback = () => {
   const navigate = useNavigate();
@@ -38,11 +84,15 @@ const OidcCallback = () => {
 
   return (
     <>
-      {authenticationError === 'deviceTimeError' && <p>{t('authentication.deviceTimeError')}</p>}
-      {authenticationError === 'permissionDeniedByUserError' && (
-        <p>{t('authentication.permissionRequestDenied')}</p>
+      {authenticationError === 'deviceTimeError' && (
+        <AuthError errorText={t('authentication:deviceTimeError')} />
       )}
-      {authenticationError === 'unknown' && <p>{t('authentication.genericError')}</p>}
+      {authenticationError === 'permissionDeniedByUserError' && (
+        <AuthError errorText={t('authentication:permissionRequestDenied')} />
+      )}
+      {authenticationError === 'unknown' && (
+        <AuthError errorText={t('authentication:genericError')} />
+      )}
     </>
   );
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,9 +2,11 @@
   "authentication": {
     "deviceTimeError": "You cannot log in because the clock on your device is more than 5 minutes wrong. Adjust your clock and try again.",
     "permissionRequestDenied": "You must accept the requested rights to use this service. Please try to log in again.",
-    "genericError": "An error occurred. Try again.",
+    "genericError": "There was an error logging in. Please try again.",
     "loginButton": "Log in",
-    "logoutButton": "Log out"
+    "logoutButton": "Log out",
+    "homePageLink": "Return to Haitaton <a>front page.</a>",
+    "supportLink": "You can also contact Haitaton technical support at the email address <a>haitatontuki@hel.fi.</a>"
   },
   "common": {
     "increment": "Increment",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -2,9 +2,11 @@
   "authentication": {
     "deviceTimeError": "Et voi kirjautua sisään koska laitteesi kello on yli 5 minuuttia väärässä. Säädä kelloa ja kokeile uudestaan.",
     "permissionRequestDenied": "Sinun täytyy hyväksyä pyytämämme oikeudet käyttääksesi tätä palvelua. Ole hyvä ja yritä kirjautua uudelleen.",
-    "genericError": "Tapahtui virhe. Yritä uudestaan.",
+    "genericError": "Kirjautumisessa tapahtui virhe. Yritä uudestaan.",
     "loginButton": "Kirjaudu",
-    "logoutButton": "Kirjaudu ulos"
+    "logoutButton": "Kirjaudu ulos",
+    "homePageLink": "Palaa Haitattoman <a>etusivulle.</a>",
+    "supportLink": "Voit myös ottaa yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <a>haitatontuki@hel.fi.</a>"
   },
   "common": {
     "increment": "Lisää",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -2,9 +2,11 @@
   "authentication": {
     "deviceTimeError": "Du kan inte logga in eftersom klockan i din enhet går mer än 5 minuter fel. Ställ in klockan och försök på nytt.",
     "permissionRequestDenied": "Du måste godkänna de rättigheter vi begärt för att använda denna tjänst. Var god försök logga in på nytt.",
-    "genericError": "Det inträffade ett fel. Försök på nytt.",
+    "genericError": "Det inträffade ett fel att logga in. Försök på nytt.",
     "loginButton": "Logga in",
-    "logoutButton": "Logga ut"
+    "logoutButton": "Logga ut",
+    "homePageLink": "Återgå till Haitatons <a>framsida.</a>",
+    "supportLink": "Du kan också kontakta Haitaton tekniska support på e-postadressen <a>haitatontuki@hel.fi.</a>"
   },
   "common": {
     "increment": "Lägg till",


### PR DESCRIPTION
# Description

Fix auth error text translations and add styling.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1703

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Go to Suomi.fi login and cancel login or append url with `login_callback?error=access_denied&error_description=Authentication+cancelled+or+failed&state=8729ae448b224a28b63fde15c758aee6` to see the error text.

# Checklist:

- [x] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

