### PR TITLE
HAI-1879 Show separate bus and tram indexes

### DIFF
--- a/cypress/integration/E2E.spec.ts
+++ b/cypress/integration/E2E.spec.ts
@@ -87,7 +87,8 @@ const hankeMockIndex: Partial<HankeIndexData> = {
     tyyppi: HANKE_INDEX_TYPE.PERUSINDEKSI,
   },
   pyorailyIndeksi: 3,
-  joukkoliikenneIndeksi: 4,
+  raitiovaunuIndeksi: 4,
+  linjaautoIndeksi: 3,
   perusIndeksi: 4.8,
 };
 

--- a/cypress/utils/indexValidator.ts
+++ b/cypress/utils/indexValidator.ts
@@ -5,17 +5,18 @@ export const validateIndexes = (hankeIndexData: Partial<HankeIndexData>) => {
   if (hankeIndexData.liikennehaittaIndeksi && hankeIndexData.liikennehaittaIndeksi.indeksi) {
     cy.get('[data-testid=test-liikennehaittaIndeksi]').should('not.be.empty');
     cy.get('[data-testid=test-liikennehaittaIndeksi]').contains(
-      hankeIndexData.liikennehaittaIndeksi.indeksi
+      hankeIndexData.liikennehaittaIndeksi.indeksi,
     );
   }
   if (hankeIndexData.pyorailyIndeksi) {
     cy.get('[data-testid=test-pyorailyIndeksi]').should('not.be.empty');
     cy.get('[data-testid=test-pyorailyIndeksi]').contains(hankeIndexData.pyorailyIndeksi);
   }
-  if (hankeIndexData.joukkoliikenneIndeksi) {
-    cy.get('[data-testid=test-joukkoliikenneIndeksi]').contains(
-      hankeIndexData.joukkoliikenneIndeksi
-    );
+  if (hankeIndexData.raitiovaunuIndeksi) {
+    cy.get('[data-testid=test-raitiovaunuIndeksi]').contains(hankeIndexData.raitiovaunuIndeksi);
+  }
+  if (hankeIndexData.linjaautoIndeksi) {
+    cy.get('[data-testid=test-linjaautoIndeksi]').contains(hankeIndexData.linjaautoIndeksi);
   }
   if (hankeIndexData.perusIndeksi) {
     cy.get('[data-testid=test-ruuhkautumisIndeksi]').contains(hankeIndexData.perusIndeksi);

--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -8,7 +8,7 @@ import usersData from '../../mocks/data/users-data.json';
 import { SignedInUser } from '../hankeUsers/hankeUser';
 import * as hankeUsersApi from '../../hanke/hankeUsers/hankeUsersApi';
 
-jest.setTimeout(40000);
+jest.setTimeout(50000);
 
 afterEach(cleanup);
 

--- a/src/domain/hanke/hankeIndexes/HankeIndexes.test.tsx
+++ b/src/domain/hanke/hankeIndexes/HankeIndexes.test.tsx
@@ -14,17 +14,21 @@ describe('HankeSidebar', () => {
     expect(findByText('Pyöräilyn pääreitti')).toBeTruthy();
     expect(getByTestId('test-pyorailyIndeksi')).toHaveTextContent('3');
     expect(getByTestId('test-pyorailyIndeksi-content')).toHaveTextContent(
-      'Kiertoreittitarve: todennäköinen'
+      'Kiertoreittitarve: todennäköinen',
     );
     expect(findByText('Merkittävät joukkoliikennereitit')).toBeTruthy();
-    expect(getByTestId('test-joukkoliikenneIndeksi')).toHaveTextContent('1');
-    expect(getByTestId('test-joukkoliikenneIndeksi-content')).toHaveTextContent(
-      'Kiertoreittitarve: ei tarvetta'
+    expect(getByTestId('test-raitiovaunuIndeksi')).toHaveTextContent('1');
+    expect(getByTestId('test-raitiovaunuIndeksi-content')).toHaveTextContent(
+      'Kiertoreittitarve: ei tarvetta',
+    );
+    expect(getByTestId('test-linjaautoIndeksi')).toHaveTextContent('2');
+    expect(getByTestId('test-linjaautoIndeksi-content')).toHaveTextContent(
+      'Kiertoreittitarve: ei tarvetta',
     );
     expect(findByText('Ruuhkautuminen')).toBeTruthy();
     expect(getByTestId('test-ruuhkautumisIndeksi')).toHaveTextContent('4');
     expect(getByTestId('test-ruuhkautumisIndeksi-content')).toHaveTextContent(
-      'Kiertoreittitarve: merkittävä'
+      'Kiertoreittitarve: merkittävä',
     );
   });
 });

--- a/src/domain/hanke/hankeIndexes/HankeIndexes.tsx
+++ b/src/domain/hanke/hankeIndexes/HankeIndexes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { LoadingSpinner, Tooltip } from 'hds-react';
@@ -95,7 +94,8 @@ const HankeIndexes: React.FC<React.PropsWithChildren<Props>> = ({
   const hankeIndexTitle = indexTitle || t('hankeIndexes:haittaindeksit');
   const liikennehaittaIndeksi = hankeIndexData?.liikennehaittaIndeksi.indeksi;
   const pyorailyIndeksi = hankeIndexData?.pyorailyIndeksi;
-  const joukkoliikenneIndeksi = hankeIndexData?.joukkoliikenneIndeksi;
+  const raitiovaunuIndeksi = hankeIndexData?.raitiovaunuIndeksi;
+  const linjaautoIndeksi = hankeIndexData?.linjaautoIndeksi;
   const perusIndeksi = hankeIndexData?.perusIndeksi;
 
   return (
@@ -123,7 +123,7 @@ const HankeIndexes: React.FC<React.PropsWithChildren<Props>> = ({
         <IndexSection
           title={t('hankeIndexes:pyorailynPaareitti')}
           content={`${t('hankeIndexes:kiertoreittitarve')}: ${t(
-            getDetourNeedByIndex(pyorailyIndeksi)
+            getDetourNeedByIndex(pyorailyIndeksi),
           )}`}
           index={pyorailyIndeksi}
           testId="test-pyorailyIndeksi"
@@ -132,12 +132,23 @@ const HankeIndexes: React.FC<React.PropsWithChildren<Props>> = ({
         />
 
         <IndexSection
-          title={t('hankeIndexes:merkittavatJoukkoliikennereitit')}
+          title={t('hankeIndexes:joukkoliikenneRaitiovaunu')}
           content={`${t('hankeIndexes:kiertoreittitarve')}: ${t(
-            getDetourNeedByIndex(joukkoliikenneIndeksi)
+            getDetourNeedByIndex(raitiovaunuIndeksi),
           )}`}
-          index={joukkoliikenneIndeksi}
-          testId="test-joukkoliikenneIndeksi"
+          index={raitiovaunuIndeksi}
+          testId="test-raitiovaunuIndeksi"
+          loading={loading}
+          showIndexText={!small}
+        />
+
+        <IndexSection
+          title={t('hankeIndexes:joukkoliikenneLinjaauto')}
+          content={`${t('hankeIndexes:kiertoreittitarve')}: ${t(
+            getDetourNeedByIndex(linjaautoIndeksi),
+          )}`}
+          index={linjaautoIndeksi}
+          testId="test-linjaautoIndeksi"
           loading={loading}
           showIndexText={!small}
         />
@@ -145,7 +156,7 @@ const HankeIndexes: React.FC<React.PropsWithChildren<Props>> = ({
         <IndexSection
           title={t('hankeIndexes:ruuhkautuminen')}
           content={`${t('hankeIndexes:kiertoreittitarve')}: ${t(
-            getDetourNeedByIndex(perusIndeksi)
+            getDetourNeedByIndex(perusIndeksi),
           )}`}
           index={perusIndeksi}
           testId="test-ruuhkautumisIndeksi"

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -67,7 +67,8 @@ test('Correct information about hanke should be displayed', async () => {
   expect(screen.getAllByText('2.1.2023–24.2.2023').length).toBe(2);
   expect(screen.getByTestId('test-liikennehaittaIndeksi')).toHaveTextContent('3');
   expect(screen.getByTestId('test-pyorailyIndeksi')).toHaveTextContent('3.5');
-  expect(screen.getByTestId('test-joukkoliikenneIndeksi')).toHaveTextContent('2');
+  expect(screen.getByTestId('test-raitiovaunuIndeksi')).toHaveTextContent('2');
+  expect(screen.getByTestId('test-linjaautoIndeksi')).toHaveTextContent('1');
   expect(screen.getByTestId('test-ruuhkautumisIndeksi')).toHaveTextContent('1.5');
   expect(screen.queryByText('11974 m²')).toBeInTheDocument();
   expect(screen.queryByText('Meluhaitta: Satunnainen haitta')).toBeInTheDocument();

--- a/src/domain/mocks/data/hankkeet-data.ts
+++ b/src/domain/mocks/data/hankkeet-data.ts
@@ -54,7 +54,8 @@ const hankkeet: HankeDataDraft[] = [
       tila: 'VOIMASSA',
       perusIndeksi: 3.5,
       pyorailyIndeksi: 3,
-      joukkoliikenneIndeksi: 4,
+      linjaautoIndeksi: 4,
+      raitiovaunuIndeksi: 2,
       liikennehaittaIndeksi: {
         indeksi: 4,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -274,7 +275,8 @@ const hankkeet: HankeDataDraft[] = [
       tila: 'VOIMASSA',
       perusIndeksi: 1.5,
       pyorailyIndeksi: 3.5,
-      joukkoliikenneIndeksi: 2,
+      linjaautoIndeksi: 1,
+      raitiovaunuIndeksi: 2,
       liikennehaittaIndeksi: {
         indeksi: 3,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/domain/mocks/hankeIndexData.ts
+++ b/src/domain/mocks/hankeIndexData.ts
@@ -10,7 +10,8 @@ const hankeIndexData: HankeIndexData = {
   },
   perusIndeksi: 4,
   pyorailyIndeksi: 3,
-  joukkoliikenneIndeksi: 1,
+  linjaautoIndeksi: 2,
+  raitiovaunuIndeksi: 1,
   tila: HANKE_INDEX_STATE.VOIMASSA,
 };
 

--- a/src/domain/types/hanke.ts
+++ b/src/domain/types/hanke.ts
@@ -220,7 +220,8 @@ export interface HankeIndexData {
   liikennehaittaIndeksi: LiikenneHaittaIndeksi;
   perusIndeksi: number;
   pyorailyIndeksi: number;
-  joukkoliikenneIndeksi: number;
+  linjaautoIndeksi: number;
+  raitiovaunuIndeksi: number;
   tila: HANKE_INDEX_STATE_KEY;
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -648,7 +648,6 @@
     "liikennehaittaindeksi": "Traffic nuisance index",
     "ruuhkautuminen": "Congestion",
     "pyorailynPaareitti": "Main cycling route",
-    "merkittavatJoukkoliikennereitit": "Major public transport routes",
     "kiertoreittitarve": "Detour need",
     "KIERTOREITTITARPEET": {
       "TODENNAKOINEN": "likely",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -664,7 +664,8 @@
     "liikennehaittaindeksi": "Liikennehaittaindeksi",
     "ruuhkautuminen": "Ruuhkautuminen",
     "pyorailynPaareitti": "Pyöräilyn pääreitti",
-    "merkittavatJoukkoliikennereitit": "Merkittävät joukkoliikennereitit",
+    "joukkoliikenneRaitiovaunu": "Joukkoliikenteen merkittävyys: Raitioliikenne",
+    "joukkoliikenneLinjaauto": "Joukkoliikenteen merkittävyys: Linja-autojen paikallisliikenne",
     "kiertoreittitarve": "Kiertoreittitarve",
     "KIERTOREITTITARPEET": {
       "TODENNAKOINEN": "todennäköinen",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -648,7 +648,6 @@
     "liikennehaittaindeksi": "Trafikolägenhetsindex",
     "ruuhkautuminen": "Köbildning",
     "pyorailynPaareitti": "Huvudled för cykeltrafik",
-    "merkittavatJoukkoliikennereitit": "Viktiga leder för kollektivtrafik",
     "kiertoreittitarve": "Behov av omväg",
     "KIERTOREITTITARPEET": {
       "TODENNAKOINEN": "sannolik",


### PR DESCRIPTION
# Description

Instead of just one joukkoliikenneindeksi show separate indexes for bus and tram.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1879

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new hanke and fill first two pages of hanke form so that it has hanke areas defined.
2. Go to third page of the form.
3. Third page of hanke form should show hanke indexes and there should be separate indexes for tram and bus.
4. Those same indexes should also be displayed in hanke page.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
