### PR TITLE
HAI-1753 Fix problem where buttons don't stay in loading state when uploading attachments

### DIFF
--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -477,9 +477,8 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
           const showSendButton =
             lastStep && isApplicationDraft(getValues('alluStatus') as AlluStatus | null);
 
-          const saveAndQuitIsLoading =
-            applicationSaveMutation.isLoading || attachmentUploadMutation.isLoading;
-          const saveAndQuitLoadingText = attachmentUploadMutation.isLoading
+          const saveAndQuitIsLoading = applicationSaveMutation.isLoading || attachmentsUploading;
+          const saveAndQuitLoadingText = attachmentsUploading
             ? t('form:buttons:loadingAttachments')
             : t('common:buttons:savingText');
           return (
@@ -488,9 +487,9 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
               totalSteps={formSteps.length}
               onPrevious={handlePreviousPage}
               onNext={handleNextPage}
-              previousButtonIsLoading={attachmentUploadMutation.isLoading}
+              previousButtonIsLoading={attachmentsUploading}
               previousButtonLoadingText={t('form:buttons:loadingAttachments')}
-              nextButtonIsLoading={attachmentUploadMutation.isLoading}
+              nextButtonIsLoading={attachmentsUploading}
               nextButtonLoadingText={t('form:buttons:loadingAttachments')}
             >
               <ApplicationCancel


### PR DESCRIPTION
# Description

Make sure that previous, next, cancel and save buttons in the bottom stay in loading state until all attachments are uploaded.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1753

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
