### PR TITLE
HAI-1744 Show save and quit button also in the first page of cable report application

### DIFF
--- a/src/domain/hanke/hooks/useNavigateToApplicationList.ts
+++ b/src/domain/hanke/hooks/useNavigateToApplicationList.ts
@@ -12,9 +12,12 @@ export default function useNavigateToApplicationList(hankeTunnus?: string) {
   const getHankeViewPath = useLinkPath(ROUTES.HANKE);
   const { HANKEPORTFOLIO } = useLocalizedRoutes();
 
-  const path = hankeTunnus ? getHankeViewPath({ hankeTunnus }) : HANKEPORTFOLIO.path;
+  function navigateToApplicationList(updatedHankeTunnus?: string | null) {
+    const hankeTunnusToUse = updatedHankeTunnus || hankeTunnus;
+    const path = hankeTunnusToUse
+      ? getHankeViewPath({ hankeTunnus: hankeTunnusToUse })
+      : HANKEPORTFOLIO.path;
 
-  function navigateToApplicationList() {
     navigate(path, { state: { initiallyActiveTab: 4 } });
   }
 

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -214,7 +214,7 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke }) => {
           <Button theme="coat" className={styles.showHankeButton} onClick={navigateToHanke}>
             {t('hankePortfolio:showHankeButton')}
           </Button>
-          <Button theme="coat" variant="secondary" onClick={navigateToApplications}>
+          <Button theme="coat" variant="secondary" onClick={() => navigateToApplications()}>
             {t('hankePortfolio:showApplicationsButton')}
           </Button>
         </div>

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -235,8 +235,8 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
 
   function saveAndQuit() {
     applicationSaveMutation.mutate(convertFormStateToApplicationData(getValues()), {
-      onSuccess() {
-        navigateToApplicationList();
+      onSuccess(data) {
+        navigateToApplicationList(data.hankeTunnus);
 
         setNotification(true, {
           position: 'top-right',
@@ -443,10 +443,15 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
           }
 
           async function handleSaveAndQuit() {
-            await handlePageChange(saveAndQuit);
+            // Make sure that name for the application exists before saving and quitting
+            const applicationNameValid = await trigger('applicationData.name', {
+              shouldFocus: true,
+            });
+            if (applicationNameValid) {
+              await handlePageChange(saveAndQuit);
+            }
           }
 
-          const firstStep = activeStepIndex === 0;
           const lastStep = activeStepIndex === formSteps.length - 1;
           const showSendButton =
             lastStep && isApplicationDraft(getValues('alluStatus') as AlluStatus | null);
@@ -476,18 +481,16 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
                 saveAndQuitIsLoadingText={saveAndQuitLoadingText}
               />
 
-              {!firstStep && (
-                <Button
-                  variant="supplementary"
-                  iconLeft={<IconSaveDiskette aria-hidden="true" />}
-                  data-testid="save-form-btn"
-                  onClick={handleSaveAndQuit}
-                  isLoading={saveAndQuitIsLoading}
-                  loadingText={saveAndQuitLoadingText}
-                >
-                  {t('hankeForm:saveDraftButton')}
-                </Button>
-              )}
+              <Button
+                variant="supplementary"
+                iconLeft={<IconSaveDiskette aria-hidden="true" />}
+                data-testid="save-form-btn"
+                onClick={handleSaveAndQuit}
+                isLoading={saveAndQuitIsLoading}
+                loadingText={saveAndQuitLoadingText}
+              >
+                {t('hankeForm:saveDraftButton')}
+              </Button>
 
               {showSendButton && (
                 <Button

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -356,6 +356,27 @@ test('Save and quit works without hanke existing first', async () => {
   expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-13');
 });
 
+test('Should save and quit from the first page with just application name entered', async () => {
+  const { user } = render(<Johtoselvitys />, undefined, '/fi/johtoselvityshakemus');
+
+  fireEvent.change(screen.getByLabelText(/työn nimi/i), {
+    target: { value: 'Johtoselvitys testi' },
+  });
+  await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
+
+  expect(screen.queryAllByText(/hakemus tallennettu/i).length).toBe(2);
+  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-14');
+});
+
+test('Should not save and quit if there is no application name', async () => {
+  const { user } = render(<Johtoselvitys />, undefined, '/fi/johtoselvityshakemus');
+
+  await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
+
+  expect(window.location.pathname).toBe('/fi/johtoselvityshakemus');
+  expect(screen.queryByText('Kenttä on pakollinen')).toBeInTheDocument();
+});
+
 test('Should show error message and not navigate away when save and quit fails', async () => {
   server.use(
     rest.put('/api/hakemukset/:id', async (req, res, ctx) => {


### PR DESCRIPTION
# Description

Save and quit button was hidden in the first page of cable report application form, while it should not, so changed that. Also validate application name when saving and quitting in the first page.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1744

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Check that save and quit button (Tallenna ja keskeytä) is visible in the first page of cable report application and that saving and quitting works.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
