### PR TITLE
HAI-1921 Fix incorrect focus order of fields with error in cable report application form

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
     'object-curly-spacing': ['warn', 'always'],
     'react/jsx-props-no-spreading': 'off',
     'import/prefer-default-export': 'off',
-    'react-hooks/exhaustive-deps': 'off',
+    'react-hooks/exhaustive-deps': 'warn',
     'no-underscore-dangle': ['error', { allow: ['__typename', '_env_'] }],
     'no-param-reassign': [
       'error',

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
-    "react-hook-form": "^7.35.0",
+    "react-hook-form": "^7.47.0",
     "react-i18next": "^12.0.0",
     "react-query": "^3.39.2",
     "react-redux": "^8.0.5",

--- a/src/common/components/radiobutton/BooleanRadioButton.tsx
+++ b/src/common/components/radiobutton/BooleanRadioButton.tsx
@@ -15,7 +15,7 @@ type Props<T extends FieldValues> = {
  */
 const BooleanRadioButton = <T extends FieldValues>({ name, id, label, value }: Props<T>) => {
   const {
-    field: { onChange, onBlur, value: inputValue },
+    field: { onChange, onBlur, value: inputValue, ref },
   } = useController({ name });
 
   return (
@@ -30,6 +30,7 @@ const BooleanRadioButton = <T extends FieldValues>({ name, id, label, value }: P
       value={value.toString()}
       checked={value === inputValue}
       data-testid={id}
+      ref={ref}
     />
   );
 };

--- a/src/common/components/textArea/TextArea.tsx
+++ b/src/common/components/textArea/TextArea.tsx
@@ -36,7 +36,7 @@ const TextArea: React.FC<Props> = ({
       control={control}
       defaultValue=""
       shouldUnregister={shouldUnregister}
-      render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => {
+      render={({ field: { onChange, onBlur, value, ref }, fieldState: { error } }) => {
         return (
           <HdsTextArea
             id={name}
@@ -53,6 +53,7 @@ const TextArea: React.FC<Props> = ({
             required={required}
             disabled={disabled}
             errorText={getInputErrorText(t, error)}
+            ref={ref}
           />
         );
       }}

--- a/src/domain/forms/components/Contact.tsx
+++ b/src/domain/forms/components/Contact.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Flex } from '@chakra-ui/react';
 import { Button, IconCross, IconPlusCircle, Tab, TabList, TabPanel, Tabs } from 'hds-react';
 import { useTranslation } from 'react-i18next';
@@ -37,15 +37,15 @@ const Contact = <T,>({
     name: subContactPath,
   });
 
-  function addSubContact() {
+  const addSubContact = useCallback(() => {
     appendSubContact(emptySubContact);
-  }
+  }, [appendSubContact, emptySubContact]);
 
   useEffect(() => {
     if (subContactFields.length === 0 && showInitialEmpty) {
       addSubContact();
     }
-  }, [subContactFields, showInitialEmpty]);
+  }, [subContactFields, showInitialEmpty, addSubContact]);
 
   const renderSubContacts = subContactFields.length > 0 && renderSubContact;
   const { tabRefs } = useSelectableTabs(subContactFields.length, { selectLastTabOnChange: true });

--- a/src/domain/forms/utils.ts
+++ b/src/domain/forms/utils.ts
@@ -10,7 +10,7 @@ import { ObjectSchema } from 'yup';
 export function changeFormStep<T extends FieldValues>(
   handleStepChange: () => void,
   fieldsToValidate: FieldPath<T>[],
-  trigger: UseFormTrigger<T>
+  trigger: UseFormTrigger<T>,
 ) {
   trigger(fieldsToValidate, { shouldFocus: true }).then((isValid) => {
     if (isValid) {
@@ -23,7 +23,7 @@ export function isPageValid<T extends FieldValues, T2 = T>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   schema: ObjectSchema<any>,
   pageFieldPaths: FieldPath<T>[],
-  formValues: T2
+  formValues: T2,
 ): boolean {
   let isValid = true;
   for (let i = 0; i < pageFieldPaths.length; i += 1) {
@@ -36,4 +36,26 @@ export function isPageValid<T extends FieldValues, T2 = T>(
     }
   }
   return isValid;
+}
+
+export function getFieldPaths<T extends FieldValues>(
+  node: object | Array<object> | null,
+  pathToNode: FieldPath<T>,
+): FieldPath<T>[] {
+  if (node === null) {
+    return [];
+  }
+
+  let fieldPaths: string[] = [];
+  if (Array.isArray(node)) {
+    node.forEach((obj, index) => {
+      fieldPaths = fieldPaths.concat(
+        Object.keys(obj).map((key) => `${pathToNode}.${index}.${key}`),
+      );
+    });
+  } else {
+    fieldPaths = Object.keys(node).map((key) => `${pathToNode}.${key}`);
+  }
+
+  return fieldPaths as FieldPath<T>[];
 }

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -130,7 +130,7 @@ const ContactField: React.FC<{
         shouldValidate: true,
       });
     }
-  }, [inputDisabled]);
+  }, [inputDisabled, contactType, index, setValue]);
 
   const label = t(`form:yhteystiedot:labels:${field}`);
 

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -22,7 +22,7 @@ import {
   convertFormStateToApplicationData,
   findOrdererKey,
 } from './utils';
-import { changeFormStep, isPageValid } from '../forms/utils';
+import { changeFormStep, getFieldPaths, isPageValid } from '../forms/utils';
 import { isApplicationDraft, saveApplication, sendApplication } from '../application/utils';
 import { HankeContacts, HankeData } from '../types/hanke';
 import { ApplicationCancel } from '../application/components/ApplicationCancel';
@@ -77,11 +77,11 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
         },
         contacts: [
           {
-            email: '',
             firstName: '',
             lastName: '',
-            orderer: true,
+            email: '',
             phone: '',
+            orderer: true,
           },
         ],
       },
