### PR TITLE
HAI-1833 Remove trailing slash from Hankkeet URL

### DIFF
--- a/src/domain/hanke/portfolio/HankePortfolioContainer.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioContainer.tsx
@@ -5,7 +5,7 @@ import { HankeData } from '../../types/hanke';
 import HankePortfolioComponent from './HankePortfolioComponent';
 
 const getHankkeet = async () => {
-  const { data } = await api.get<HankeData[]>(`/hankkeet/`, {
+  const { data } = await api.get<HankeData[]>(`/hankkeet`, {
     params: {
       geometry: true,
     },


### PR DESCRIPTION
# Description

Backend has deprecated support for URLs with trailing slashes, so remove them from the frontend.

Only one such URL seems to be called, the hanke list. Change the URL to one without the trailing slash.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1833

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Other