### PR TITLE
HAI-1755 Don't send duplicate attachements in cable report application

### DIFF
--- a/src/domain/application/attachments.test.ts
+++ b/src/domain/application/attachments.test.ts
@@ -1,0 +1,73 @@
+import { removeDuplicateAttachments } from './attachments';
+import { ApplicationAttachmentMetadata } from './types/application';
+
+const attachments: ApplicationAttachmentMetadata[] = [
+  {
+    id: '5842de6c-9521-4053-92b7-ae1370ab7e93',
+    fileName: 'Haitaton_liite.png',
+    createdByUserId: 'b9a58f4c-f5fe-11ec-997f-0a580a800284',
+    createdAt: '2023-08-15T08:40:05.948818Z',
+    applicationId: 1,
+    attachmentType: 'MUU',
+  },
+  {
+    id: '4a61945e-a43f-4ee5-8239-1329b4809954',
+    fileName: 'Haitaton_liite_2.txt',
+    createdByUserId: 'b9a58f4c-f5fe-11ec-997f-0a580a800284',
+    createdAt: '2023-08-15T08:40:06.004338Z',
+    applicationId: 1,
+    attachmentType: 'MUU',
+  },
+  {
+    id: 'cfeba660-d415-4557-84f9-818eb64a3483',
+    fileName: 'Haitaton_liite_3.jpg',
+    createdByUserId: 'b9a58f4c-f5fe-11ec-997f-0a580a800284',
+    createdAt: '2023-08-15T12:32:17.923746Z',
+    applicationId: 1,
+    attachmentType: 'MUU',
+  },
+  {
+    id: '58584665-5ed3-478b-95ab-c140c52e3408',
+    fileName: 'Haitaton_liite_4.pdf',
+    createdByUserId: 'b9a58f4c-f5fe-11ec-997f-0a580a800284',
+    createdAt: '2023-08-15T12:32:32.746984Z',
+    applicationId: 1,
+    attachmentType: 'MUU',
+  },
+];
+
+test('Should filter out existing attachments', () => {
+  const files = [
+    new File([''], 'Haitaton_liite.png'),
+    new File([''], 'Haitaton_liite_2.txt'),
+    new File([''], 'Haitaton_liite_uusi.pdf'),
+    new File([''], 'Haitaton_liite_3.jpg'),
+    new File([''], 'Haitaton_liite_uusi_2.jpg'),
+    new File([''], 'Haitaton_liite_4.pdf'),
+  ];
+
+  expect(removeDuplicateAttachments(files, attachments)).toMatchObject([
+    { name: 'Haitaton_liite_uusi.pdf' },
+    { name: 'Haitaton_liite_uusi_2.jpg' },
+  ]);
+});
+
+test('Should not filter out anything from only new files', () => {
+  const files = [
+    new File([''], 'Haitaton_liite_uusi.pdf'),
+    new File([''], 'Haitaton_liite_uusi_2.jpg'),
+    new File([''], 'Haitaton_liite_uusi_3.jpg'),
+  ];
+
+  expect(removeDuplicateAttachments(files, attachments)).toMatchObject([
+    { name: 'Haitaton_liite_uusi.pdf' },
+    { name: 'Haitaton_liite_uusi_2.jpg' },
+    { name: 'Haitaton_liite_uusi_3.jpg' },
+  ]);
+
+  expect(removeDuplicateAttachments(files, [])).toMatchObject([
+    { name: 'Haitaton_liite_uusi.pdf' },
+    { name: 'Haitaton_liite_uusi_2.jpg' },
+    { name: 'Haitaton_liite_uusi_3.jpg' },
+  ]);
+});

--- a/src/domain/application/attachments.ts
+++ b/src/domain/application/attachments.ts
@@ -50,3 +50,13 @@ export async function deleteAttachment({
 }) {
   await api.delete(`/hakemukset/${applicationId}/liitteet/${attachmentId}`);
 }
+
+// Filter out duplicate files based on file name
+export function removeDuplicateAttachments(
+  files: File[],
+  attachments: ApplicationAttachmentMetadata[] | undefined
+) {
+  return files.filter((file) =>
+    attachments?.every((attachment) => attachment.fileName !== file.name)
+  );
+}

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -34,7 +34,7 @@ import useHanke from '../hanke/hooks/useHanke';
 import { AlluStatus, Application } from '../application/types/application';
 import Attachments from './Attachments';
 import ConfirmationDialog from '../../common/components/HDSConfirmationDialog/ConfirmationDialog';
-import { uploadAttachment } from '../application/attachments';
+import { removeDuplicateAttachments, uploadAttachment } from '../application/attachments';
 import useAttachments from '../application/hooks/useAttachments';
 import { APPLICATION_ID_STORAGE_KEY } from '../application/constants';
 
@@ -284,9 +284,7 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
     }
 
     // Filter out attachments that have same names as those that have already been sent
-    const filesToSend = newAttachments.filter((file) =>
-      existingAttachments?.every((attachment) => attachment.fileName !== file.name)
-    );
+    const filesToSend = removeDuplicateAttachments(newAttachments, existingAttachments);
 
     const mutations = filesToSend.map((file) =>
       attachmentUploadMutation.mutateAsync({

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -283,7 +283,12 @@ const JohtoselvitysContainer: React.FC<Props> = ({ hankeData, application }) => 
       return Promise.resolve();
     }
 
-    const mutations = newAttachments.map((file) =>
+    // Filter out attachments that have same names as those that have already been sent
+    const filesToSend = newAttachments.filter((file) =>
+      existingAttachments?.every((attachment) => attachment.fileName !== file.name)
+    );
+
+    const mutations = filesToSend.map((file) =>
       attachmentUploadMutation.mutateAsync({
         applicationId,
         attachmentType: 'MUU',


### PR DESCRIPTION
# Description

Check name of each attachment that is being sent and if there already is an attachment of that name in the application don't send that attachment again.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1755

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Try to send attachment of same name as exists in cable report application and check in the summary page that there are no duplicates.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
