### PR TITLE
HAI-1311 Redirect user to original route after login

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "i18next-browser-languagedetector": "^7.0.1",
     "immer": "8.0.2",
     "jest-fetch-mock": "^3.0.3",
-    "jest-localstorage-mock": "^2.4.6",
     "local-web-server": "^4.2.1",
     "lodash": "^4.17.21",
     "msw": "^0.49.0",

--- a/src/common/routes/AppRoutes.tsx
+++ b/src/common/routes/AppRoutes.tsx
@@ -6,9 +6,11 @@ import Login from '../../domain/auth/components/Login';
 import OidcCallback from '../../domain/auth/components/OidcCallback';
 import { LOGIN_CALLBACK_PATH, LOGIN_PATH } from '../../domain/auth/constants';
 import LocaleRoutes from './LocaleRoutes';
+import { REDIRECT_PATH_KEY } from './constants';
 
 const AppRoutes: React.FC<React.PropsWithChildren<unknown>> = () => {
   const currentLocale = useLocale();
+  const redirectPath = sessionStorage.getItem(REDIRECT_PATH_KEY);
 
   return (
     <Routes>
@@ -17,7 +19,10 @@ const AppRoutes: React.FC<React.PropsWithChildren<unknown>> = () => {
       {Object.values(LANGUAGES).map((locale) => (
         <Route path={`/${locale}/*`} element={<LocaleRoutes />} key={locale} />
       ))}
-      <Route path="*" element={<Navigate to={`/${currentLocale}`} />} />
+      <Route
+        path="*"
+        element={<Navigate to={redirectPath ? redirectPath : `/${currentLocale}`} />}
+      />
     </Routes>
   );
 };

--- a/src/common/routes/PrivateRoute.tsx
+++ b/src/common/routes/PrivateRoute.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 import useUser from '../../domain/auth/useUser';
+import { REDIRECT_PATH_KEY } from './constants';
 
 type Props = {
   element: JSX.Element;
@@ -8,9 +9,20 @@ type Props = {
 
 const PrivateRoute: React.FC<React.PropsWithChildren<Props>> = ({ element }) => {
   const { data: user } = useUser();
+  const isAuthenticated = Boolean(user?.profile);
 
-  if (!user?.profile) {
-    return <Navigate to="/" />;
+  useEffect(() => {
+    if (isAuthenticated) {
+      sessionStorage.removeItem(REDIRECT_PATH_KEY);
+    }
+  }, [isAuthenticated]);
+
+  if (!isAuthenticated) {
+    // If user tries to access private route when not signed in,
+    // save URL path to session storage and navigate to login,
+    // so that user can be redirected to that route after login
+    sessionStorage.setItem(REDIRECT_PATH_KEY, location.pathname);
+    return <Navigate to="/login" />;
   }
 
   return element;

--- a/src/common/routes/PrivateRoute.tsx
+++ b/src/common/routes/PrivateRoute.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import useUser from '../../domain/auth/useUser';
 import { REDIRECT_PATH_KEY } from './constants';
 
@@ -10,6 +10,7 @@ type Props = {
 const PrivateRoute: React.FC<React.PropsWithChildren<Props>> = ({ element }) => {
   const { data: user } = useUser();
   const isAuthenticated = Boolean(user?.profile);
+  const location = useLocation();
 
   useEffect(() => {
     if (isAuthenticated) {

--- a/src/common/routes/Routes.test.tsx
+++ b/src/common/routes/Routes.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { InitialEntry } from '@remix-run/router';
+import { User } from 'oidc-client';
+import { Provider } from 'react-redux';
+import AppRoutes from './AppRoutes';
+import { FeatureFlagsProvider } from '../components/featureFlags/FeatureFlagsContext';
+import { GlobalNotificationProvider } from '../components/globalNotification/GlobalNotificationContext';
+import authService from '../../domain/auth/authService';
+import { store } from '../redux/store';
+import i18n from '../../locales/i18n';
+import { REDIRECT_PATH_KEY } from './constants';
+
+afterEach(() => {
+  sessionStorage.clear();
+});
+
+const path = '/fi/johtoselvityshakemus';
+
+const mockUser: Partial<User> = {
+  id_token: 'fffff-aaaaaa-11111',
+  access_token: '.BnutWVN1x7RSAP5bU2a-tXdVPuof_9pBNd_Ozw',
+  profile: {
+    iss: '',
+    sub: '',
+    aud: '',
+    exp: 0,
+    iat: 0,
+  },
+};
+
+function getWrapper(routerInitialEntries?: InitialEntry[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retryDelay: 0,
+      },
+    },
+  });
+
+  return render(
+    <MemoryRouter initialEntries={routerInitialEntries}>
+      <Provider store={store}>
+        <QueryClientProvider client={queryClient}>
+          <I18nextProvider i18n={i18n}>
+            <FeatureFlagsProvider>
+              <GlobalNotificationProvider>
+                <AppRoutes />
+              </GlobalNotificationProvider>
+            </FeatureFlagsProvider>
+          </I18nextProvider>
+        </QueryClientProvider>
+      </Provider>
+    </MemoryRouter>,
+  );
+}
+
+test('Should save path to session storage and navigate to login if trying to navigate to private route', async () => {
+  const login = jest.spyOn(authService, 'login').mockResolvedValue();
+
+  getWrapper([path]);
+
+  await waitFor(() => expect(login).toHaveBeenCalled());
+  expect(window.sessionStorage.getItem(REDIRECT_PATH_KEY)).toBe(path);
+});
+
+test('Should redirect to path stored in session storage after login if one exists', async () => {
+  sessionStorage.setItem(REDIRECT_PATH_KEY, path);
+  jest.spyOn(authService.userManager, 'getUser').mockResolvedValue(mockUser as User);
+
+  getWrapper();
+
+  await waitFor(() =>
+    expect(window.document.title).toBe('Haitaton - Luo uusi johtoselvityshakemus'),
+  );
+});

--- a/src/common/routes/constants.ts
+++ b/src/common/routes/constants.ts
@@ -1,0 +1,1 @@
+export const REDIRECT_PATH_KEY = 'redirect-path';

--- a/src/domain/auth/authService.test.ts
+++ b/src/domain/auth/authService.test.ts
@@ -12,9 +12,6 @@ describe('authService', () => {
 
   afterEach(() => {
     localStorage.clear();
-    // eslint-disable-next-line
-    // @ts-ignore
-    localStorage.setItem.mockClear();
     jest.restoreAllMocks();
   });
 

--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -7,7 +7,7 @@ import { server } from '../../mocks/test-server';
 import usersData from '../../mocks/data/users-data.json';
 import { SignedInUser } from '../hankeUsers/hankeUser';
 
-jest.setTimeout(30000);
+jest.setTimeout(40000);
 
 afterEach(cleanup);
 
@@ -151,7 +151,9 @@ test('Filtering works', async () => {
   const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
 
   await waitForLoadingToFinish();
-  await user.type(screen.getByRole('combobox', { name: 'Haku' }), 'Matti Meikäläinen');
+  fireEvent.change(screen.getByRole('combobox', { name: 'Haku' }), {
+    target: { value: 'Matti Meikäläinen' },
+  });
 
   await waitFor(() =>
     expect((screen.getByRole('table') as HTMLTableElement).tBodies[0].rows).toHaveLength(1),
@@ -160,7 +162,9 @@ test('Filtering works', async () => {
 
   // Clear the search
   await user.click(screen.getByRole('button', { name: 'Clear' }));
-  await user.type(screen.getByRole('combobox', { name: 'Haku' }), 'ak');
+  fireEvent.change(screen.getByRole('combobox', { name: 'Haku' }), {
+    target: { value: 'ak' },
+  });
 
   await waitFor(() =>
     expect((screen.getByRole('table') as HTMLTableElement).tBodies[0].rows).toHaveLength(2),

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,7 +4,6 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 import '@testing-library/jest-dom/extend-expect';
-import 'jest-localstorage-mock';
 import { GlobalWithFetchMock } from 'jest-fetch-mock';
 import 'jest-canvas-mock';
 import { server } from './domain/mocks/test-server';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10787,11 +10787,6 @@ jest-leak-detector@^27.5.1:
     jest-get-type "^27.5.1"
     pretty-format "^27.5.1"
 
-jest-localstorage-mock@^2.4.6:
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.4.6.tgz#ebb9481943bf52e0f8c864ae4858eb791d68149d"
-  integrity sha512-8n6tuqscEShpvC7vkq3BPabOGGszD1cdLAKTtTtCRqH2bWJIVfpV4aIhrDJstV7xLOjo56wSVZkoMbT7dWLIVg==
-
 jest-matcher-utils@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"


### PR DESCRIPTION
# Description

If user tries to access page that requires login, that path is saved to session storage and user is redirected to login and after successful login user is redirected to the path in session storage.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1311

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. When not logged in try to access for example cable report application form: http://localhost:3001/fi/johtoselvityshakemus
2. You should be taken to login and after that to cable report application form

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
