### PR TITLE
HAI-1761 Add validation for maximum number of attachments

### DIFF
--- a/src/domain/johtoselvitys/Attachments.tsx
+++ b/src/domain/johtoselvitys/Attachments.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FileInput, IconTrash, Notification } from 'hds-react';
 import { Box } from '@chakra-ui/react';
@@ -12,6 +12,7 @@ import { ApplicationAttachmentMetadata } from '../application/types/application'
 import { deleteAttachment } from '../application/attachments';
 import { JohtoselvitysFormValues } from './types';
 import ErrorLoadingText from '../../common/components/errorLoadingText/ErrorLoadingText';
+import { MAX_ATTACHMENT_NUMBER } from './constants';
 
 type Props = {
   existingAttachments: ApplicationAttachmentMetadata[] | undefined;
@@ -29,7 +30,11 @@ function Attachments({
   const queryClient = useQueryClient();
   const { t } = useTranslation();
   const locale = useLocale();
-  const { getValues } = useFormContext<JohtoselvitysFormValues>();
+  const {
+    getValues,
+    setValue,
+    formState: { errors },
+  } = useFormContext<JohtoselvitysFormValues>();
 
   const alluStatus = getValues('alluStatus');
 
@@ -40,6 +45,13 @@ function Attachments({
       queryClient.invalidateQueries('attachments');
     },
   });
+
+  useEffect(() => {
+    const attachmentNumber =
+      newAttachments.length + (existingAttachments ? existingAttachments.length : 0);
+
+    setValue('attachmentNumber', attachmentNumber, { shouldValidate: true });
+  }, [newAttachments, existingAttachments, setValue]);
 
   function handleFilesChange(files: File[]) {
     onAddAttachments(files);
@@ -142,6 +154,18 @@ function Attachments({
             fileName: fileToDelete?.fileName,
           })}
         </Notification>
+      )}
+
+      {errors.attachmentNumber && (
+        <Notification
+          position="inline"
+          type="error"
+          label={t('hakemus:notifications:maxAttachmentsNumberExceeded', {
+            maxNumber: MAX_ATTACHMENT_NUMBER,
+          })}
+          notificationAriaLabel={t('common:components:notification:notification')}
+          style={{ marginTop: 'var(--spacing-l)' }}
+        />
       )}
     </Box>
   );

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -136,7 +136,7 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
     setValue,
     handleSubmit,
     trigger,
-    formState: { isDirty },
+    formState: { isDirty, errors: formErrors },
     reset,
   } = formContext;
 
@@ -318,6 +318,8 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
         'applicationData.propertyDeveloperWithContacts',
         'applicationData.representativeWithContacts',
       ],
+      // Attachments page
+      ['attachmentNumber'],
     ],
     [ordererKey]
   );
@@ -446,7 +448,11 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
         {function renderFormActions(activeStepIndex, handlePrevious, handleNext) {
           async function handlePageChange(handlerFunction: () => void): Promise<void> {
             try {
-              if (activeStepIndex === 3 && newAttachments.length > 0) {
+              if (
+                activeStepIndex === 3 &&
+                newAttachments.length > 0 &&
+                !formErrors.attachmentNumber
+              ) {
                 await saveAttachments();
                 setNewAttachments([]);
               }

--- a/src/domain/johtoselvitys/constants.ts
+++ b/src/domain/johtoselvitys/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_ATTACHMENT_NUMBER = 20;

--- a/src/domain/johtoselvitys/types.ts
+++ b/src/domain/johtoselvitys/types.ts
@@ -14,4 +14,5 @@ export interface JohtoselvitysFormValues extends Application {
   applicationData: JohtoselvitysFormData;
   geometriesChanged?: boolean; // virtualField
   selfIntersectingPolygon?: boolean; // virtualField
+  attachmentNumber?: number; // virtualField
 }

--- a/src/domain/johtoselvitys/utils.ts
+++ b/src/domain/johtoselvitys/utils.ts
@@ -50,6 +50,8 @@ export function convertFormStateToApplicationData(formState: JohtoselvitysFormVa
   delete formState.geometriesChanged;
   // eslint-disable-next-line no-param-reassign
   delete formState.selfIntersectingPolygon;
+  // eslint-disable-next-line no-param-reassign
+  delete formState.attachmentNumber;
 
   const data: Application = cloneDeep(formState);
 

--- a/src/domain/johtoselvitys/validationSchema.ts
+++ b/src/domain/johtoselvitys/validationSchema.ts
@@ -1,5 +1,6 @@
 import yup from '../../common/utils/yup';
 import isValidBusinessId from '../../common/utils/isValidBusinessId';
+import { MAX_ATTACHMENT_NUMBER } from './constants';
 
 const addressSchema = yup.object().shape({
   streetAddress: yup.object().shape({
@@ -75,4 +76,5 @@ export const validationSchema = yup.object().shape({
     areas: yup.array(areaSchema).min(1),
   }),
   selfIntersectingPolygon: yup.boolean().isFalse(),
+  attachmentNumber: yup.number().max(MAX_ATTACHMENT_NUMBER),
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -508,7 +508,8 @@
       "sendSuccessLabel": "EN:Hakemus lähetetty",
       "sendErrorLabel": "EN:Hakemuksen lähetys epäonnistui",
       "sendSuccessText": "EN:Hakemuksen lähetys onnistui",
-      "sendErrorText": "EN:Hakemusta ei voitu lähettää. Tarkista hakemuksen oikea sisältö ja että olet kirjautunut."
+      "sendErrorText": "EN:Hakemusta ei voitu lähettää. Tarkista hakemuksen oikea sisältö ja että olet kirjautunut.",
+      "maxAttachmentsNumberExceeded": "The maximum number of attachments ({{maxNumber}} items) has been exceeded"
     },
     "buttons": {
       "continueToApplication": "EN:Jatka hakemukseen",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -593,7 +593,8 @@
       "sendErrorText": "<0>Hakemus on tallennettu luonnoksena, koska hakemuksen lähettäminen käsittelyyn epäonnistui. Yritä lähettämistä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi.</1></0>",
       "cancelSuccessLabel": "Hakemus peruttiin",
       "cancelSuccessText": "Hakemus peruttiin onnistuneesti",
-      "noApplications": "Hankkeella ei ole lisättyjä hakemuksia"
+      "noApplications": "Hankkeella ei ole lisättyjä hakemuksia",
+      "maxAttachmentsNumberExceeded": "Liitteiden enimmäismäärä ({{maxNumber}} kpl) ylitetty"
     },
     "status": {
       "PENDING_CLIENT": "Näkyy viranomaiselle",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -508,7 +508,8 @@
       "sendSuccessLabel": "SV:Hakemus lähetetty",
       "sendErrorLabel": "SV:Hakemuksen lähetys epäonnistui",
       "sendSuccessText": "SV:Hakemuksen lähetys onnistui",
-      "sendErrorText": "SV:Hakemusta ei voitu lähettää. Tarkista hakemuksen oikea sisältö ja että olet kirjautunut."
+      "sendErrorText": "SV:Hakemusta ei voitu lähettää. Tarkista hakemuksen oikea sisältö ja että olet kirjautunut.",
+      "maxAttachmentsNumberExceeded": "Maximalt antal bilagor ({{maxNumber}} st) har överskridits"
     },
     "buttons": {
       "continueToApplication": "SV:Jatka hakemukseen",


### PR DESCRIPTION
# Description

Added validation that cable report application can have maximum of 20 attachments.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1761

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
