### PR TITLE
HAI-1835 Add possibility to copy user's own information to other contacts in cable report application

### DIFF
--- a/src/common/components/textInput/TextInput.tsx
+++ b/src/common/components/textInput/TextInput.tsx
@@ -17,6 +17,7 @@ type PropTypes = {
   helperText?: string;
   shouldUnregister?: boolean;
   className?: string;
+  autoComplete?: string;
 };
 
 const TextInput: React.FC<React.PropsWithChildren<PropTypes>> = ({
@@ -30,6 +31,7 @@ const TextInput: React.FC<React.PropsWithChildren<PropTypes>> = ({
   helperText,
   shouldUnregister,
   className,
+  autoComplete,
 }) => {
   const { t } = useTranslation();
   const { control } = useFormContext();
@@ -57,6 +59,7 @@ const TextInput: React.FC<React.PropsWithChildren<PropTypes>> = ({
           onBlur={onBlur}
           onChange={onChange}
           ref={ref}
+          autoComplete={autoComplete}
           {...tooltip}
         />
       )}

--- a/src/domain/johtoselvitys/BasicInfo.tsx
+++ b/src/domain/johtoselvitys/BasicInfo.tsx
@@ -218,6 +218,7 @@ export function BasicInfo() {
         name="applicationData.name"
         label={t('hakemus:labels:nimi')}
         required
+        autoComplete="on"
       />
 
       <TextInput
@@ -225,6 +226,7 @@ export function BasicInfo() {
         name="applicationData.postalAddress.streetAddress.streetName"
         label={t('form:yhteystiedot:labels:osoite')}
         required
+        autoComplete="street-address"
       />
 
       <SelectionGroup
@@ -362,12 +364,14 @@ export function BasicInfo() {
                   label={t('form:yhteystiedot:labels:email')}
                   required
                   disabled={applicationSent}
+                  autoComplete="email"
                 />
                 <TextInput
                   name={`applicationData.${customerType}.contacts.0.phone`}
                   label={t('form:yhteystiedot:labels:puhelinnumero')}
                   required
                   disabled={applicationSent}
+                  autoComplete="tel"
                 />
               </ResponsiveGrid>
             </React.Fragment>

--- a/src/domain/johtoselvitys/Contacts.module.scss
+++ b/src/domain/johtoselvitys/Contacts.module.scss
@@ -9,3 +9,7 @@
   padding: var(--spacing-s);
   margin-bottom: var(--spacing-s);
 }
+
+.fillOwnInfoButton {
+  align-self: end;
+}

--- a/src/domain/johtoselvitys/Contacts.test.tsx
+++ b/src/domain/johtoselvitys/Contacts.test.tsx
@@ -1,15 +1,22 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { fireEvent, render, screen } from '../../testUtils/render';
 import { Contacts } from './Contacts';
 import hankkeet from '../mocks/data/hankkeet-data';
+import applications from '../mocks/data/hakemukset-data';
 import { HankeContact, HankeDataDraft } from '../types/hanke';
+import { JohtoselvitysFormValues } from './types';
 
 jest.setTimeout(10000);
 
-function Form({ hanke }: { hanke?: HankeDataDraft }) {
-  const methods = useForm({});
+function Form({
+  hanke,
+  application,
+}: {
+  hanke?: HankeDataDraft;
+  application?: JohtoselvitysFormValues;
+}) {
+  const methods = useForm({ defaultValues: application || { applicationData: {} } });
 
   const hankeContacts = [hanke?.omistajat, hanke?.rakennuttajat, hanke?.toteuttajat, hanke?.muut];
 
@@ -67,4 +74,47 @@ test('Business id field is not disabled if customer type is company or associati
   fireEvent.click(screen.getAllByText(/yhdistys/i)[0]);
 
   expect(screen.getAllByLabelText(/y-tunnus/i)[0]).toBeEnabled();
+});
+
+test('Customer fields can be filled with orderer information', async () => {
+  const application = applications[0];
+  const orderer = application.applicationData.customerWithContacts.contacts[0];
+  const { user } = render(<Form application={application} />);
+
+  await user.click(
+    screen.getByTestId('applicationData.customerWithContacts.customer.fillOwnInfoButton'),
+  );
+
+  expect(screen.getByTestId('applicationData.customerWithContacts.customer.name')).toHaveValue(
+    `${orderer.firstName} ${orderer.lastName}`,
+  );
+  expect(screen.getByTestId('applicationData.customerWithContacts.customer.email')).toHaveValue(
+    orderer.email,
+  );
+  expect(screen.getByTestId('applicationData.customerWithContacts.customer.phone')).toHaveValue(
+    orderer.phone,
+  );
+});
+
+test('Contact fields can be filled with orderer information', async () => {
+  const application = applications[0];
+  const orderer = application.applicationData.customerWithContacts.contacts[0];
+  const { user } = render(<Form application={application} />);
+
+  await user.click(
+    screen.getByTestId('applicationData.contractorWithContacts.contacts.0.fillOwnInfoButton'),
+  );
+
+  expect(
+    screen.getByTestId('applicationData.contractorWithContacts.contacts.0.firstName'),
+  ).toHaveValue(orderer.firstName);
+  expect(
+    screen.getByTestId('applicationData.contractorWithContacts.contacts.0.lastName'),
+  ).toHaveValue(orderer.lastName);
+  expect(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.email')).toHaveValue(
+    orderer.email,
+  );
+  expect(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.phone')).toHaveValue(
+    orderer.phone,
+  );
 });

--- a/src/domain/johtoselvitys/Contacts.test.tsx
+++ b/src/domain/johtoselvitys/Contacts.test.tsx
@@ -16,7 +16,7 @@ function Form({
   hanke?: HankeDataDraft;
   application?: JohtoselvitysFormValues;
 }) {
-  const methods = useForm({ defaultValues: application || { applicationData: {} } });
+  const methods = useForm({ defaultValues: application ?? { applicationData: {} } });
 
   const hankeContacts = [hanke?.omistajat, hanke?.rakennuttajat, hanke?.toteuttajat, hanke?.muut];
 

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -126,7 +126,8 @@
       }
     },
     "buttons": {
-      "loadingAttachments": "Ladataan tiedostoja..."
+      "loadingAttachments": "Ladataan tiedostoja...",
+      "fillWithOwnInformation": "Täytä omilla tiedoilla"
     },
     "helperTexts": {
       "dateInForm": "Anna muodossa P.K.VVVV",


### PR DESCRIPTION
# Description

Added button that enables user to copy the information they have entered in the first page of cable report application to other contacts in the contact page.

Also added autocomplete attributes to many of the cable report application text fields.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1835

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Either create new cable report application or edit a previous one
2. Fill the form up to contacts page
3. There should be "Täytä omilla tiedoilla" button with each customer type and their contacts
4. Press the button and check that information filled in the first page as user's own information is copied to corresponding fields. 

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
