### PR TITLE
HAI-1841 Add better error messages for failed attachment uploads

### DIFF
--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -208,11 +208,13 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
     },
     onError(error: AxiosError, { file }) {
       setAttachmentUploadErrors((errors) => {
-        // TODO: Should show different error texts for different kinds of errors,
-        // once those texts have been defined
+        const errorMessage =
+          error.response?.status === 400
+            ? t('form:errors:fileLoadBadFileError', { fileName: file.name })
+            : t('form:errors:fileLoadTechnicalError', { fileName: file.name });
         return errors.concat(
           <Box as="p" key={file.name} mb="var(--spacing-s)">
-            {file.name}: {t('common:error')}
+            {errorMessage}
           </Box>,
         );
       });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -76,7 +76,9 @@
     "errors": {
       "areaRequired": "At least one area is required",
       "fileLoadError": "Error in loading file",
-      "selfIntersectingArea": "The area borders cannot intersect with each other"
+      "selfIntersectingArea": "The area borders cannot intersect with each other",
+      "fileLoadTechnicalError": "Uploading the file ({{fileName}}) failed. Please try again later.",
+      "fileLoadBadFileError": "There is a problem with the file ({{fileName}}). Please check that the file format is correct and the file size does not exceed 100 MB."
     },
     "headers": {
       "perustiedot": "Basic information",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -80,7 +80,9 @@
     "errors": {
       "areaRequired": "Vähintään yksi alue vaaditaan",
       "fileLoadError": "Tiedoston latauksessa tapahtui virhe",
-      "selfIntersectingArea": "Alueen reunat eivät saa leikata toisiaan"
+      "selfIntersectingArea": "Alueen reunat eivät saa leikata toisiaan",
+      "fileLoadTechnicalError": "Tiedoston ({{fileName}}) lataus epäonnistui, yritä hetken päästä uudelleen.",
+      "fileLoadBadFileError": "Tiedosto ({{fileName}}) on viallinen. Tarkistathan, että tiedostomuoto on oikea eikä sen koko ylitä sallittua maksimikokoa."
     },
     "headers": {
       "perustiedot": "Perustiedot",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -76,7 +76,9 @@
     "errors": {
       "areaRequired": "Det krävs minst ett område",
       "fileLoadError": "Fel i laddning av fil",
-      "selfIntersectingArea": "Områdets kanter får inte skära varandra"
+      "selfIntersectingArea": "Områdets kanter får inte skära varandra",
+      "fileLoadTechnicalError": "Laddning av filen ({{fileName}}) misslyckades, försök igen om en stund.",
+      "fileLoadBadFileError": "Filen ({{fileName}}) är felaktig. Kontrollera att filen har rätt format och att den inte är större än 100 MB."
     },
     "headers": {
       "perustiedot": "Basdata",


### PR DESCRIPTION
# Description

Added specific error messages for failed attachment uploads in cable report application form. One for bad request (when there is something wrong with the file) and one for error caused by technical reason.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1841

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
