### PR TITLE
HAI-1752 Disable editing users own information after application has been sent to Allu

### DIFF
--- a/src/domain/johtoselvitys/BasicInfo.tsx
+++ b/src/domain/johtoselvitys/BasicInfo.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Checkbox, Link, Select, SelectionGroup } from 'hds-react';
+import { Checkbox, Link, Notification, Select, SelectionGroup } from 'hds-react';
 import { useFormContext } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import { isEqual } from 'lodash';
@@ -284,6 +284,16 @@ export const BasicHankeInfo: React.FC = () => {
       <Text tag="h2" styleAs="h4" weight="bold" spacingBottom="s">
         {t('form:labels:omatTiedot')}
       </Text>
+
+      {applicationSent && (
+        <Notification
+          label={t('hakemus:notifications:sentApplicationPersonalInfoNotification')}
+          size="small"
+          style={{ marginBottom: 'var(--spacing-s)' }}
+        >
+          {t('hakemus:notifications:sentApplicationPersonalInfoNotification')}
+        </Notification>
+      )}
 
       <ResponsiveGrid>
         <Select<Option>

--- a/src/domain/johtoselvitys/BasicInfo.tsx
+++ b/src/domain/johtoselvitys/BasicInfo.tsx
@@ -89,6 +89,8 @@ export const BasicHankeInfo: React.FC = () => {
   const { t } = useTranslation();
   const user = useUser();
 
+  const applicationSent: boolean = getValues('alluStatus') !== null;
+
   const [selectedRole, setSelectedRole] = useState(() =>
     // Set contact key with orderer field true to be the initial selected role.
     findOrdererKey(getValues('applicationData'))
@@ -292,6 +294,7 @@ export const BasicHankeInfo: React.FC = () => {
           onChange={handleRoleChange}
           helper={t('form:labels:roleHelper')}
           required
+          disabled={applicationSent}
         />
       </ResponsiveGrid>
 
@@ -308,6 +311,7 @@ export const BasicHankeInfo: React.FC = () => {
                   helperText={
                     user.data?.profile.given_name ? t('form:labels:fromHelsinkiProfile') : ''
                   }
+                  disabled={applicationSent}
                 />
                 <TextInput
                   name={`applicationData.${selectedRole}.contacts.0.lastName`}
@@ -317,6 +321,7 @@ export const BasicHankeInfo: React.FC = () => {
                   helperText={
                     user.data?.profile.family_name ? t('form:labels:fromHelsinkiProfile') : ''
                   }
+                  disabled={applicationSent}
                 />
               </ResponsiveGrid>
 
@@ -325,11 +330,13 @@ export const BasicHankeInfo: React.FC = () => {
                   name={`applicationData.${customerType}.contacts.0.email`}
                   label={t('form:yhteystiedot:labels:email')}
                   required
+                  disabled={applicationSent}
                 />
                 <TextInput
                   name={`applicationData.${customerType}.contacts.0.phone`}
                   label={t('form:yhteystiedot:labels:puhelinnumero')}
                   required
+                  disabled={applicationSent}
                 />
               </ResponsiveGrid>
             </React.Fragment>

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -423,12 +423,14 @@ test('Should save existing application between page changes when there is change
 });
 
 test('Should change users own role and its fields correctly', async () => {
-  const { user } = render(<JohtoselvitysContainer application={applications[3]} />);
+  const { user } = render(<JohtoselvitysContainer application={application} />);
 
   const firstName = 'Tauno';
   const lastName = 'Työmies';
   const email = 'tauno@test.com';
   const phone = '0401234567';
+
+  fillBasicInformation();
 
   fireEvent.click(screen.getByRole('button', { name: /rooli/i }));
   fireEvent.click(screen.getByText(/työn suorittaja/i));
@@ -450,7 +452,14 @@ test('Should change users own role and its fields correctly', async () => {
   fireEvent.change(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.phone'), {
     target: { value: phone },
   });
-  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+  // Move to areas page
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+  fillAreasInformation();
+
+  // Move to contacts page
+  await user.click(screen.getByRole('button', { name: /seuraava/i }));
   await user.click(screen.getByTestId('contractorWithContacts-0'));
 
   expect(
@@ -557,4 +566,22 @@ test('Should show inline notification when editing a form that is in pending sta
       'Hakemusta voit muokata niin kauan, kun sitä ei vielä ole otettu käsittelyyn. Uusi versio hakemuksesta lähtee viranomaiselle automaattisesti lomakkeen tallennuksen yhteydessä.'
     )
   ).toBeInTheDocument();
+});
+
+test('Should not allow to edit own info when application has been sent to Allu', () => {
+  render(<JohtoselvitysContainer application={applications[1]} />);
+
+  expect(screen.getByRole('button', { name: /rooli/i })).toBeDisabled();
+  expect(
+    screen.getByTestId('applicationData.customerWithContacts.contacts.0.firstName')
+  ).toBeDisabled();
+  expect(
+    screen.getByTestId('applicationData.customerWithContacts.contacts.0.lastName')
+  ).toBeDisabled();
+  expect(
+    screen.getByTestId('applicationData.customerWithContacts.contacts.0.email')
+  ).toBeDisabled();
+  expect(
+    screen.getByTestId('applicationData.customerWithContacts.contacts.0.phone')
+  ).toBeDisabled();
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -509,7 +509,8 @@
       "sendErrorLabel": "EN:Hakemuksen lähetys epäonnistui",
       "sendSuccessText": "EN:Hakemuksen lähetys onnistui",
       "sendErrorText": "EN:Hakemusta ei voitu lähettää. Tarkista hakemuksen oikea sisältö ja että olet kirjautunut.",
-      "maxAttachmentsNumberExceeded": "The maximum number of attachments ({{maxNumber}} items) has been exceeded"
+      "maxAttachmentsNumberExceeded": "The maximum number of attachments ({{maxNumber}} items) has been exceeded",
+      "sentApplicationPersonalInfoNotification": "The personal information of the submitted application cannot be edited"
     },
     "buttons": {
       "continueToApplication": "EN:Jatka hakemukseen",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -594,7 +594,8 @@
       "cancelSuccessLabel": "Hakemus peruttiin",
       "cancelSuccessText": "Hakemus peruttiin onnistuneesti",
       "noApplications": "Hankkeella ei ole lisättyjä hakemuksia",
-      "maxAttachmentsNumberExceeded": "Liitteiden enimmäismäärä ({{maxNumber}} kpl) ylitetty"
+      "maxAttachmentsNumberExceeded": "Liitteiden enimmäismäärä ({{maxNumber}} kpl) ylitetty",
+      "sentApplicationPersonalInfoNotification": "Lähetetyn hakemuksen omia tietoja ei voi muokata"
     },
     "status": {
       "PENDING_CLIENT": "Näkyy viranomaiselle",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -509,7 +509,8 @@
       "sendErrorLabel": "SV:Hakemuksen lähetys epäonnistui",
       "sendSuccessText": "SV:Hakemuksen lähetys onnistui",
       "sendErrorText": "SV:Hakemusta ei voitu lähettää. Tarkista hakemuksen oikea sisältö ja että olet kirjautunut.",
-      "maxAttachmentsNumberExceeded": "Maximalt antal bilagor ({{maxNumber}} st) har överskridits"
+      "maxAttachmentsNumberExceeded": "Maximalt antal bilagor ({{maxNumber}} st) har överskridits",
+      "sentApplicationPersonalInfoNotification": "Egna upplysningar för den inskickade ansökan kan inte redigeras"
     },
     "buttons": {
       "continueToApplication": "SV:Jatka hakemukseen",


### PR DESCRIPTION
# Description

User should not be able to edit their own information in cable report application, after application has been sent to Allu, so disabled those fields in that case.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1752

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Check that own information can't be edited in an application that has been sent to Allu.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: