### PR TITLE
HAI-1790 Fix problem where user could duplicate their information

### DIFF
--- a/src/domain/johtoselvitys/BasicInfo.tsx
+++ b/src/domain/johtoselvitys/BasicInfo.tsx
@@ -146,6 +146,8 @@ export const BasicHankeInfo: React.FC = () => {
   ];
 
   function handleRoleChange(role: Option) {
+    if (role.value === selectedRole) return;
+
     const previousRoleContacts = getValues(`applicationData.${selectedRole}.contacts`);
     const contactToMove = previousRoleContacts.slice(0, 1);
 

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -479,6 +479,18 @@ test('Should change users own role and its fields correctly', async () => {
   );
 });
 
+test('Should not change anything if selecting the same role again', async () => {
+  const { user } = render(<JohtoselvitysContainer application={applications[0]} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /rooli/i }));
+  // Select the role to be Hakija again
+  await user.click(screen.getAllByText(/hakija/i)[1]);
+  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+  // Check that there isn't another contact added
+  expect(screen.queryByTestId('customerWithContacts-1')).not.toBeInTheDocument();
+});
+
 test('Should not show send button when application has moved to pending state', async () => {
   const { user } = render(<JohtoselvitysContainer application={applications[1]} />);
 


### PR DESCRIPTION
# Description

There was an issue in cable report application form, when user selected the same role again in basic information page, their information would be duplicated and there would be multiple orderers for the application.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1790

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

In cable report application form, select the same role again (for example if your role is Hakija, select it again from the dropdown) and check from the contacts page that there is no change.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
