### PR TITLE
HAI-1939 Fix problem where validation errors would remain when filling sub-contacts in cable report application

### DIFF
--- a/src/domain/johtoselvitys/Contacts.tsx
+++ b/src/domain/johtoselvitys/Contacts.tsx
@@ -209,10 +209,14 @@ const ContactFields: React.FC<{
 
   function fillWithOrdererInformation() {
     if (ordererInformation !== undefined) {
-      setValue(`applicationData.${customerType}.contacts.${index}`, {
-        ...ordererInformation,
-        orderer: false,
-      });
+      setValue(
+        `applicationData.${customerType}.contacts.${index}`,
+        {
+          ...ordererInformation,
+          orderer: false,
+        },
+        { shouldValidate: true, shouldDirty: true },
+      );
     }
   }
 

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -617,4 +617,22 @@ test('Form is saved when contacts are filled with orderer information', async ()
 
   expect(screen.queryByText(/hakemus tallennettu/i)).toBeInTheDocument();
   expect(saveApplication).toHaveBeenCalledTimes(1);
+
+  saveApplication.mockRestore();
+});
+
+test('Form is saved when sub contacts are filled with orderer information', async () => {
+  const saveApplication = jest.spyOn(applicationApi, 'saveApplication');
+  const { user } = render(<JohtoselvitysContainer application={applications[0]} />);
+
+  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+  await user.click(
+    screen.getByTestId('applicationData.contractorWithContacts.contacts.0.fillOwnInfoButton'),
+  );
+  await user.click(screen.getByRole('button', { name: /edellinen/i }));
+
+  expect(screen.queryByText(/hakemus tallennettu/i)).toBeInTheDocument();
+  expect(saveApplication).toHaveBeenCalledTimes(1);
+
+  saveApplication.mockRestore();
 });


### PR DESCRIPTION
# Description

If there were validation errors when user pressed Fill with own information button, those errors remained even when they should not.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1939

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Edit for example customer contacts name field and leave it empty
2. Click some other field. There should be validation error: "Kenttä on pakollinen".
3. Click "Täytä omilla tiedoilla" button.
4. Validation error(s) should go away from that customer contact.   

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
