### PR TITLE
HAI-1510 Fix lower and upper case names causing problems in table sorting

### DIFF
--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -80,7 +80,7 @@ test('Pagination works', async () => {
   await waitForLoadingToFinish();
   fireEvent.click(screen.getByTestId('hds-pagination-next-button'));
 
-  expect((screen.getByRole('table') as HTMLTableElement).tBodies[0].rows).toHaveLength(1);
+  expect((screen.getByRole('table') as HTMLTableElement).tBodies[0].rows).toHaveLength(2);
   expect(screen.getAllByText(users[10].nimi)).toHaveLength(2);
   expect(screen.getAllByText(users[10].sahkoposti)).toHaveLength(2);
 });
@@ -96,11 +96,11 @@ test('Sorting by users name works', async () => {
   expect(screen.getByTestId('nimi-2')).toHaveTextContent(users[8].nimi);
   expect(screen.getByTestId('nimi-3')).toHaveTextContent(users[5].nimi);
   expect(screen.getByTestId('nimi-4')).toHaveTextContent(users[0].nimi);
-  expect(screen.getByTestId('nimi-5')).toHaveTextContent(users[6].nimi);
-  expect(screen.getByTestId('nimi-6')).toHaveTextContent(users[7].nimi);
-  expect(screen.getByTestId('nimi-7')).toHaveTextContent(users[10].nimi);
-  expect(screen.getByTestId('nimi-8')).toHaveTextContent(users[4].nimi);
-  expect(screen.getByTestId('nimi-9')).toHaveTextContent(users[1].nimi);
+  expect(screen.getByTestId('nimi-5')).toHaveTextContent(users[11].nimi);
+  expect(screen.getByTestId('nimi-6')).toHaveTextContent(users[6].nimi);
+  expect(screen.getByTestId('nimi-7')).toHaveTextContent(users[7].nimi);
+  expect(screen.getByTestId('nimi-8')).toHaveTextContent(users[10].nimi);
+  expect(screen.getByTestId('nimi-9')).toHaveTextContent(users[4].nimi);
 
   fireEvent.click(screen.getByTestId('hds-table-sorting-header-nimi'));
 
@@ -111,9 +111,9 @@ test('Sorting by users name works', async () => {
   expect(screen.getByTestId('nimi-4')).toHaveTextContent(users[7].nimi);
   expect(screen.getByTestId('nimi-5')).toHaveTextContent(users[6].nimi);
   expect(screen.getByTestId('nimi-6')).toHaveTextContent(users[0].nimi);
-  expect(screen.getByTestId('nimi-7')).toHaveTextContent(users[5].nimi);
-  expect(screen.getByTestId('nimi-8')).toHaveTextContent(users[8].nimi);
-  expect(screen.getByTestId('nimi-9')).toHaveTextContent(users[9].nimi);
+  expect(screen.getByTestId('nimi-7')).toHaveTextContent(users[11].nimi);
+  expect(screen.getByTestId('nimi-8')).toHaveTextContent(users[5].nimi);
+  expect(screen.getByTestId('nimi-9')).toHaveTextContent(users[8].nimi);
 });
 
 test('Sorting by users email works', async () => {
@@ -127,11 +127,11 @@ test('Sorting by users email works', async () => {
   expect(screen.getByTestId('sahkoposti-2')).toHaveTextContent(users[8].sahkoposti);
   expect(screen.getByTestId('sahkoposti-3')).toHaveTextContent(users[5].sahkoposti);
   expect(screen.getByTestId('sahkoposti-4')).toHaveTextContent(users[0].sahkoposti);
-  expect(screen.getByTestId('sahkoposti-5')).toHaveTextContent(users[6].sahkoposti);
-  expect(screen.getByTestId('sahkoposti-6')).toHaveTextContent(users[7].sahkoposti);
-  expect(screen.getByTestId('sahkoposti-7')).toHaveTextContent(users[10].sahkoposti);
-  expect(screen.getByTestId('sahkoposti-8')).toHaveTextContent(users[4].sahkoposti);
-  expect(screen.getByTestId('sahkoposti-9')).toHaveTextContent(users[1].sahkoposti);
+  expect(screen.getByTestId('sahkoposti-5')).toHaveTextContent(users[11].sahkoposti);
+  expect(screen.getByTestId('sahkoposti-6')).toHaveTextContent(users[6].sahkoposti);
+  expect(screen.getByTestId('sahkoposti-7')).toHaveTextContent(users[7].sahkoposti);
+  expect(screen.getByTestId('sahkoposti-8')).toHaveTextContent(users[10].sahkoposti);
+  expect(screen.getByTestId('sahkoposti-9')).toHaveTextContent(users[4].sahkoposti);
 
   fireEvent.click(screen.getByTestId('hds-table-sorting-header-sahkoposti'));
 
@@ -141,26 +141,30 @@ test('Sorting by users email works', async () => {
   expect(screen.getByTestId('sahkoposti-3')).toHaveTextContent(users[10].sahkoposti);
   expect(screen.getByTestId('sahkoposti-4')).toHaveTextContent(users[7].sahkoposti);
   expect(screen.getByTestId('sahkoposti-5')).toHaveTextContent(users[6].sahkoposti);
-  expect(screen.getByTestId('sahkoposti-6')).toHaveTextContent(users[0].sahkoposti);
-  expect(screen.getByTestId('sahkoposti-7')).toHaveTextContent(users[5].sahkoposti);
-  expect(screen.getByTestId('sahkoposti-8')).toHaveTextContent(users[8].sahkoposti);
-  expect(screen.getByTestId('sahkoposti-9')).toHaveTextContent(users[9].sahkoposti);
+  expect(screen.getByTestId('sahkoposti-6')).toHaveTextContent(users[11].sahkoposti);
+  expect(screen.getByTestId('sahkoposti-7')).toHaveTextContent(users[0].sahkoposti);
+  expect(screen.getByTestId('sahkoposti-8')).toHaveTextContent(users[5].sahkoposti);
+  expect(screen.getByTestId('sahkoposti-9')).toHaveTextContent(users[8].sahkoposti);
 });
 
 test('Filtering works', async () => {
   const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
 
   await waitForLoadingToFinish();
-  await user.type(screen.getByRole('combobox', { name: 'Haku' }), 'Matti Meikäläinen');
+  fireEvent.change(screen.getByRole('combobox', { name: 'Haku' }), {
+    target: { value: 'Teppo Työmies' },
+  });
 
   await waitFor(() =>
     expect((screen.getByRole('table') as HTMLTableElement).tBodies[0].rows).toHaveLength(1),
   );
-  expect(screen.getAllByText(users[0].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(users[1].nimi)).toHaveLength(2);
 
   // Clear the search
   await user.click(screen.getByRole('button', { name: 'Clear' }));
-  await user.type(screen.getByRole('combobox', { name: 'Haku' }), 'ak');
+  fireEvent.change(screen.getByRole('combobox', { name: 'Haku' }), {
+    target: { value: 'ak' },
+  });
 
   await waitFor(() =>
     expect((screen.getByRole('table') as HTMLTableElement).tBodies[0].rows).toHaveLength(2),

--- a/src/domain/hanke/accessRights/AccessRightsView.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.tsx
@@ -35,6 +35,10 @@ import { updateHankeUsers } from '../hankeUsers/hankeUsersApi';
 import Container from '../../../common/components/container/Container';
 import UserCard from './UserCard';
 
+function sortCaseInsensive(rowOneColumn: string, rowTwoColumn: string) {
+  return rowOneColumn.toUpperCase() > rowTwoColumn.toUpperCase() ? 1 : -1;
+}
+
 type Props = {
   hankeUsers: HankeUser[];
   hankeTunnus: string;
@@ -75,6 +79,16 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
       columns,
       data: usersData,
       autoResetFilters: false,
+      sortTypes: {
+        alphanumeric: (row1, row2, columnName) => {
+          const rowOneColumn: string | number = row1.values[columnName];
+          const rowTwoColumn: string | number = row2.values[columnName];
+          if (isNaN(rowOneColumn as number)) {
+            return sortCaseInsensive(rowOneColumn as string, rowTwoColumn as string);
+          }
+          return Number(rowOneColumn) > Number(rowTwoColumn) ? 1 : -1;
+        },
+      },
     },
     useFilters,
     useSortBy,
@@ -182,6 +196,26 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
     );
   }
 
+  const tableCols = [
+    {
+      headerName: t('form:yhteystiedot:labels:nimi'),
+      key: NAME_KEY,
+      isSortable: true,
+      customSortCompareFunction: sortCaseInsensive,
+    },
+    {
+      headerName: t('form:yhteystiedot:labels:email'),
+      key: EMAIL_KEY,
+      isSortable: true,
+      customSortCompareFunction: sortCaseInsensive,
+    },
+    {
+      headerName: t('hankeUsers:accessRights'),
+      key: ACCESS_RIGHT_LEVEL_KEY,
+      transform: getAccessRightSelect,
+    },
+  ];
+
   return (
     <article className={styles.container}>
       <header className={styles.header}>
@@ -261,23 +295,7 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
 
         <div className={styles.table}>
           <Table
-            cols={[
-              {
-                headerName: t('form:yhteystiedot:labels:nimi'),
-                key: NAME_KEY,
-                isSortable: true,
-              },
-              {
-                headerName: t('form:yhteystiedot:labels:email'),
-                key: EMAIL_KEY,
-                isSortable: true,
-              },
-              {
-                headerName: t('hankeUsers:accessRights'),
-                key: ACCESS_RIGHT_LEVEL_KEY,
-                transform: getAccessRightSelect,
-              },
-            ]}
+            cols={tableCols}
             rows={page.map((row) => row.original)}
             onSort={handleTableSort}
             indexKey="id"

--- a/src/domain/hanke/accessRights/AccessRightsView.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.tsx
@@ -81,12 +81,9 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
       autoResetFilters: false,
       sortTypes: {
         alphanumeric: (row1, row2, columnName) => {
-          const rowOneColumn: string | number = row1.values[columnName];
-          const rowTwoColumn: string | number = row2.values[columnName];
-          if (isNaN(rowOneColumn as number)) {
-            return sortCaseInsensive(rowOneColumn as string, rowTwoColumn as string);
-          }
-          return Number(rowOneColumn) > Number(rowTwoColumn) ? 1 : -1;
+          const rowOneColumn: string = row1.values[columnName];
+          const rowTwoColumn: string = row2.values[columnName];
+          return sortCaseInsensive(rowOneColumn, rowTwoColumn);
         },
       },
     },

--- a/src/domain/hanke/accessRights/AccessRightsView.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.tsx
@@ -36,7 +36,12 @@ import Container from '../../../common/components/container/Container';
 import UserCard from './UserCard';
 
 function sortCaseInsensive(rowOneColumn: string, rowTwoColumn: string) {
-  return rowOneColumn.toUpperCase() > rowTwoColumn.toUpperCase() ? 1 : -1;
+  const rowOneColUpperCase = rowOneColumn.toUpperCase();
+  const rowTwoColUpperCase = rowTwoColumn.toUpperCase();
+  if (rowOneColUpperCase === rowTwoColUpperCase) {
+    return 0;
+  }
+  return rowOneColUpperCase > rowTwoColUpperCase ? 1 : -1;
 }
 
 type Props = {

--- a/src/domain/hanke/accessRights/AccessRightsView.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.tsx
@@ -35,7 +35,7 @@ import { updateHankeUsers } from '../hankeUsers/hankeUsersApi';
 import Container from '../../../common/components/container/Container';
 import UserCard from './UserCard';
 
-function sortCaseInsensive(rowOneColumn: string, rowTwoColumn: string) {
+function sortCaseInsensitive(rowOneColumn: string, rowTwoColumn: string) {
   const rowOneColUpperCase = rowOneColumn.toUpperCase();
   const rowTwoColUpperCase = rowTwoColumn.toUpperCase();
   if (rowOneColUpperCase === rowTwoColUpperCase) {
@@ -88,7 +88,7 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
         alphanumeric: (row1, row2, columnName) => {
           const rowOneColumn: string = row1.values[columnName];
           const rowTwoColumn: string = row2.values[columnName];
-          return sortCaseInsensive(rowOneColumn, rowTwoColumn);
+          return sortCaseInsensitive(rowOneColumn, rowTwoColumn);
         },
       },
     },
@@ -203,13 +203,13 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
       headerName: t('form:yhteystiedot:labels:nimi'),
       key: NAME_KEY,
       isSortable: true,
-      customSortCompareFunction: sortCaseInsensive,
+      customSortCompareFunction: sortCaseInsensitive,
     },
     {
       headerName: t('form:yhteystiedot:labels:email'),
       key: EMAIL_KEY,
       isSortable: true,
-      customSortCompareFunction: sortCaseInsensive,
+      customSortCompareFunction: sortCaseInsensitive,
     },
     {
       headerName: t('hankeUsers:accessRights'),

--- a/src/domain/mocks/data/users-data.json
+++ b/src/domain/mocks/data/users-data.json
@@ -86,5 +86,13 @@
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
+  },
+  {
+    "id": "3fa85f64-5717-4562-b3fc-2c963f66af5",
+    "sahkoposti": "matti@test.com",
+    "nimi": "matti Meikäläinen",
+    "kayttooikeustaso": "KATSELUOIKEUS",
+    "tunnistautunut": true,
+    "hankeTunnus": "HAI22-2"
   }
 ]


### PR DESCRIPTION
# Description

Fixed problem where sorting in users rights view table would not work correctly when there are names in both lower and upper case.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1510

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Check that users are sorted alphabetically even if there are names like Matti and mauno for example.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
