### PR TITLE
HAI-1807 Make sure that external links have aria-labels and correct icons

### DIFF
--- a/src/common/components/header/Header.tsx
+++ b/src/common/components/header/Header.tsx
@@ -42,6 +42,10 @@ const Header: React.FC = () => {
     end: false,
   });
 
+  const workInstructionsAriaLabel = `${t('routes:WORKINSTRUCTIONS:headerLabel')}. ${t(
+    'common:components:link:openInNewTabAriaLabel'
+  )} ${t('common:components:link:openInExternalDomainAriaLabel')}`;
+
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -95,6 +99,7 @@ const Header: React.FC = () => {
             target="_blank"
             rel="noreferrer"
             icon={<IconLinkExternal />}
+            aria-label={workInstructionsAriaLabel}
           >
             {t('routes:WORKINSTRUCTIONS:headerLabel')}
           </Navigation.Item>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -22,6 +22,10 @@
       "confirmButton": "Vahvista"
     },
     "components": {
+      "link": {
+        "openInNewTabAriaLabel": "Avautuu uudessa välilehdessä.",
+        "openInExternalDomainAriaLabel": "Siirtyy toiseen sivustoon."
+      },
       "linkbox": {
         "linkbox": "Linkkialue"
       },

--- a/src/pages/staticPages/ManualPage.tsx
+++ b/src/pages/staticPages/ManualPage.tsx
@@ -33,6 +33,11 @@ const ManualPage: React.FC = () => {
             rel="noreferrer"
             style={{ color: 'var(--color-coat-of-arms)' }}
             openInNewTab
+            external
+            openInNewTabAriaLabel={t('common:components:link:openInNewTabAriaLabel')}
+            openInExternalDomainAriaLabel={t(
+              'common:components:link:openInExternalDomainAriaLabel'
+            )}
           >
             {t('staticPages:manualPage:linkText')}
           </Link>


### PR DESCRIPTION
# Description

Work instructions link in header was missing aria-label, and manual link in manual page was missing the external link icon, so added those.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1807

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