@@ -105,11 +105,11 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
         },
         contacts: [
           {
-            email: '',
             firstName: '',
             lastName: '',
-            orderer: false,
+            email: '',
             phone: '',
+            orderer: false,
           },
         ],
       },
@@ -316,17 +316,28 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
 
   const ordererKey = findOrdererKey(getValues('applicationData'));
 
+  const customer = getValues('applicationData.customerWithContacts.customer');
+  const customersContacts = getValues('applicationData.customerWithContacts.contacts');
+  const contractor = getValues('applicationData.contractorWithContacts.customer');
+  const contractorsContacts = getValues('applicationData.contractorWithContacts.contacts');
+  const propertyDeveloper = getValues('applicationData.propertyDeveloperWithContacts.customer');
+  const propertyDevelopersContacts = getValues(
+    'applicationData.propertyDeveloperWithContacts.contacts',
+  );
+  const representative = getValues('applicationData.representativeWithContacts.customer');
+  const representativesContacts = getValues('applicationData.representativeWithContacts.contacts');
+
   // Fields that are validated in each page when moving forward in form
   const pageFieldsToValidate: FieldPath<JohtoselvitysFormValues>[][] = useMemo(
     () => [
       // Basic information page
       [
         'applicationData.name',
-        'applicationData.postalAddress',
+        'applicationData.postalAddress.streetAddress.streetName',
+        'applicationData.constructionWork',
+        'applicationData.rockExcavation',
         'applicationData.workDescription',
         `applicationData.${ordererKey}.contacts`,
-        'applicationData.rockExcavation',
-        'applicationData.constructionWork',
       ],
       // Areas page
       [
@@ -337,15 +348,53 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
       ],
       // Contacts page
       [
-        'applicationData.customerWithContacts',
-        'applicationData.contractorWithContacts',
-        'applicationData.propertyDeveloperWithContacts',
-        'applicationData.representativeWithContacts',
+        ...getFieldPaths<JohtoselvitysFormValues>(
+          customer,
+          'applicationData.customerWithContacts.customer',
+        ),
+        ...getFieldPaths<JohtoselvitysFormValues>(
+          customersContacts,
+          'applicationData.customerWithContacts.contacts',
+        ),
+        ...getFieldPaths<JohtoselvitysFormValues>(
+          contractor,
+          'applicationData.contractorWithContacts.customer',
+        ),
+        ...getFieldPaths<JohtoselvitysFormValues>(
+          contractorsContacts,
+          'applicationData.contractorWithContacts.contacts',
+        ),
+        ...getFieldPaths<JohtoselvitysFormValues>(
+          propertyDeveloper,
+          'applicationData.propertyDeveloperWithContacts.customer',
+        ),
+        ...getFieldPaths<JohtoselvitysFormValues>(
+          propertyDevelopersContacts,
+          'applicationData.propertyDeveloperWithContacts.contacts',
+        ),
+        ...getFieldPaths<JohtoselvitysFormValues>(
+          representative,
+          'applicationData.representativeWithContacts.customer',
+        ),
+        ...getFieldPaths<JohtoselvitysFormValues>(
+          representativesContacts,
+          'applicationData.representativeWithContacts.contacts',
+        ),
       ],
       // Attachments page
       ['attachmentNumber'],
     ],
-    [ordererKey],
+    [
+      ordererKey,
+      customer,
+      customersContacts,
+      contractor,
+      contractorsContacts,
+      propertyDeveloper,
+      propertyDevelopersContacts,
+      representative,
+      representativesContacts,
+    ],
   );
 
   const formSteps = useMemo(() => {

--- a/src/domain/johtoselvitys/validationSchema.ts
+++ b/src/domain/johtoselvitys/validationSchema.ts
@@ -17,6 +17,7 @@ const contactSchema = yup
     lastName: yup.string().trim().required(),
     email: yup.string().trim().email().max(100).required(),
     phone: yup.string().trim().max(20).required(),
+    orderer: yup.boolean(),
   });
 
 const customerSchema = contactSchema.omit(['firstName', 'lastName']).shape({
@@ -31,6 +32,10 @@ const customerSchema = contactSchema.omit(['firstName', 'lastName']).shape({
         schema.test('is-business-id', 'Is not valid business id', isValidBusinessId),
       otherwise: (schema) => schema,
     }),
+  country: yup.string().nullable(),
+  ovt: yup.string().nullable(),
+  invoicingOperator: yup.string().nullable(),
+  sapCustomerNumber: yup.string().nullable(),
 });
 
 const customerWithContactsSchema = yup.object().shape({

--- a/yarn.lock
+++ b/yarn.lock
@@ -14252,15 +14252,15 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
-react-hook-form@^7.35.0:
-  version "7.35.0"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.35.0.tgz#b133de48fc84b1e62f9277ba79dfbacd9bb13dd3"
-  integrity sha512-9CYdOed+Itbiu5VMVxW0PK9mBR3f0gDGJcZEyUSm0eJbDymQ913TRs2gHcQZZmfTC+rtxyDFRuelMxx/+xwMcw==
-
 react-hook-form@^7.43.3:
   version "7.43.9"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.43.9.tgz#84b56ac2f38f8e946c6032ccb760e13a1037c66d"
   integrity sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==
+
+react-hook-form@^7.47.0:
+  version "7.47.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.47.0.tgz#a42f07266bd297ddf1f914f08f4b5f9783262f31"
+  integrity sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==
 
 react-i18next@^12.0.0:
   version "12.0.0"


### PR DESCRIPTION
# Description

When triggering form validations, field paths in the array given to react-hook-form trigger function were not in correct order, and so focus went to wrong field when there were errors. Fixed this by making sure the field paths are in correct order.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1921

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create new cable report application and fill first and second page.
2. In third page try to move to next or previous page of the form without filling any fields.
3. Focus should go to name field of the Applicant 

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
