### PR TITLE
HAI-1574 Add possibility to toggle two map layers in cable report application form

### DIFF
--- a/src/common/components/map/controls/Controls.module.scss
+++ b/src/common/components/map/controls/Controls.module.scss
@@ -18,7 +18,8 @@
 
 .controlMenu {
   background: var(--color-white);
-  padding: var(--spacing-xs) var(--spacing-xs) var(--spacing-xs) var(--spacing-3-xs);
+  padding: var(--spacing-s) var(--spacing-xs) var(--spacing-xs) var(--spacing-3-xs);
+  border: 2px solid var(--color-black-60) !important;
 
   &__divider {
     margin-top: var(--spacing-xs);
@@ -30,9 +31,10 @@
   position: absolute;
   top: var(--spacing-s);
   right: var(--spacing-s);
+  background: var(--color-black-80);
 
   &__button {
-    padding: var(--spacing-3-xs);
+    padding: var(--spacing-3-xs) var(--spacing-2-xs);
   }
 }
 

--- a/src/common/components/map/controls/LayerControl.tsx
+++ b/src/common/components/map/controls/LayerControl.tsx
@@ -5,17 +5,17 @@ import { useTranslation } from 'react-i18next';
 import { Checkbox } from 'hds-react';
 import ControlPanel from './ControlPanel';
 import styles from './Controls.module.scss';
+import { MapTileLayerId } from '../../../../domain/map/types';
 
 type TileLayer = {
-  id: string;
+  id: MapTileLayerId;
   visible: boolean;
 };
 
 type Props = {
   tileLayers: TileLayer[];
   // I dont want to import type from domain. Maybe move layers here under common dir?
-  // eslint-disable-next-line
-  onClickTileLayer: (key: any) => void; // TODO: improve type definition
+  onClickTileLayer: (key: MapTileLayerId) => void;
 };
 
 const LayerControl: React.FC<Props> = ({ tileLayers, onClickTileLayer }) => {
@@ -27,10 +27,11 @@ const LayerControl: React.FC<Props> = ({ tileLayers, onClickTileLayer }) => {
         <MenuButton
           aria-label={t('map:controls:ariaLayerMenu')}
           type="button"
+          className={styles.tileLayerControl__button}
           // Disable form submit
           onClick={() => false}
         >
-          <IconLayers aria-hidden />
+          <IconLayers aria-hidden color="white" />
         </MenuButton>
         <MenuList className={styles.controlMenu} aria-hidden id="layer-list" role="menu">
           <MenuGroup>

--- a/src/common/components/map/layers/TileLayer.tsx
+++ b/src/common/components/map/layers/TileLayer.tsx
@@ -8,9 +8,10 @@ type Props = {
   minZoom?: number;
   maxZoom?: number;
   zIndex?: number;
+  opacity?: number;
 };
 
-const TileLayer: React.FC<Props> = ({ source, minZoom, maxZoom, zIndex = 0 }) => {
+const TileLayer: React.FC<Props> = ({ source, minZoom, maxZoom, zIndex = 0, opacity = 1 }) => {
   const { map } = useContext(MapContext);
 
   useEffect(() => {
@@ -21,6 +22,7 @@ const TileLayer: React.FC<Props> = ({ source, minZoom, maxZoom, zIndex = 0 }) =>
       minZoom,
       maxZoom,
       zIndex,
+      opacity,
     });
 
     map.addLayer(tileLayer);
@@ -32,7 +34,7 @@ const TileLayer: React.FC<Props> = ({ source, minZoom, maxZoom, zIndex = 0 }) =>
         map.removeLayer(tileLayer);
       }
     };
-  }, [map, maxZoom, minZoom, zIndex, source]);
+  }, [map, maxZoom, minZoom, zIndex, source, opacity]);
 
   return null;
 };

--- a/src/domain/johtoselvitys/Geometries.test.tsx
+++ b/src/domain/johtoselvitys/Geometries.test.tsx
@@ -3,7 +3,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { render, screen } from '../../testUtils/render';
 import { Geometries } from './Geometries';
 
