### PR TITLE
HAI-1917 Fix problem where form is not saved after filling contact information with user's own information

### DIFF
--- a/src/domain/johtoselvitys/Contacts.tsx
+++ b/src/domain/johtoselvitys/Contacts.tsx
@@ -124,7 +124,7 @@ const CustomerFields: React.FC<{
           invoicingOperator: null,
           sapCustomerNumber: null,
         },
-        { shouldValidate: true },
+        { shouldValidate: true, shouldDirty: true },
       );
     }
   }

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -9,6 +9,7 @@ import { HankeData } from '../types/hanke';
 import hankkeet from '../mocks/data/hankkeet-data';
 import applications from '../mocks/data/hakemukset-data';
 import { JohtoselvitysFormValues } from './types';
+import * as applicationApi from '../application/utils';
 
 afterEach(cleanup);
 
@@ -602,4 +603,18 @@ test('Validation error is shown if no work is about checkbox is selected', async
     ),
   );
   expect(screen.queryByText('Kenttä on pakollinen')).toBeInTheDocument();
+});
+
+test('Form is saved when contacts are filled with orderer information', async () => {
+  const saveApplication = jest.spyOn(applicationApi, 'saveApplication');
+  const { user } = render(<JohtoselvitysContainer application={applications[0]} />);
+
+  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+  await user.click(
+    screen.getByTestId('applicationData.customerWithContacts.customer.fillOwnInfoButton'),
+  );
+  await user.click(screen.getByRole('button', { name: /edellinen/i }));
+
+  expect(screen.queryByText(/hakemus tallennettu/i)).toBeInTheDocument();
+  expect(saveApplication).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
# Description

Fixed a problem in cable report application form where the form would not be saved when user clicked the Täytä omilla tiedoilla button in contacts page and changed form page after that. This was caused by not setting the form fields as dirty.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1917

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
