### PR TITLE
Show inline notification when editing a form that is in pending state

### DIFF
--- a/src/domain/forms/MultipageForm.module.scss
+++ b/src/domain/forms/MultipageForm.module.scss
@@ -8,6 +8,7 @@
       box-sizing: content-box;
     }
 
+    margin-top: var(--spacing-l);
     margin-bottom: var(--spacing-l);
   }
 }

--- a/src/domain/forms/MultipageForm.test.tsx
+++ b/src/domain/forms/MultipageForm.test.tsx
@@ -45,6 +45,36 @@ test('renders form heading and labels for form steps', () => {
   expect(screen.getByText('Vaihe 1/2: Title 1')).toBeInTheDocument();
 });
 
+test('renders form notification if texts are given', () => {
+  const formSteps = [
+    {
+      element: <Page1 />,
+      label: 'Title 1',
+      state: StepState.available,
+    },
+    {
+      element: <Page2 />,
+      label: 'Title 2',
+      state: StepState.disabled,
+    },
+  ];
+
+  const handleSave = jest.fn();
+
+  render(
+    <MultipageForm
+      heading="Test form"
+      formSteps={formSteps}
+      onStepChange={handleSave}
+      notificationLabel="Notification label"
+      notificationText="Notification text"
+    />
+  );
+
+  expect(screen.getByText('Notification label')).toBeInTheDocument();
+  expect(screen.getByText('Notification text')).toBeInTheDocument();
+});
+
 test('form pages can be navigated', async () => {
   const formSteps = [
     {

--- a/src/domain/forms/MultipageForm.tsx
+++ b/src/domain/forms/MultipageForm.tsx
@@ -1,5 +1,5 @@
 import React, { useReducer } from 'react';
-import { Stepper, StepState } from 'hds-react';
+import { Notification, Stepper, StepState } from 'hds-react';
 import styles from './MultipageForm.module.scss';
 import useLocale from '../../common/hooks/useLocale';
 import Text from '../../common/components/text/Text';
@@ -32,6 +32,8 @@ interface Props {
   /** Function that is called when step is changed */
   onStepChange?: () => void;
   onSubmit?: () => void;
+  notificationLabel?: string;
+  notificationText?: string;
 }
 
 /**
@@ -45,6 +47,8 @@ const MultipageForm: React.FC<Props> = ({
   formSteps,
   onStepChange,
   onSubmit,
+  notificationLabel,
+  notificationText,
 }) => {
   const locale = useLocale();
 
@@ -89,6 +93,12 @@ const MultipageForm: React.FC<Props> = ({
         <Text tag="h2" styleAs="h4" spacingBottom="m">
           {subHeading}
         </Text>
+      )}
+
+      {notificationLabel && notificationText && (
+        <Notification dataTestId="form-notification" size="large" label={notificationLabel}>
+          {notificationText}
+        </Notification>
       )}
 
       <div className={styles.stepper}>

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -402,6 +402,15 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
     </div>
   );
 
+  const notificationLabel =
+    getValues('alluStatus') === AlluStatus.PENDING
+      ? t('form:notifications:labels:editSentApplication')
+      : undefined;
+  const notificationText =
+    getValues('alluStatus') === AlluStatus.PENDING
+      ? t('form:notifications:descriptions:editSentApplication')
+      : undefined;
+
   return (
     <FormProvider {...formContext}>
       {/* Notification for saving application */}
@@ -418,6 +427,8 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
         formSteps={formSteps}
         onStepChange={handleStepChange}
         onSubmit={handleSubmit(sendCableApplication)}
+        notificationLabel={notificationLabel}
+        notificationText={notificationText}
       >
         {function renderFormActions(activeStepIndex, handlePrevious, handleNext) {
           async function handlePageChange(handlerFunction: () => void): Promise<void> {

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -495,3 +495,21 @@ test('Should not allow start date be after end date', async () => {
   await user.click(screen.getByRole('button', { name: /seuraava/i }));
   expect(screen.queryByText('Vaihe 2/5: Alueet')).toBeInTheDocument();
 });
+
+test('Should not show inline notification by default', () => {
+  render(<JohtoselvitysContainer application={applications[0]} />);
+
+  expect(screen.queryByTestId('form-notification')).not.toBeInTheDocument();
+});
+
+test('Should show inline notification when editing a form that is in pending state', () => {
+  render(<JohtoselvitysContainer application={applications[1]} />);
+
+  expect(screen.queryByTestId('form-notification')).toBeInTheDocument();
+  expect(screen.queryByText('Olet muokkaamassa jo lähetettyä hakemusta.')).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      'Hakemusta voit muokata niin kauan, kun sitä ei vielä ole otettu käsittelyyn. Uusi versio hakemuksesta lähtee viranomaiselle automaattisesti lomakkeen tallennuksen yhteydessä.'
+    )
+  ).toBeInTheDocument();
+});

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -111,10 +111,12 @@
     },
     "notifications": {
       "labels": {
-        "attachmentRemoved": "Liitetiedosto poistettu"
+        "attachmentRemoved": "Liitetiedosto poistettu",
+        "editSentApplication": "Olet muokkaamassa jo lähetettyä hakemusta."
       },
       "descriptions": {
-        "attachmentRemoved": "Liitetiedosto {{fileName}} poistettu"
+        "attachmentRemoved": "Liitetiedosto {{fileName}} poistettu",
+        "editSentApplication": "Hakemusta voit muokata niin kauan, kun sitä ei vielä ole otettu käsittelyyn. Uusi versio hakemuksesta lähtee viranomaiselle automaattisesti lomakkeen tallennuksen yhteydessä."
       }
     },
     "buttons": {


### PR DESCRIPTION
# Description

Show inline notification when editing a form that is in pending state.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1742

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Edit a form that is in pending state. There should be inline notification on top. It should not show on other form states.

# Checklist:

-  [x] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
