### PR TITLE
HAI-1838 Enable adding business id also for association in cable report application

### DIFF
--- a/src/domain/johtoselvitys/Contacts.test.tsx
+++ b/src/domain/johtoselvitys/Contacts.test.tsx
@@ -41,16 +41,11 @@ test('Contacts can be filled with hanke contact info', async () => {
   );
 });
 
-test('Business id field is disabled if customer type not company', () => {
+test('Business id field is disabled if customer type is not company or association', () => {
   render(<Form />);
 
   fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
   fireEvent.click(screen.getAllByText(/yksityishenkilö/i)[0]);
-
-  expect(screen.getAllByLabelText(/y-tunnus/i)[0]).toBeDisabled();
-
-  fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
-  fireEvent.click(screen.getAllByText(/yhdistys/i)[0]);
 
   expect(screen.getAllByLabelText(/y-tunnus/i)[0]).toBeDisabled();
 
@@ -60,11 +55,16 @@ test('Business id field is disabled if customer type not company', () => {
   expect(screen.getAllByLabelText(/y-tunnus/i)[0]).toBeDisabled();
 });
 
-test('Business id field is not disabled if customer type is company', () => {
+test('Business id field is not disabled if customer type is company or association', () => {
   render(<Form />);
 
   fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
   fireEvent.click(screen.getAllByText(/yritys/i)[0]);
 
-  expect(screen.getAllByLabelText(/y-tunnus/i)[0]).not.toBeDisabled();
+  expect(screen.getAllByLabelText(/y-tunnus/i)[0]).toBeEnabled();
+
+  fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+  fireEvent.click(screen.getAllByText(/yhdistys/i)[0]);
+
+  expect(screen.getAllByLabelText(/y-tunnus/i)[0]).toBeEnabled();
 });

--- a/src/domain/johtoselvitys/Contacts.tsx
+++ b/src/domain/johtoselvitys/Contacts.tsx
@@ -63,8 +63,8 @@ const CustomerFields: React.FC<{ customerType: CustomerType; hankeContacts?: Han
   ]);
 
   useEffect(() => {
-    // If setting contact type to other than company, set null to registry key
-    if (selectedContactType !== 'COMPANY') {
+    // If setting contact type to other than company or association, set null to registry key
+    if (selectedContactType === 'PERSON' || selectedContactType === 'OTHER') {
       setValue(`applicationData.${customerType}.customer.registryKey`, null, {
         shouldValidate: true,
       });
@@ -119,7 +119,7 @@ const CustomerFields: React.FC<{ customerType: CustomerType; hankeContacts?: Han
           <TextInput
             name={`applicationData.${customerType}.customer.registryKey`}
             label={t('form:yhteystiedot:labels:ytunnus')}
-            disabled={selectedContactType !== 'COMPANY'}
+            disabled={selectedContactType === 'PERSON' || selectedContactType === 'OTHER'}
           />
           <TextInput
             name={`applicationData.${customerType}.customer.email`}

--- a/src/domain/johtoselvitys/validationSchema.ts
+++ b/src/domain/johtoselvitys/validationSchema.ts
@@ -26,7 +26,7 @@ const customerSchema = contactSchema.omit(['firstName', 'lastName']).shape({
     .string()
     .nullable()
     .when('type', {
-      is: 'COMPANY',
+      is: (value: string) => value === 'COMPANY' || value === 'ASSOCIATION',
       then: (schema) =>
         schema.test('is-business-id', 'Is not valid business id', isValidBusinessId),
       otherwise: (schema) => schema,


### PR DESCRIPTION
# Description

Made a change that business id can also be entered for association in cable report application form.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1838

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Check that business id (y-tunnus) can be entered for association in cable report application form contacts page.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
