### PR TITLE
HAI-1512 Implement sending invitation links again in user rights view

### DIFF
--- a/src/domain/hanke/accessRights/AccessRightsView.module.scss
+++ b/src/domain/hanke/accessRights/AccessRightsView.module.scss
@@ -50,16 +50,41 @@
 
 .table > div {
   overflow-x: initial;
+  display: none;
 
-  @include respond-below(m) {
-    display: none;
+  @include respond-above(l) {
+    display: block;
   }
 }
 
 .userCards {
-  @include respond-above(m) {
+  @include respond-above(l) {
     display: none;
   }
+}
+
+.accessRightSelect {
+  min-width: auto;
+
+  @include respond-above(m) {
+    min-width: 250px;
+  }
+
+  @include respond-above(l) {
+    min-width: 330px;
+  }
+}
+
+.invitationSendButtonContainer {
+  min-width: auto;
+
+  @include respond-above(xl) {
+    min-width: 300px;
+  }
+}
+
+.invitationSendButton {
+  vertical-align: middle;
 }
 
 .pagination {

--- a/src/domain/hanke/accessRights/AccessRightsView.module.scss
+++ b/src/domain/hanke/accessRights/AccessRightsView.module.scss
@@ -71,7 +71,7 @@
   }
 
   @include respond-above(l) {
-    min-width: 330px;
+    min-width: 345px;
   }
 }
 

--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -6,6 +6,7 @@ import AccessRightsViewContainer from './AccessRightsViewContainer';
 import { server } from '../../mocks/test-server';
 import usersData from '../../mocks/data/users-data.json';
 import { SignedInUser } from '../hankeUsers/hankeUser';
+import * as hankeUsersApi from '../../hanke/hankeUsers/hankeUsersApi';
 
 jest.setTimeout(40000);
 
@@ -301,4 +302,96 @@ test('Should not be able to remove all rights if user does not have all rights',
   await waitForLoadingToFinish();
 
   expect(screen.getByTestId('kayttooikeustaso-3').querySelector('button')).toBeDisabled();
+});
+
+test('Should show Käyttäjä tunnistautunut text for correct users', async () => {
+  render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
+
+  await waitForLoadingToFinish();
+
+  expect(screen.getByTestId('tunnistautunut-0')).toHaveTextContent('Käyttäjä tunnistautunut');
+  expect(screen.getByTestId('tunnistautunut-1')).not.toHaveTextContent('Käyttäjä tunnistautunut');
+  expect(screen.getByTestId('tunnistautunut-2')).toHaveTextContent('Käyttäjä tunnistautunut');
+  expect(screen.getByTestId('tunnistautunut-6')).toHaveTextContent('Käyttäjä tunnistautunut');
+  expect(screen.getByTestId('tunnistautunut-7')).toHaveTextContent('Käyttäjä tunnistautunut');
+  expect(screen.getByTestId('tunnistautunut-8')).toHaveTextContent('Käyttäjä tunnistautunut');
+});
+
+test('Should send invitation to user when cliking the Lähetä kutsulinkki uudelleen button', async () => {
+  const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
+
+  await waitForLoadingToFinish();
+
+  const invitationButton = screen.getAllByRole('button', {
+    name: 'Lähetä kutsulinkki uudelleen',
+  })[0];
+  await user.click(invitationButton);
+
+  await waitFor(() => {
+    expect(
+      screen.queryByText('Kutsulinkki lähetetty osoitteeseen teppo@test.com.'),
+    ).toBeInTheDocument();
+  });
+  expect(invitationButton).toHaveTextContent('Kutsulinkki lähetetty');
+  expect(invitationButton).toBeDisabled();
+});
+
+test('Should not send multiple requests when cliking the Lähetä kutsulinkki uudelleen button many times', async () => {
+  const sendInvitation = jest.spyOn(hankeUsersApi, 'resendInvitation');
+  const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
+
+  await waitForLoadingToFinish();
+
+  const invitationButton = screen.getAllByRole('button', {
+    name: 'Lähetä kutsulinkki uudelleen',
+  })[0];
+  await user.click(invitationButton);
+  await user.click(invitationButton);
+  await user.click(invitationButton);
+
+  expect(sendInvitation).toHaveBeenCalledTimes(1);
+
+  sendInvitation.mockRestore();
+});
+
+test('Should show error notification if sending invitation fails', async () => {
+  server.use(
+    rest.post('/api/kayttajat/:kayttajaId/kutsu', async (req, res, ctx) => {
+      return res(ctx.status(500), ctx.json({ errorMessage: 'Failed for testing purposes' }));
+    }),
+  );
+
+  const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
+
+  await waitForLoadingToFinish();
+
+  const invitationButton = screen.getAllByRole('button', {
+    name: 'Lähetä kutsulinkki uudelleen',
+  })[1];
+  await user.click(invitationButton);
+
+  expect(screen.queryByText('Virhe linkin lähettämisessä')).toBeInTheDocument();
+});
+
+test('Should not show invitation buttons if user does not have permission to send invitation', async () => {
+  server.use(
+    rest.get('/api/hankkeet/:hankeTunnus/whoami', async (req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.json<SignedInUser>(
+          getSignedInUser({ kayttooikeustaso: 'KATSELUOIKEUS', kayttooikeudet: ['VIEW'] }),
+        ),
+      );
+    }),
+  );
+
+  render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
+
+  await waitForLoadingToFinish();
+
+  expect(
+    screen.queryAllByRole('button', {
+      name: 'Lähetä kutsulinkki uudelleen',
+    }),
+  ).toHaveLength(0);
 });