-jest.setTimeout(10000);
+jest.setTimeout(30000);
 
 function TestComponent() {
   const formContext = useForm();

--- a/src/domain/johtoselvitys/Geometries.tsx
+++ b/src/domain/johtoselvitys/Geometries.tsx
@@ -32,6 +32,10 @@ import useForceUpdate from '../../common/hooks/useForceUpdate';
 import { getAreaDefaultName } from '../application/utils';
 import FeatureHoverBox from '../map/components/FeatureHoverBox/FeatureHoverBox';
 import ConfirmationDialog from '../../common/components/HDSConfirmationDialog/ConfirmationDialog';
+import LayerControl from '../../common/components/map/controls/LayerControl';
+import { MapTileLayerId } from '../map/types';
+import { useMapDataLayers } from '../map/hooks/useMapLayers';
+import Ortokartta from '../map/components/Layers/Ortokartta';
 
 interface AreaToRemove {
   index: number;
@@ -84,6 +88,9 @@ export const Geometries: React.FC = () => {
   );
 
   const [featuresLoaded, setFeaturesLoaded] = useState(false);
+
+  const { mapTileLayers, toggleMapTileLayer } = useMapDataLayers();
+  const ortoLayerOpacity = mapTileLayers.kantakartta.visible ? 0.5 : 1;
 
   useEffect(() => {
     function handleAddFeature(e: VectorSourceEvent<Geometry>) {
@@ -196,7 +203,8 @@ export const Geometries: React.FC = () => {
 
       <div className={styles.mapContainer}>
         <Map zoom={9} center={addressCoordinate} mapClassName={styles.mapContainer__inner}>
-          <Kantakartta />
+          {mapTileLayers.kantakartta.visible && <Kantakartta />}
+          {mapTileLayers.ortokartta.visible && <Ortokartta opacity={ortoLayerOpacity} />}
 
           <AddressSearchContainer position={{ top: '1rem', left: '1rem' }} zIndex={101} />
 
@@ -220,6 +228,11 @@ export const Geometries: React.FC = () => {
                 onSelfIntersectingPolygon={handleSelfIntersectingPolygon}
               />
             )}
+
+            <LayerControl
+              tileLayers={Object.values(mapTileLayers)}
+              onClickTileLayer={(id: MapTileLayerId) => toggleMapTileLayer(id)}
+            />
           </Controls>
         </Map>
       </div>

--- a/src/domain/map/HankeMap.test.tsx
+++ b/src/domain/map/HankeMap.test.tsx
@@ -17,7 +17,7 @@ describe('HankeMap', () => {
     expect(screen.getByLabelText('Kantakartta')).toBeChecked();
     await user.click(screen.getByText('Ortokartta'));
     expect(screen.getByLabelText('Ortokartta')).toBeChecked();
-    expect(screen.getByLabelText('Kantakartta')).not.toBeChecked();
+    expect(screen.getByLabelText('Kantakartta')).toBeChecked();
   });
 
   test('Number of projects displayed on the map can be controlled with dateRangeControl', async () => {

--- a/src/domain/map/HankeMap.tsx
+++ b/src/domain/map/HankeMap.tsx
@@ -23,6 +23,7 @@ import AddressSearchContainer from './components/AddressSearch/AddressSearchCont
 const HankeMap: React.FC = () => {
   const [zoom] = useState(9); // TODO: also take zoom into consideration
   const { mapTileLayers, toggleMapTileLayer } = useMapDataLayers();
+  const ortoLayerOpacity = mapTileLayers.kantakartta.visible ? 0.5 : 1;
   const {
     hankeFilterStartDate,
     hankeFilterEndDate,
@@ -36,8 +37,8 @@ const HankeMap: React.FC = () => {
         <AddressSearchContainer position={{ top: '1rem', left: '1rem' }} />
 
         <MapGuide />
-        {mapTileLayers.ortokartta.visible && <Ortokartta />}
         {mapTileLayers.kantakartta.visible && <Kantakartta />}
+        {mapTileLayers.ortokartta.visible && <Ortokartta opacity={ortoLayerOpacity} />}
         <OverviewMapControl />
 
         <HankkeetProvider>

--- a/src/domain/map/components/HankeDrawer/HankeDrawer.tsx
+++ b/src/domain/map/components/HankeDrawer/HankeDrawer.tsx
@@ -43,6 +43,7 @@ const HankeDrawer: React.FC<Props> = ({
   zoom = 9,
 }) => {
   const { mapTileLayers, toggleMapTileLayer, handleUpdateGeometryState } = useMapDataLayers();
+  const ortoLayerOpacity = mapTileLayers.kantakartta.visible ? 0.5 : 1;
   const [drawSource] = useState<VectorSource>(existingDrawSource || new VectorSource());
 
   const featuresLoaded = useRef(false);
@@ -110,7 +111,7 @@ const HankeDrawer: React.FC<Props> = ({
           <OverviewMapControl className={hankeDrawerStyles.overviewMap} />
 
           {mapTileLayers.kantakartta.visible && <Kantakartta />}
-          {mapTileLayers.ortokartta.visible && <Ortokartta />}
+          {mapTileLayers.ortokartta.visible && <Ortokartta opacity={ortoLayerOpacity} />}
           <VectorLayer source={drawSource} zIndex={100} className="drawLayer" />
 
           {featuresLoaded.current && <FitSource source={drawSource} />}

--- a/src/domain/map/components/Layers/Ortokartta.tsx
+++ b/src/domain/map/components/Layers/Ortokartta.tsx
@@ -1,29 +1,40 @@
 import React from 'react';
 import { TileWMS } from 'ol/source';
+import { useTranslation } from 'react-i18next';
 import TileLayer from '../../../../common/components/map/layers/TileLayer';
 import { projection } from '../../../../common/components/map/utils';
 
-const Ortokartta = () => (
-  <TileLayer
-    zIndex={2}
-    source={
-      new TileWMS({
-        url: 'https://kartta.hel.fi/ws/geoserver/avoindata/wms',
-        params: {
-          LAYERS: 'Ortoilmakuva',
-          FORMAT: 'image/jpeg',
-          WIDTH: 256,
-          HEIGHT: 256,
-          VERSION: '1.1.1',
-          TRANSPARENT: 'false',
-        },
-        projection: projection || undefined,
-        hidpi: false,
-        transition: 0,
-        attributions: ['Aineistot &copy; <a href="https://kartta.hel.fi">Helsingin kaupunki</a>'],
-      })
-    }
-  />
-);
+type Props = {
+  // eslint-disable-next-line react/require-default-props
+  opacity?: number;
+};
+
+function Ortokartta({ opacity }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <TileLayer
+      zIndex={2}
+      source={
+        new TileWMS({
+          url: 'https://kartta.hel.fi/ws/geoserver/avoindata/wms',
+          params: {
+            LAYERS: 'Ortoilmakuva',
+            FORMAT: 'image/jpeg',
+            WIDTH: 256,
+            HEIGHT: 256,
+            VERSION: '1.1.1',
+            TRANSPARENT: 'false',
+          },
+          projection: projection || undefined,
+          hidpi: false,
+          transition: 0,
+          attributions: [t('map:attribution')],
+        })
+      }
+      opacity={opacity}
+    />
+  );
+}
 
 export default React.memo(Ortokartta);

--- a/src/domain/map/reducer.ts
+++ b/src/domain/map/reducer.ts
@@ -14,11 +14,7 @@ const toggleMapTileLayer: CaseReducer<ReducerState, PayloadAction<MapTileLayerId
   state,
   action
 ) => {
-  (Object.keys(state.mapTileLayers) as Array<keyof typeof state.mapTileLayers>).forEach(
-    (mapTileLayerKey) => {
-      state.mapTileLayers[mapTileLayerKey].visible = action.payload === mapTileLayerKey;
-    }
-  );
+  state.mapTileLayers[action.payload].visible = !state.mapTileLayers[action.payload].visible;
 };
 
 const updateDrawGeometry: CaseReducer<ReducerState, PayloadAction<HankeGeoJSON>> = (
@@ -54,8 +50,8 @@ const initialState: ReducerState = {
   drawGeometry: null,
   visibleLayers: [],
   mapTileLayers: {
-    [MAPTILES.ORTOKARTTA]: buildTilelayerState(MAPTILES.ORTOKARTTA, false),
     [MAPTILES.KANTAKARTTA]: buildTilelayerState(MAPTILES.KANTAKARTTA, true),
+    [MAPTILES.ORTOKARTTA]: buildTilelayerState(MAPTILES.ORTOKARTTA, false),
   },
   hankeFilters: {
     startDate: `${currentYear}-01-01`,


### PR DESCRIPTION
# Description

Added orto map layer to cable report application form and the control to toggle it and base map layer on/off. If both layers are on, the orto map layer is displayed at 50% opacity on top of the base map layer.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1574

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Navigate to areas page of cable report application form and check that map layers can be toggled on/off from the menu in top right corner of the map.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
