### PR TITLE
HAI-1599 Navigate to hanke list after generated hanke deletion

### DIFF
--- a/src/domain/application/components/ApplicationCancel.test.tsx
+++ b/src/domain/application/components/ApplicationCancel.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { rest } from 'msw';
 import { IconCross } from 'hds-react';
 import { render, screen } from '../../../testUtils/render';
 import { ApplicationCancel } from './ApplicationCancel';
 import mockApplications from '../../mocks/data/hakemukset-data';
+import { server } from '../../mocks/test-server';
 
 test('Cancel application when it has not been saved', async () => {
   const { user } = render(
@@ -11,7 +13,7 @@ test('Cancel application when it has not been saved', async () => {
       alluStatus={null}
       hankeTunnus="HAI22-2"
       buttonIcon={<IconCross />}
-    />
+    />,
   );
 
   await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
@@ -32,7 +34,7 @@ test('Cancel application when it has been saved, but not sent to Allu', async ()
       alluStatus={application.alluStatus}
       hankeTunnus="HAI22-2"
       buttonIcon={<IconCross />}
-    />
+    />,
   );
 
   await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
@@ -41,6 +43,29 @@ test('Cancel application when it has been saved, but not sent to Allu', async ()
   await user.click(screen.getByRole('button', { name: 'Vahvista' }));
 
   expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2');
+  expect(screen.queryByText('Hakemus peruttiin onnistuneesti')).toBeInTheDocument();
+});
+
+test('Cancel application when generated hanke is also deleted, directs to hanke list', async () => {
+  server.use(
+    rest.delete('/api/hakemukset/:id', async (req, res, ctx) => {
+      return res(ctx.status(200), ctx.json({ hankeDeleted: true }));
+    }),
+  );
+  const application = mockApplications[0];
+  const { user } = render(
+    <ApplicationCancel
+      applicationId={application.id}
+      alluStatus={application.alluStatus}
+      hankeTunnus="HAI22-2"
+      buttonIcon={<IconCross />}
+    />,
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
+  await user.click(screen.getByRole('button', { name: 'Vahvista' }));
+
+  expect(window.location.pathname).toBe('/fi/hankesalkku');
   expect(screen.queryByText('Hakemus peruttiin onnistuneesti')).toBeInTheDocument();
 });
 
@@ -53,7 +78,7 @@ test('Cancel application when it has been saved and sent to Allu but is still pe
       alluStatus={application.alluStatus}
       hankeTunnus="HAI22-2"
       buttonIcon={<IconCross />}
-    />
+    />,
   );
 
   await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
@@ -74,7 +99,7 @@ test('Canceling application is not possible when it in handling in Allu', () => 
       alluStatus={application.alluStatus}
       hankeTunnus="HAI22-2"
       buttonIcon={<IconCross />}
-    />
+    />,
   );
 
   expect(screen.queryByRole('button', { name: 'Peru hakemus' })).not.toBeInTheDocument();

--- a/src/domain/application/components/ApplicationCancel.tsx
+++ b/src/domain/application/components/ApplicationCancel.tsx
@@ -7,7 +7,10 @@ import { AlluStatusStrings } from '../types/application';
 import { isApplicationPending, cancelApplication } from '../utils';
 import ConfirmationDialog from '../../../common/components/HDSConfirmationDialog/ConfirmationDialog';
 import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
-import useNavigateToApplicationList from '../../hanke/hooks/useNavigateToApplicationList';
+import {
+  useNavigateToApplicationList,
+  useNavigateToHankeList,
+} from '../../hanke/hooks/useNavigateToApplicationList';
 
 type Props = {
   applicationId: number | null;
@@ -28,6 +31,7 @@ export const ApplicationCancel: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
   const navigateToApplicationList = useNavigateToApplicationList(hankeTunnus);
+  const navigateToHankeList = useNavigateToHankeList();
 
   const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -44,7 +48,7 @@ export const ApplicationCancel: React.FC<Props> = ({
       }
       setErrorMessage(message);
     },
-    onSuccess() {
+    onSuccess(data) {
       const closeButtonLabelText = t('common:components:notification:closeButtonLabelText');
       setNotification(true, {
         label: t('hakemus:notifications:cancelSuccessLabel'),
@@ -55,7 +59,7 @@ export const ApplicationCancel: React.FC<Props> = ({
         autoClose: true,
         autoCloseDuration: 7000,
       });
-      navigateToApplicationList();
+      data?.hankeDeleted ? navigateToHankeList() : navigateToApplicationList();
     },
   });
 

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -143,6 +143,10 @@ export interface Application {
   hankeTunnus: string | null;
 }
 
+export interface ApplicationDeletionResult {
+  hankeDeleted: boolean;
+}
+
 export function isCustomerWithContacts(value: unknown): value is CustomerWithContacts {
   return (value as CustomerWithContacts)?.contacts !== undefined;
 }

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -1,6 +1,11 @@
 import { TFunction } from 'i18next';
 import api from '../api/api';
-import { AlluStatus, AlluStatusStrings, Application } from './types/application';
+import {
+  AlluStatus,
+  AlluStatusStrings,
+  Application,
+  ApplicationDeletionResult,
+} from './types/application';
 
 /**
  * Save application to Haitaton backend
@@ -47,7 +52,7 @@ export function isApplicationDraft(alluStatus: AlluStatus | null) {
 export async function cancelApplication(applicationId: number | null) {
   if (applicationId === null) return null;
 
-  const response = await api.delete<Application>(`/hakemukset/${applicationId}`);
+  const response = await api.delete<ApplicationDeletionResult>(`/hakemukset/${applicationId}`);
   return response.data;
 }
 

--- a/src/domain/hanke/hooks/useNavigateToApplicationList.ts
+++ b/src/domain/hanke/hooks/useNavigateToApplicationList.ts
@@ -7,7 +7,7 @@ import { ROUTES } from '../../../common/types/route';
  * Returns a function to navigate to hanke view with application list tab initially open.
  * If there is no hankeTunnus, returned function navigates to hanke portfolio as a fallback.
  */
-export default function useNavigateToApplicationList(hankeTunnus?: string) {
+function useNavigateToApplicationList(hankeTunnus?: string) {
   const navigate = useNavigate();
   const getHankeViewPath = useLinkPath(ROUTES.HANKE);
   const { HANKEPORTFOLIO } = useLocalizedRoutes();
@@ -23,3 +23,15 @@ export default function useNavigateToApplicationList(hankeTunnus?: string) {
 
   return navigateToApplicationList;
 }
+
+function useNavigateToHankeList() {
+  const navigate = useNavigate();
+  const { HANKEPORTFOLIO } = useLocalizedRoutes();
+  function navigateToHankeList() {
+    navigate(HANKEPORTFOLIO.path, { state: { initiallyActiveTab: 4 } });
+  }
+
+  return navigateToHankeList;
+}
+
+export { useNavigateToApplicationList, useNavigateToHankeList };

--- a/src/domain/hanke/hooks/useNavigateToApplicationList.ts
+++ b/src/domain/hanke/hooks/useNavigateToApplicationList.ts
@@ -28,7 +28,7 @@ function useNavigateToHankeList() {
   const navigate = useNavigate();
   const { HANKEPORTFOLIO } = useLocalizedRoutes();
   function navigateToHankeList() {
-    navigate(HANKEPORTFOLIO.path, { state: { initiallyActiveTab: 4 } });
+    navigate(HANKEPORTFOLIO.path);
   }
 
   return navigateToHankeList;

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -37,7 +37,7 @@ import HankeDraftStateNotification from '../edit/components/HankeDraftStateNotif
 import Container from '../../../common/components/container/Container';
 import { SKIP_TO_ELEMENT_ID } from '../../../common/constants/constants';
 import useHankeViewPath from '../hooks/useHankeViewPath';
-import useNavigateToApplicationList from '../hooks/useNavigateToApplicationList';
+import { useNavigateToApplicationList } from '../hooks/useNavigateToApplicationList';
 import FeatureFlags from '../../../common/components/featureFlags/FeatureFlags';
 
 type CustomAccordionProps = {
@@ -250,7 +250,7 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
     if (value.length === 0) return tyyppiRows;
     return tyyppiRows.filter((hanke) => {
       const includedTyypit = hanke.values.tyomaaTyyppi.filter((tyyppi: string) =>
-        value.includes(tyyppi)
+        value.includes(tyyppi),
       );
       return includedTyypit.length > 0;
     });
@@ -264,7 +264,7 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
             hankeIsBetweenDates({ startDate: dateStart, endDate: hankeFilterEndDate })({
               startDate: hanke.values.alkuPvm,
               endDate: hanke.values.loppuPvm,
-            })
+            }),
           );
         }
         return dateStartRows.filter((hanke) => dateStart <= hanke.values.loppuPvm);
@@ -279,7 +279,7 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
             hankeIsBetweenDates({ startDate: hankeFilterStartDate, endDate: dateEnd })({
               startDate: hanke.values.alkuPvm,
               endDate: hanke.values.loppuPvm,
-            })
+            }),
           );
         }
         return dateEndRows.filter((hanke) => hanke.values.alkuPvm <= dateEnd);
@@ -352,7 +352,7 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
     useFilters,
     useGlobalFilter,
     useSortBy,
-    usePagination
+    usePagination,
   );
 
   const { t, i18n } = useTranslation();

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -27,7 +27,7 @@ import { isApplicationDraft, saveApplication, sendApplication } from '../applica
 import { HankeContacts, HankeData } from '../types/hanke';
 import { ApplicationCancel } from '../application/components/ApplicationCancel';
 import ApplicationSaveNotification from '../application/components/ApplicationSaveNotification';
-import useNavigateToApplicationList from '../hanke/hooks/useNavigateToApplicationList';
+import { useNavigateToApplicationList } from '../hanke/hooks/useNavigateToApplicationList';
 import { useGlobalNotification } from '../../common/components/globalNotification/GlobalNotificationContext';
 import useApplicationSendNotification from '../application/hooks/useApplicationSendNotification';
 import useHanke from '../hanke/hooks/useHanke';


### PR DESCRIPTION
# Description

When the only application of a genedated hanke is deleted, backend also deletes the hanke.

If hanke deletion result is defined in the response object. If hanke was deleted, user is directed to hanke listing.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1599

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Create johtoselvitys with generated hanke, delete johtoselvitys. Should navigate to hanke list. If hanke is not generated, should work as before (stay at the specific hanke).

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
