### PR TITLE
HAI-1469 Make Helsinki logo to be language dependant

### DIFF
--- a/src/common/components/footer/Footer.tsx
+++ b/src/common/components/footer/Footer.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Footer } from 'hds-react';
+import { Footer, LogoLanguage } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { useLocalizedRoutes } from '../../hooks/useLocalizedRoutes';
 
 const HaitatonFooter: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { MANUAL, HAITATON_INFO, ACCESSIBILITY, PRIVACY_POLICY } = useLocalizedRoutes();
 
   return (
-    <Footer title="Haitaton">
+    <Footer title="Haitaton" logoLanguage={i18n.language as LogoLanguage}>
       <Footer.Navigation
         variant="minimal"
         navigationAriaLabel={t('common:ariaLabels:footerNavigation')}

--- a/src/common/components/header/Header.tsx
+++ b/src/common/components/header/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconLinkExternal, IconSignout, Navigation } from 'hds-react';
+import { IconLinkExternal, IconSignout, LogoLanguage, Navigation } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { NavLink, useMatch, useLocation, useNavigate } from 'react-router-dom';
 import { $enum } from 'ts-enum-util';
@@ -60,6 +60,7 @@ const Header: React.FC = () => {
       skipToContentLabel={t('common:components:header:skipToContentLabel')}
       titleUrl={HOME.path}
       className="header"
+      logoLanguage={i18n.language as LogoLanguage}
     >
       {isAuthenticated && (
         <Navigation.Row ariaLabel={t('common:ariaLabels:topNavigation')}>


### PR DESCRIPTION
# Description

Defined logoLanguage prop for Navigation and Footer components so that Helsinki logo language is changed when UI language is changed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1469

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

When changing language to Swedish check that Helsinki logo language is changed to Swedish and otherwise is in Finnish.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
