### PR TITLE
HAI-1840 Update work instructions link

### DIFF
--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -318,7 +318,7 @@
       }
     },
     "WORKINSTRUCTIONS": {
-      "path": "https://www.hel.fi/fi/kaupunkiymparisto-ja-liikenne/tontit-ja-rakentamisen-luvat/rakentamisvaiheen-ohjeet",
+      "path": "https://www.hel.fi/fi/kaupunkiymparisto-ja-liikenne/tontit-ja-rakentamisen-luvat/tyomaan-luvat-ja-ohjeet",
       "headerLabel": "Työohjeet",
       "meta": {
         "title": "Haitaton - Työohjeet"


### PR DESCRIPTION
# Description

Updated work instructions link in nav bar and front page to match the new version of hel.fi site.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1840

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Check that work instructions link (Työohjeet) goes here https://www.hel.fi/fi/kaupunkiymparisto-ja-liikenne/tontit-ja-rakentamisen-luvat/tyomaan-luvat-ja-ohjeet when UI language is Finnish. There are no translations for other languages of that page.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
