### PR TITLE
HAI-1765 Change first name and last name fields in basic information page to be read-only

### DIFF
--- a/src/domain/johtoselvitys/BasicInfo.tsx
+++ b/src/domain/johtoselvitys/BasicInfo.tsx
@@ -295,21 +295,6 @@ export const BasicHankeInfo: React.FC = () => {
         />
       </ResponsiveGrid>
 
-      {/* TODO: Getting the profile information will be done in HAI-1398 */}
-      {/* Until then, user can input name */}
-      {/* <Text tag="p" styleAs="body-m" spacingBottom="xs">
-        <Box as="span" fontWeight={500}>
-          {t('form:yhteystiedot:labels:nimi')} *
-        </Box>
-      </Text>
-      <Text tag="p" styleAs="body-l" spacingBottom="xs">
-        {getValues(`applicationData.${selectedRole}.contacts.0.name`)}
-      </Text> */}
-      {/* <Text tag="p" styleAs="body-m" spacingBottom="s">
-        <Box as="span" color="var(--color-black-60)">
-          {t('form:labels:fromHelsinkiProfile')}
-        </Box>
-      </Text> */}
       {customerTypes.map((customerType) => {
         if (customerType === selectedRole) {
           return (
@@ -319,11 +304,19 @@ export const BasicHankeInfo: React.FC = () => {
                   name={`applicationData.${selectedRole}.contacts.0.firstName`}
                   label={t('hankeForm:labels:etunimi')}
                   required
+                  readOnly={Boolean(user.data?.profile.given_name)}
+                  helperText={
+                    user.data?.profile.given_name ? t('form:labels:fromHelsinkiProfile') : ''
+                  }
                 />
                 <TextInput
                   name={`applicationData.${selectedRole}.contacts.0.lastName`}
                   label={t('hankeForm:labels:sukunimi')}
                   required
+                  readOnly={Boolean(user.data?.profile.family_name)}
+                  helperText={
+                    user.data?.profile.family_name ? t('form:labels:fromHelsinkiProfile') : ''
+                  }
                 />
               </ResponsiveGrid>
 


### PR DESCRIPTION
# Description

First name and last name fields in cable report application forms first page are now read-only if they can be retrieved from Helsinki profile.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1765

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
