### PR TITLE
HAI-1736 Update copyright footer to adhere to OSM licence

### DIFF
--- a/src/common/components/footer/Footer.tsx
+++ b/src/common/components/footer/Footer.tsx
@@ -19,7 +19,7 @@ function HaitatonFooter() {
         <Footer.Item as={Link} to={ACCESSIBILITY.path} label={ACCESSIBILITY.label} />
         <Footer.Item as={Link} to={PRIVACY_POLICY.path} label={PRIVACY_POLICY.label} />
       </Footer.Navigation>
-      <Footer.Base copyrightHolder="Helsingin kaupunki" />
+      <Footer.Base copyrightHolder="Helsingin kaupunki, OpenStreetMap contributors" />
     </Footer>
   );
 }


### PR DESCRIPTION
# Description

Update copyright footer to adhere to OSM licence:
- © Helsingin kaupunki, OpenStreetMap contributors 2023 

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1736

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Deploy the application. Verify the copyright info in footer element is correct.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
