### PR TITLE
HAI-1839 Fix issue where Work is about validation error remains when it shouldn't

### DIFF
--- a/src/domain/johtoselvitys/BasicInfo.tsx
+++ b/src/domain/johtoselvitys/BasicInfo.tsx
@@ -78,13 +78,14 @@ const customerTypes: CustomerType[] = [
 
 type Option = { value: CustomerType; label: string };
 
-export const BasicHankeInfo: React.FC<React.PropsWithChildren<unknown>> = () => {
+export function BasicInfo() {
   const {
     register,
     watch,
     setValue,
     getValues,
     formState: { errors },
+    trigger,
   } = useFormContext<JohtoselvitysFormValues>();
   const { t } = useTranslation();
   const user = useUser();
@@ -107,6 +108,11 @@ export const BasicHankeInfo: React.FC<React.PropsWithChildren<unknown>> = () => 
     'applicationData.propertyConnectivity',
     'applicationData.emergencyWork',
   ]);
+
+  // Trigger validation for constructionWork field
+  function validateConstructionWork() {
+    trigger('applicationData.constructionWork');
+  }
 
   useEffect(() => {
     const userFirstName = user.data?.profile.given_name;
@@ -228,28 +234,39 @@ export const BasicHankeInfo: React.FC<React.PropsWithChildren<unknown>> = () => 
         errorText={errors?.applicationData?.constructionWork && t('form:validations:required')}
       >
         <Checkbox
-          {...register('applicationData.constructionWork')}
+          {...register('applicationData.constructionWork', {
+            // Trigger validation for applicationData.constructionWork when
+            // running onChange handlers for each of these checkboxes
+            // to keep work is about validation error up to date
+            onChange: validateConstructionWork,
+          })}
           id="applicationData.constructionWork"
           name="applicationData.constructionWork"
           label={t('hakemus:labels:constructionWork')}
           checked={constructionWorkChecked}
         />
         <Checkbox
-          {...register('applicationData.maintenanceWork')}
+          {...register('applicationData.maintenanceWork', {
+            onChange: validateConstructionWork,
+          })}
           id="applicationData.maintenanceWork"
           name="applicationData.maintenanceWork"
           label={t('hakemus:labels:maintenanceWork')}
           checked={maintenanceWorkChecked}
         />
         <Checkbox
-          {...register('applicationData.propertyConnectivity')}
+          {...register('applicationData.propertyConnectivity', {
+            onChange: validateConstructionWork,
+          })}
           id="applicationData.propertyConnectivity"
           name="applicationData.propertyConnectivity"
           label={t('hakemus:labels:propertyConnectivity')}
           checked={propertyConnectivityChecked}
         />
         <Checkbox
-          {...register('applicationData.emergencyWork')}
+          {...register('applicationData.emergencyWork', {
+            onChange: validateConstructionWork,
+          })}
           id="applicationData.emergencyWork"
           name="applicationData.emergencyWork"
           label={t('hakemus:labels:emergencyWork')}
@@ -360,4 +377,4 @@ export const BasicHankeInfo: React.FC<React.PropsWithChildren<unknown>> = () => 
       })}
     </div>
   );
-};
+}

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -10,7 +10,7 @@ import { Box } from '@chakra-ui/react';
 import { useBeforeUnload } from 'react-router-dom';
 
 import { JohtoselvitysFormValues } from './types';
-import { BasicHankeInfo } from './BasicInfo';
+import { BasicInfo } from './BasicInfo';
 import { Contacts } from './Contacts';
 import { Geometries } from './Geometries';
 import { ReviewAndSend } from './ReviewAndSend';
@@ -352,7 +352,7 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
 
     return [
       {
-        element: <BasicHankeInfo />,
+        element: <BasicInfo />,
         label: t('form:headers:perustiedot'),
         state: StepState.available,
       },

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -572,3 +572,34 @@ test('Should not allow to edit own info when application has been sent to Allu',
     screen.getByTestId('applicationData.customerWithContacts.contacts.0.phone'),
   ).toBeDisabled();
 });
+
+test('Validation error is shown if no work is about checkbox is selected', async () => {
+  const { user } = render(<JohtoselvitysContainer />);
+
+  await user.click(screen.getByLabelText(/uuden rakenteen tai johdon rakentamisesta/i));
+  await user.click(screen.getByLabelText(/uuden rakenteen tai johdon rakentamisesta/i));
+  expect(screen.queryByText('Kenttä on pakollinen')).toBeInTheDocument();
+
+  await user.click(screen.getByLabelText(/olemassaolevan rakenteen kunnossapitotyöstä/i));
+  expect(screen.queryByText('Kenttä on pakollinen')).not.toBeInTheDocument();
+  await user.click(screen.getByLabelText(/olemassaolevan rakenteen kunnossapitotyöstä/i));
+  expect(screen.queryByText('Kenttä on pakollinen')).toBeInTheDocument();
+
+  await user.click(screen.getByLabelText(/kiinteistöliittymien rakentamisesta/i));
+  expect(screen.queryByText('Kenttä on pakollinen')).not.toBeInTheDocument();
+  await user.click(screen.getByLabelText(/kiinteistöliittymien rakentamisesta/i));
+  expect(screen.queryByText('Kenttä on pakollinen')).toBeInTheDocument();
+
+  await user.click(
+    screen.getByLabelText(
+      /kaivutyö on aloitettu ennen johtoselvityksen tilaamista merkittävien vahinkojen välttämiseksi/i,
+    ),
+  );
+  expect(screen.queryByText('Kenttä on pakollinen')).not.toBeInTheDocument();
+  await user.click(
+    screen.getByLabelText(
+      /kaivutyö on aloitettu ennen johtoselvityksen tilaamista merkittävien vahinkojen välttämiseksi/i,
+    ),
+  );
+  expect(screen.queryByText('Kenttä on pakollinen')).toBeInTheDocument();
+});


### PR DESCRIPTION
# Description

Fixed issue in cable report application form where "Work is about" (Työssä on kyse) validation error message would remain even when one of the "Work is about" checkboxes was checked.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1839

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Go trough the steps in the Jira issue and check that error message is not shown.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
