### PR TITLE
HAI-1794 Fix problem where visiting different language url than selected language would show 404 page

### DIFF
--- a/src/common/components/header/Header.tsx
+++ b/src/common/components/header/Header.tsx
@@ -7,7 +7,6 @@ import { getMatchingRouteKey, useLocalizedRoutes } from '../../hooks/useLocalize
 import authService from '../../../domain/auth/authService';
 import useUser from '../../../domain/auth/useUser';
 import { Language, LANGUAGES } from '../../types/language';
-import { I18NLANGKEY } from '../../../locales/constants';
 import { SKIP_TO_ELEMENT_ID } from '../../constants/constants';
 import { useFeatureFlags } from '../featureFlags/FeatureFlagsContext';
 
@@ -47,7 +46,6 @@ const Header: React.FC = () => {
   const navigate = useNavigate();
 
   async function setLanguage(lang: Language) {
-    localStorage.setItem(I18NLANGKEY, lang);
     const routeKey = getMatchingRouteKey(i18n, i18n.language as Language, location.pathname);
     await i18n.changeLanguage(lang);
     const to = lang + t(`routes:${routeKey}.path`);

--- a/src/domain/auth/components/OidcCallback.test.tsx
+++ b/src/domain/auth/components/OidcCallback.test.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
-import { cleanup, waitFor } from '@testing-library/react';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { render } from '../../../testUtils/render';
+import { Routes, Route, MemoryRouter } from 'react-router-dom';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
 import authService from '../authService';
 import OidcCallback from './OidcCallback';
 import { LOGIN_CALLBACK_PATH } from '../constants';
+import i18n from '../../../locales/i18nForTests';
 
 const getWrapper = () =>
   render(
-    <Routes>
-      <Route path={LOGIN_CALLBACK_PATH} element={<OidcCallback />} />
-    </Routes>,
-    {},
-    LOGIN_CALLBACK_PATH
+    <MemoryRouter initialEntries={[LOGIN_CALLBACK_PATH]}>
+      <I18nextProvider i18n={i18n}>
+        <Routes>
+          <Route path={LOGIN_CALLBACK_PATH} element={<OidcCallback />} />
+        </Routes>
+      </I18nextProvider>
+    </MemoryRouter>
   );
 
 describe('<OidcCallback />', () => {

--- a/src/domain/auth/components/OidcCallback.tsx
+++ b/src/domain/auth/components/OidcCallback.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Flex } from '@chakra-ui/react';
-import { useNavigate } from 'react-router-dom';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link as HDSLink } from 'hds-react';
 import authService from '../authService';
@@ -52,7 +51,6 @@ const AuthError = ({ errorText }: AuthErrorProps) => {
 };
 
 const OidcCallback = () => {
-  const navigate = useNavigate();
   const { t } = useTranslation();
   const [authenticationError, setAuthenticationError] = useState<AuthenticationError | null>(null);
 
@@ -60,7 +58,7 @@ const OidcCallback = () => {
     authService
       .endLogin()
       .then(() => {
-        navigate('/');
+        window.location.pathname = '/';
       })
       .catch((error: Error) => {
         // Handle error caused by device time being more than 5 minutes off
@@ -80,7 +78,7 @@ const OidcCallback = () => {
           setAuthenticationError('unknown');
         }
       });
-  }, [navigate, t]);
+  }, [t]);
 
   return (
     <>

--- a/src/locales/constants.ts
+++ b/src/locales/constants.ts
@@ -1,1 +1,0 @@
-export const I18NLANGKEY = 'i18nextLng';

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -15,7 +15,8 @@ i18n
       sv,
     },
     detection: {
-      order: ['localStorage', 'sessionStorage', 'path'],
+      order: ['path', 'localStorage', 'sessionStorage'],
+      excludeCacheFor: ['login'],
     },
     fallbackLng: 'fi',
     debug: false,


### PR DESCRIPTION
# Description

Changed language detection order so that path is before localStorage so that language in the url path takes priority when detecting UI language.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1794

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Paste different language url to browser address bar than UI:s selected language (for example /en/projectportfolio when current language is Finnish) and check that correct page is opened and that UI language is changed to correct one.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: