### PR TITLE
HAI-1941 Show hanke name and tunnus in user identification success notification

### DIFF
--- a/src/domain/auth/components/UserIdentify.test.tsx
+++ b/src/domain/auth/components/UserIdentify.test.tsx
@@ -14,12 +14,14 @@ import { store } from '../../../common/redux/store';
 import i18n from '../../../locales/i18n';
 import authService from '../authService';
 import { REDIRECT_PATH_KEY } from '../../../common/routes/constants';
+import * as hankeUsersApi from '../../hanke/hankeUsers/hankeUsersApi';
 
 afterEach(() => {
   sessionStorage.clear();
 });
 
-const path = '/fi/kutsu?id=5ArrqPT6kW97QTK7t7ya9PA2';
+const id = '5ArrqPT6kW97QTK7t7ya9PA2';
+const path = `/fi/kutsu?id=${id}`;
 
 const mockUser: Partial<User> = {
   id_token: 'fffff-aaaaaa-11111',
@@ -72,9 +74,15 @@ test('Should save path with query string to session storage and navigate to logi
 test('Should identify user after login', async () => {
   sessionStorage.setItem(REDIRECT_PATH_KEY, path);
   jest.spyOn(authService.userManager, 'getUser').mockResolvedValue(mockUser as User);
+  const identifyUser = jest.spyOn(hankeUsersApi, 'identifyUser');
 
   getWrapper();
 
   await waitFor(() => expect(window.document.title).toBe('Haitaton - Etusivu'));
-  expect(screen.queryByText('Tunnistautuminen onnistui')).toBeInTheDocument();
+  expect(identifyUser).toHaveBeenCalledWith(id);
+  expect(
+    screen.queryByText(
+      'Tunnistautuminen onnistui. Sinut on nyt lisätty hankkeelle (Aidasmäentien vesihuollon rakentaminen HAI22-2).',
+    ),
+  ).toBeInTheDocument();
 });

--- a/src/domain/auth/components/UserIdentify.tsx
+++ b/src/domain/auth/components/UserIdentify.tsx
@@ -31,10 +31,10 @@ function UserIdentify() {
   useEffect(() => {
     if (isAuthenticated && id !== null && !identifyUserCalled.current) {
       mutate(id, {
-        onSuccess() {
+        onSuccess({ hankeNimi, hankeTunnus }) {
           setNotification(true, {
             label: t('hankeUsers:notifications:userIdentifiedLabel'),
-            message: t('hankeUsers:notifications:userIdentifiedText'),
+            message: t('hankeUsers:notifications:userIdentifiedText', { hankeNimi, hankeTunnus }),
             type: 'success',
             dismissible: true,
             closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),

--- a/src/domain/hanke/hankeUsers/hankeUser.ts
+++ b/src/domain/hanke/hankeUsers/hankeUser.ts
@@ -30,3 +30,9 @@ export type SignedInUser = {
   kayttooikeustaso: keyof typeof AccessRightLevel;
   kayttooikeudet: UserRights;
 };
+
+export type IdentificationResponse = {
+  kayttajaId: string;
+  hankeTunnus: string;
+  hankeNimi: string;
+};

--- a/src/domain/hanke/hankeUsers/hankeUsersApi.ts
+++ b/src/domain/hanke/hankeUsers/hankeUsersApi.ts
@@ -1,5 +1,5 @@
 import api from '../../api/api';
-import { HankeUser, SignedInUser } from './hankeUser';
+import { HankeUser, IdentificationResponse, SignedInUser } from './hankeUser';
 
 export async function getHankeUsers(hankeTunnus: string) {
   const { data } = await api.get<{ kayttajat: HankeUser[] }>(`hankkeet/${hankeTunnus}/kayttajat`);
@@ -24,6 +24,6 @@ export async function getSignedInUser(hankeTunnus?: string): Promise<SignedInUse
 }
 
 export async function identifyUser(id: string) {
-  const { data } = await api.post('kayttajat', { tunniste: id });
+  const { data } = await api.post<IdentificationResponse>('kayttajat', { tunniste: id });
   return data;
 }

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -5,7 +5,7 @@ import * as hankkeetDB from './data/hankkeet';
 import * as hakemuksetDB from './data/hakemukset';
 import * as usersDB from './data/users';
 import ApiError from './apiError';
-import { SignedInUser } from '../hanke/hankeUsers/hankeUser';
+import { IdentificationResponse, SignedInUser } from '../hanke/hankeUsers/hankeUser';
 
 const apiUrl = '/api';
 
@@ -206,6 +206,13 @@ export const handlers = [
   }),
 
   rest.post(`${apiUrl}/kayttajat`, async (req, res, ctx) => {
-    return res(ctx.status(204));
+    return res(
+      ctx.status(200),
+      ctx.json<IdentificationResponse>({
+        kayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+        hankeTunnus: 'HAI22-2',
+        hankeNimi: 'Aidasmäentien vesihuollon rakentaminen',
+      }),
+    );
   }),
 ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -859,7 +859,7 @@
       "rightsUpdatedErrorLabel": "Virhe päivityksessä",
       "rightsUpdatedErrorText": "<0>Käyttöoikeuksien päivityksessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>",
       "userIdentifiedLabel": "Tunnistautuminen onnistui",
-      "userIdentifiedText": "Tunnistautuminen onnistui. Sinut on nyt lisätty hankkeelle.",
+      "userIdentifiedText": "Tunnistautuminen onnistui. Sinut on nyt lisätty hankkeelle ({{hankeNimi}} {{hankeTunnus}}).",
       "userIdentifiedError": "Tunnistautuminen epäonnistui"
     }
   },


### PR DESCRIPTION
# Description

Added hanke name and tunnus to notification that is shown after successfully identifying user.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1941

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