--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -336,7 +336,7 @@ test('Should send invitation to user when cliking the Lähetä kutsulinkki uudel
   expect(invitationButton).toBeDisabled();
 });
 
-test('Should not send multiple requests when cliking the Lähetä kutsulinkki uudelleen button many times', async () => {
+test('Should not send multiple requests when clicking the Lähetä kutsulinkki uudelleen button many times', async () => {
   const sendInvitation = jest.spyOn(hankeUsersApi, 'resendInvitation');
   const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
 

--- a/src/domain/hanke/hankeUsers/hankeUser.ts
+++ b/src/domain/hanke/hankeUsers/hankeUser.ts
@@ -23,6 +23,7 @@ export type UserRights = Array<
   | 'MODIFY_DELETE_PERMISSIONS'
   | 'EDIT_APPLICATIONS'
   | 'MODIFY_APPLICATION_PERMISSIONS'
+  | 'RESEND_INVITATION'
 >;
 
 export type SignedInUser = {

--- a/src/domain/hanke/hankeUsers/hankeUsersApi.ts
+++ b/src/domain/hanke/hankeUsers/hankeUsersApi.ts
@@ -27,3 +27,8 @@ export async function identifyUser(id: string) {
   const { data } = await api.post<IdentificationResponse>('kayttajat', { tunniste: id });
   return data;
 }
+
+export async function resendInvitation(kayttajaId: string) {
+  await api.post(`kayttajat/${kayttajaId}/kutsu`);
+  return kayttajaId;
+}

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -200,6 +200,7 @@ export const handlers = [
           'MODIFY_DELETE_PERMISSIONS',
           'EDIT_APPLICATIONS',
           'MODIFY_APPLICATION_PERMISSIONS',
+          'RESEND_INVITATION',
         ],
       }),
     );
@@ -214,5 +215,9 @@ export const handlers = [
         hankeNimi: 'Aidasmäentien vesihuollon rakentaminen',
       }),
     );
+  }),
+
+  rest.post(`${apiUrl}/kayttajat/:kayttajaId/kutsu`, async (req, res, ctx) => {
+    return res(ctx.delay(), ctx.status(204));
   }),
 ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -861,8 +861,17 @@
       "rightsUpdatedErrorText": "<0>Käyttöoikeuksien päivityksessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>",
       "userIdentifiedLabel": "Tunnistautuminen onnistui",
       "userIdentifiedText": "Tunnistautuminen onnistui. Sinut on nyt lisätty hankkeelle ({{hankeNimi}} {{hankeTunnus}}).",
-      "userIdentifiedError": "Tunnistautuminen epäonnistui"
-    }
+      "userIdentifiedError": "Tunnistautuminen epäonnistui",
+      "invitationSentSuccessLabel": "Kutsulinkki lähetetty",
+      "invitationSentSuccessText": "Kutsulinkki lähetetty osoitteeseen {{email}}.",
+      "invitationSentErrorLabel": "Virhe linkin lähettämisessä",
+      "invitationSentErrorText": "<0>Kutsulinkin lähettämisessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>"
+    },
+    "buttons": {
+      "resendInvitation": "Lähetä kutsulinkki uudelleen",
+      "invitationSent": "Kutsulinkki lähetetty"
+    },
+    "userIdentified": "Käyttäjä tunnistautunut"
   },
   "map": {
     "controls": {


### PR DESCRIPTION
# Description

Added button for each user in the list to send invitation link to that user again if that user has not been identified in Haitaton before.

When the button is pressed it is disabled and it's text is changed to Kutsulinkki lähetetty until the user visits the page again.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1512

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Navigate to Käyttöoikeuksien hallinta view for hanke that has users that haven't been identified yet.
2. Click "Lähetä kutsulinkki uudelleen" button for some user.
3. Check that success notification is shown and that the button is disabled and button text is changed to "Kutsulinkki lähetetty".
4. Navigate away and back to the view again and check that the button you pressed previously is enabled.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
