### PR TITLE
HAI-1763 Redirect user to edit route on page refresh when creating new cable report application

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-i18next": "^11.7.3",
     "react-query": "^3.39.2",
     "react-redux": "^7.2.1",
-    "react-router-dom": "6.3.0",
+    "react-router-dom": "^6.13.0",
     "react-scripts": "^4.0.3",
     "react-table": "^7.8.0",
     "redux-thunk": "^2.3.0",

--- a/src/domain/application/constants.ts
+++ b/src/domain/application/constants.ts
@@ -1,0 +1,1 @@
+export const APPLICATION_ID_STORAGE_KEY = 'application-id';

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Button, IconCross, IconEnvelope, IconSaveDiskette, StepState } from 'hds-react';
 import { FormProvider, useForm, FieldPath } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -7,6 +7,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { merge } from 'lodash';
 import { AxiosError } from 'axios';
 import { Box } from '@chakra-ui/react';
+import { useBeforeUnload } from 'react-router-dom';
 
 import { JohtoselvitysFormValues } from './types';
 import { BasicHankeInfo } from './BasicInfo';
@@ -35,6 +36,7 @@ import Attachments from './Attachments';
 import ConfirmationDialog from '../../common/components/HDSConfirmationDialog/ConfirmationDialog';
 import { uploadAttachment } from '../application/attachments';
 import useAttachments from '../application/hooks/useAttachments';
+import { APPLICATION_ID_STORAGE_KEY } from '../application/constants';
 
 type Props = {
   hankeData?: HankeData;
@@ -139,6 +141,20 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
     formState: { isDirty, errors: formErrors },
     reset,
   } = formContext;
+
+  // Setup a callback to save application id to session storage
+  // when the page is about to be unloaded if the application
+  // has been saved (id exists) and user is not editing
+  // previously created application. This is done so that
+  // user can be redirected to editing route if the page is refreshed.
+  useBeforeUnload(
+    useCallback(() => {
+      const applicationId = getValues('id');
+      if (applicationId && !application) {
+        sessionStorage.setItem(APPLICATION_ID_STORAGE_KEY, applicationId.toString());
+      }
+    }, [getValues, application])
+  );
 
   // If application is created without hanke existing first, get generated hanke data
   // after first save when hankeTunnus is available

--- a/src/pages/EditJohtoselvitysPage.tsx
+++ b/src/pages/EditJohtoselvitysPage.tsx
@@ -9,6 +9,7 @@ import JohtoselvitysContainer from '../domain/johtoselvitys/JohtoselvitysContain
 import { useApplication } from '../domain/application/hooks/useApplication';
 import useHanke from '../domain/hanke/hooks/useHanke';
 import ErrorLoadingText from '../common/components/errorLoadingText/ErrorLoadingText';
+import { APPLICATION_ID_STORAGE_KEY } from '../domain/application/constants';
 
 const EditJohtoselvitysPage: React.FC = () => {
   const { id } = useParams();
@@ -16,6 +17,11 @@ const EditJohtoselvitysPage: React.FC = () => {
 
   const applicationQueryResult = useApplication(Number(id));
   const hankeQueryResult = useHanke(applicationQueryResult.data?.hankeTunnus);
+
+  const applicationId = sessionStorage.getItem(APPLICATION_ID_STORAGE_KEY);
+  if (applicationId) {
+    sessionStorage.removeItem(APPLICATION_ID_STORAGE_KEY);
+  }
 
   if (applicationQueryResult.isLoading || hankeQueryResult?.isLoading) {
     return (

--- a/src/pages/Johtoselvitys.tsx
+++ b/src/pages/Johtoselvitys.tsx
@@ -1,16 +1,28 @@
 import React from 'react';
 import { Flex } from '@chakra-ui/react';
 import { LoadingSpinner } from 'hds-react';
+import { Navigate } from 'react-router-dom';
 import Container from '../common/components/container/Container';
 import PageMeta from './components/PageMeta';
 import { useLocalizedRoutes } from '../common/hooks/useLocalizedRoutes';
 import JohtoselvitysContainer from '../domain/johtoselvitys/JohtoselvitysContainer';
 import { useHankeDataInApplication } from '../domain/application/hooks/useHankeDataInApplication';
+import useLinkPath from '../common/hooks/useLinkPath';
+import { ROUTES } from '../common/types/route';
+import { APPLICATION_ID_STORAGE_KEY } from '../domain/application/constants';
 
 const Johtoselvitys: React.FC = () => {
   const { JOHTOSELVITYSHAKEMUS } = useLocalizedRoutes();
+  const getEditApplicationPath = useLinkPath(ROUTES.EDIT_JOHTOSELVITYSHAKEMUS);
 
   const result = useHankeDataInApplication();
+
+  // Navigate to edit route if application id exists in session storage,
+  // which means user refreshed the page while creating new application.
+  const applicationId = sessionStorage.getItem(APPLICATION_ID_STORAGE_KEY);
+  if (applicationId) {
+    return <Navigate to={getEditApplicationPath({ id: applicationId })} />;
+  }
 
   if (result?.isLoading) {
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,13 +1736,6 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.7.6":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
-  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/template@^7.10.4", "@babel/template@^7.3.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -3126,6 +3119,11 @@
     redux "^4.0.0"
     redux-thunk "^2.3.0"
     reselect "^4.0.0"
+
+"@remix-run/router@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.6.3.tgz#8205baf6e17ef93be35bf62c37d2d594e9be0dad"
+  integrity sha512-EXJysQ7J3veRECd0kZFQwYYd5sJMcq2O/m60zu1W2l3oVQ9xtub8jTOtYRE0+M2iomyG/W3Ps7+vp2kna0C27Q==
 
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
@@ -9163,13 +9161,6 @@ hey-listen@^1.0.8:
   resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
   integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
-history@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
-  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
-
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -14418,20 +14409,20 @@ react-remove-scroll@2.4.0:
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
 
-react-router-dom@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
-  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+react-router-dom@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.13.0.tgz#6651f456bb2af42ef14f6880123b1f575539e81f"
+  integrity sha512-6Nqoqd7fgwxxVGdbiMHTpDHCYPq62d7Wk1Of7B82vH7ZPwwsRaIa22zRZKPPg413R5REVNiyuQPKDG1bubcOFA==
   dependencies:
-    history "^5.2.0"
-    react-router "6.3.0"
+    "@remix-run/router" "1.6.3"
+    react-router "6.13.0"
 
-react-router@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
-  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+react-router@6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.13.0.tgz#7e4427a271dae0cafbdb88c56ccbd9b1434ee93f"
+  integrity sha512-Si6KnfEnJw7gUQkNa70dlpI1bul46FuSxX5t5WwlUBxE25DAz2BjVkwaK8Y2s242bQrZPXCpmwLPtIO5pv4tXg==
   dependencies:
-    history "^5.2.0"
+    "@remix-run/router" "1.6.3"
 
 react-scripts@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
# Description

When user is creating new cable report application and if the application has been saved, application id is saved to sessionStorage when user refreshes the page so that user can be redirected to edit view.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1763

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Go to create new cable report application and make sure that the application is saved by going to next page. Then refresh the page and check that you are editing the same application you just created.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
