### PR TITLE
HAI-2008 Allow user to name hanke areas

### DIFF
--- a/src/common/components/textInput/TextInput.tsx
+++ b/src/common/components/textInput/TextInput.tsx
@@ -19,6 +19,7 @@ type PropTypes = {
   shouldUnregister?: boolean;
   className?: string;
   autoComplete?: string;
+  defaultValue?: string;
 };
 
 const TextInput: React.FC<React.PropsWithChildren<PropTypes>> = ({
@@ -34,6 +35,7 @@ const TextInput: React.FC<React.PropsWithChildren<PropTypes>> = ({
   shouldUnregister,
   className,
   autoComplete,
+  defaultValue = '',
 }) => {
   const { t } = useTranslation();
   const { control } = useFormContext();
@@ -42,7 +44,7 @@ const TextInput: React.FC<React.PropsWithChildren<PropTypes>> = ({
     <Controller
       name={name}
       control={control}
-      defaultValue=""
+      defaultValue={defaultValue}
       shouldUnregister={shouldUnregister}
       render={({ field: { value, onBlur, onChange, ref }, fieldState: { error } }) => (
         <HdsTextInput

--- a/src/common/hooks/useFieldArrayWithStateUpdate.ts
+++ b/src/common/hooks/useFieldArrayWithStateUpdate.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useFieldArray, UseFieldArrayProps, useFormContext } from 'react-hook-form';
+
+/**
+ * Wrapper for React Hook Form useFieldArray that calls
+ * setValue for each field in fieldArray when the fields
+ * change, so that the fields are updated correctly
+ */
+export default function useFieldArrayWithStateUpdate(props: UseFieldArrayProps) {
+  const { setValue, getValues } = useFormContext();
+  const fieldArrayReturn = useFieldArray(props);
+
+  useEffect(() => {
+    fieldArrayReturn.fields.forEach((_, index) => {
+      setValue(`${props.name}.${index}`, getValues(`${props.name}.${index}`));
+    });
+  }, [setValue, getValues, fieldArrayReturn.fields, props.name]);
+
+  return fieldArrayReturn;
+}

--- a/src/domain/forms/components/Contact.tsx
+++ b/src/domain/forms/components/Contact.tsx
@@ -2,9 +2,10 @@ import React, { useCallback, useEffect } from 'react';
 import { Flex } from '@chakra-ui/react';
 import { Button, IconCross, IconPlusCircle, Tab, TabList, TabPanel, Tabs } from 'hds-react';
 import { useTranslation } from 'react-i18next';
-import { useFieldArray, UseFieldArrayRemove } from 'react-hook-form';
+import { UseFieldArrayRemove } from 'react-hook-form';
 import styles from './Contact.module.scss';
 import useSelectableTabs from '../../../common/hooks/useSelectableTabs';
+import useFieldArrayWithStateUpdate from '../../../common/hooks/useFieldArrayWithStateUpdate';
 
 interface Props<T> {
   contactType: T;
@@ -33,7 +34,7 @@ const Contact = <T,>({
     fields: subContactFields,
     append: appendSubContact,
     remove: removeSubContact,
-  } = useFieldArray({
+  } = useFieldArrayWithStateUpdate({
     name: subContactPath,
   });
 

--- a/src/domain/hanke/edit/HankeFormAlueet.tsx
+++ b/src/domain/hanke/edit/HankeFormAlueet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { useFieldArray, useFormContext } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
 import { Feature } from 'ol';
@@ -15,6 +15,7 @@ import Text from '../../../common/components/text/Text';
 import useSelectableTabs from '../../../common/hooks/useSelectableTabs';
 import useHighlightArea from '../../map/hooks/useHighlightArea';
 import useAddressCoordinate from '../../map/hooks/useAddressCoordinate';
+import useFieldArrayWithStateUpdate from '../../../common/hooks/useFieldArrayWithStateUpdate';
 
 function getEmptyArea(feature: Feature): Omit<HankeAlueFormState, 'id' | 'geometriat'> {
   return {
@@ -31,8 +32,12 @@ function getEmptyArea(feature: Feature): Omit<HankeAlueFormState, 'id' | 'geomet
 
 const HankeFormAlueet: React.FC<FormProps> = ({ formData }) => {
   const { t } = useTranslation();
-  const { setValue, trigger } = useFormContext();
-  const { fields: hankeAlueet, append, remove } = useFieldArray({
+  const { setValue, trigger, watch } = useFormContext();
+  const {
+    fields: hankeAlueet,
+    append,
+    remove,
+  } = useFieldArrayWithStateUpdate({
     name: FORMFIELD.HANKEALUEET,
   });
   const [drawSource] = useState<VectorSource>(new VectorSource());
@@ -52,7 +57,7 @@ const HankeFormAlueet: React.FC<FormProps> = ({ formData }) => {
 
       setValue(FORMFIELD.GEOMETRIES_CHANGED, true, { shouldDirty: true });
     },
-    [setValue, append]
+    [setValue, append],
   );
 
   const handleChangeFeature = useCallback(() => {
@@ -100,10 +105,11 @@ const HankeFormAlueet: React.FC<FormProps> = ({ formData }) => {
             const hankeAlue = formData.alueet && formData.alueet[index];
             const hankeGeometry = hankeAlue?.feature?.getGeometry();
             const surfaceArea = hankeGeometry && `(${formatSurfaceArea(hankeGeometry)})`;
+            const name = watch(`${FORMFIELD.HANKEALUEET}.${index}.nimi`);
             return (
               <Tab key={item.id} onClick={() => higlightArea(hankeAlue?.feature)}>
                 <div ref={tabRefs[index]}>
-                  {t('hankeForm:hankkeenAlueForm:area')} {index + 1} {surfaceArea}
+                  {name} {surfaceArea}
                 </div>
               </Tab>
             );

--- a/src/domain/hanke/edit/HankeFormAlueet.tsx
+++ b/src/domain/hanke/edit/HankeFormAlueet.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
@@ -16,6 +16,8 @@ import useSelectableTabs from '../../../common/hooks/useSelectableTabs';
 import useHighlightArea from '../../map/hooks/useHighlightArea';
 import useAddressCoordinate from '../../map/hooks/useAddressCoordinate';
 import useFieldArrayWithStateUpdate from '../../../common/hooks/useFieldArrayWithStateUpdate';
+import { HankeAlue } from '../../types/hanke';
+import { getAreaDefaultName } from './utils';
 
 function getEmptyArea(feature: Feature): Omit<HankeAlueFormState, 'id' | 'geometriat'> {
   return {
@@ -32,7 +34,7 @@ function getEmptyArea(feature: Feature): Omit<HankeAlueFormState, 'id' | 'geomet
 
 const HankeFormAlueet: React.FC<FormProps> = ({ formData }) => {
   const { t } = useTranslation();
-  const { setValue, trigger, watch } = useFormContext();
+  const { setValue, trigger, watch, getValues } = useFormContext();
   const {
     fields: hankeAlueet,
     append,
@@ -47,6 +49,18 @@ const HankeFormAlueet: React.FC<FormProps> = ({ formData }) => {
   const { tabRefs } = useSelectableTabs(hankeAlueet.length, { selectLastTabOnChange: true });
 
   const higlightArea = useHighlightArea();
+
+  useEffect(() => {
+    // If there are hanke areas with no name on unmount, set default names for them
+    return function cleanup() {
+      const areas = getValues(FORMFIELD.HANKEALUEET) as HankeAlue[];
+      areas.forEach((area, i) => {
+        if (!area.nimi) {
+          setValue(`${FORMFIELD.HANKEALUEET}.${i}.nimi`, getAreaDefaultName(areas));
+        }
+      });
+    };
+  }, [getValues, setValue]);
 
   const handleAddFeature = useCallback(
     (feature: Feature<Geometry>) => {

--- a/src/domain/hanke/edit/components/AreaSummary.tsx
+++ b/src/domain/hanke/edit/components/AreaSummary.tsx
@@ -13,9 +13,7 @@ const AreaSummary: React.FC<{ area: HankeAlueFormState; index: number }> = ({ ar
   return (
     <div style={{ marginBottom: 'var(--spacing-m)' }}>
       <p style={{ marginBottom: 'var(--spacing-s)' }}>
-        <strong>
-          {t('hankeForm:hankkeenAlueForm:area')} {index + 1}
-        </strong>
+        <strong>{area.nimi || t('hanke:alue:title', { index: index + 1 })}</strong>
       </p>
       <p>
         {t('form:labels:pintaAla')}: {surfaceArea}

--- a/src/domain/hanke/edit/components/Haitat.tsx
+++ b/src/domain/hanke/edit/components/Haitat.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Button, Fieldset, IconTrash } from 'hds-react';
 import { $enum } from 'ts-enum-util';
 import { Box, Flex, Spacer } from '@chakra-ui/react';
-import { FORMFIELD } from '../types';
+import { FORMFIELD, HankeDataFormState } from '../types';
 import DatePicker from '../../../../common/components/datePicker/DatePicker';
 import Dropdown from '../../../../common/components/dropdown/Dropdown';
 import useLocale from '../../../../common/hooks/useLocale';
@@ -17,6 +17,8 @@ import {
   HANKE_TARINAHAITTA,
 } from '../../../types/hanke';
 import styles from './Haitat.module.scss';
+import TextInput from '../../../../common/components/textInput/TextInput';
+import { getAreaDefaultName } from '../utils';
 
 type Props = {
   index: number;
@@ -26,13 +28,18 @@ type Props = {
 const Haitat: React.FC<Props> = ({ index, onRemoveArea }) => {
   const { t } = useTranslation();
   const locale = useLocale();
-  const { getValues, watch, setValue } = useFormContext();
+  const { getValues, watch, setValue } = useFormContext<HankeDataFormState>();
   const formValues: HankeAlue[] = getValues(FORMFIELD.HANKEALUEET);
 
   const watchHankeAlueet: HankeAlue[] = watch(FORMFIELD.HANKEALUEET);
   const haittaAlkuPvm = watchHankeAlueet[index]?.haittaAlkuPvm;
   const haittaLoppuPvm = watchHankeAlueet[index]?.haittaLoppuPvm;
   const minEndDate = haittaAlkuPvm && new Date(haittaAlkuPvm);
+
+  const areaDefaultName = useMemo(
+    () => getAreaDefaultName(getValues(FORMFIELD.HANKEALUEET)),
+    [getValues],
+  );
 
   useEffect(() => {
     if (haittaAlkuPvm && haittaLoppuPvm && haittaAlkuPvm > haittaLoppuPvm) {
@@ -49,6 +56,16 @@ const Haitat: React.FC<Props> = ({ index, onRemoveArea }) => {
       <Box mb="var(--spacing-l)">
         <p>{t('hankeForm:hankkeenAlueForm:haitatInstructions')}</p>
       </Box>
+
+      <div className={`${styles.formRow} ${styles.formRowEven} formWprShort`}>
+        <TextInput
+          name={`${FORMFIELD.HANKEALUEET}.${index}.nimi`}
+          label={t('form:labels:areaName')}
+          helperText={t('form:helperTexts:areaName')}
+          defaultValue={areaDefaultName}
+          maxLength={100}
+        />
+      </div>
 
       <div className={`${styles.formRow} ${styles.formRowEven}`}>
         <DatePicker

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -54,6 +54,7 @@ const otherPartySchema = contactSchema
   });
 
 export const hankeAlueSchema = yup.object().shape({
+  [FORMFIELD.NIMI]: yup.string(),
   [FORMFIELD.HAITTA_ALKU_PVM]: yup.date().required(),
   [FORMFIELD.HAITTA_LOPPU_PVM]: yup
     .date()

--- a/src/domain/hanke/edit/utils.test.ts
+++ b/src/domain/hanke/edit/utils.test.ts
@@ -1,0 +1,42 @@
+import { HankeAlueFormState } from './types';
+import { getAreaDefaultName } from './utils';
+
+function getArea(areaName: string): HankeAlueFormState {
+  return {
+    nimi: areaName,
+    id: null,
+    haittaAlkuPvm: '2023-01-12T00:00:00Z',
+    haittaLoppuPvm: '2024-11-27T00:00:00Z',
+    kaistaHaitta: null,
+    kaistaPituusHaitta: null,
+    meluHaitta: null,
+    polyHaitta: null,
+    tarinaHaitta: null,
+  };
+}
+
+test('Should get default area name when there are no areas', () => {
+  const areaName = getAreaDefaultName([]);
+
+  expect(areaName).toBe('Hankealue 1');
+});
+
+test('Should get correct default area name based on other areas', () => {
+  const areaName = getAreaDefaultName([
+    getArea('Hankealue 1'),
+    getArea('Hankealue 3'),
+    getArea('Hankealue 7'),
+    getArea('Oma alue 3'),
+  ]);
+
+  expect(areaName).toBe('Hankealue 8');
+
+  const secondAreaName = getAreaDefaultName([
+    getArea('Hankealue 1'),
+    getArea('Kuoppa'),
+    getArea('Hankealue 30'),
+    getArea('Hankealue 7'),
+  ]);
+
+  expect(secondAreaName).toBe('Hankealue 31');
+});

--- a/src/domain/hanke/edit/utils.test.ts
+++ b/src/domain/hanke/edit/utils.test.ts
@@ -39,4 +39,13 @@ test('Should get correct default area name based on other areas', () => {
   ]);
 
   expect(secondAreaName).toBe('Hankealue 31');
+
+  const thirdAreaName = getAreaDefaultName([
+    getArea('Hankealue 1'),
+    getArea('Hankealue 3'),
+    getArea('Hankealue 7'),
+    getArea('Oma alue 9'),
+  ]);
+
+  expect(thirdAreaName).toBe('Hankealue 8');
 });

--- a/src/domain/hanke/edit/utils.ts
+++ b/src/domain/hanke/edit/utils.ts
@@ -8,7 +8,6 @@ import { formatFeaturesToHankeGeoJSON, getFeatureFromHankeGeometry } from '../..
 import { getSurfaceArea } from '../../../common/components/map/utils';
 import { Application } from '../../application/types/application';
 import { isApplicationPending } from '../../application/utils';
-import { maxBy } from 'lodash';
 
 export function getAreasMinStartDate(areas: HankeAlue[] | undefined) {
   const areaStartDates = areas?.map((alue) => {

--- a/src/domain/hanke/edit/utils.ts
+++ b/src/domain/hanke/edit/utils.ts
@@ -8,6 +8,7 @@ import { formatFeaturesToHankeGeoJSON, getFeatureFromHankeGeometry } from '../..
 import { getSurfaceArea } from '../../../common/components/map/utils';
 import { Application } from '../../application/types/application';
 import { isApplicationPending } from '../../application/utils';
+import { maxBy } from 'lodash';
 
 export function getAreasMinStartDate(areas: HankeAlue[] | undefined) {
   const areaStartDates = areas?.map((alue) => {
@@ -59,7 +60,7 @@ export const convertFormStateToHankeData = (hankeData: HankeDataFormState): Hank
  * Add openlayers feature to each hanke area, converting area geometry into openlayers feature.
  */
 export const convertHankeDataToFormState = (
-  hankeData: HankeDataDraft | undefined
+  hankeData: HankeDataDraft | undefined,
 ): HankeDataFormState => ({
   ...hankeData,
   [FORMFIELD.HANKEALUEET]:
@@ -72,6 +73,7 @@ export const convertHankeDataToFormState = (
       return {
         ...alue,
         feature: new Feature(new Polygon(geometry.coordinates)),
+        nimi: alue.nimi !== null && alue.nimi !== '' ? alue.nimi : undefined,
       };
     }),
   omistajat: hankeData?.omistajat ? hankeData.omistajat : [],
@@ -107,4 +109,25 @@ export function calculateTotalSurfaceArea(areas?: HankeAlueFormState[]) {
  */
 export function canHankeBeCancelled(applications: Application[]): boolean {
   return applications.every((application) => isApplicationPending(application.alluStatus));
+}
+
+/**
+ * Get default name for hanke area
+ */
+export function getAreaDefaultName(areas?: HankeAlueFormState[]) {
+  if (areas === undefined) {
+    return undefined;
+  }
+
+  function getAreaNumber(area?: HankeAlueFormState): number {
+    const areaNumber = area?.nimi?.match(/\d+$/);
+    return areaNumber ? Number(areaNumber[0]) : 0;
+  }
+
+  const defaultNameRegExp = /^Hankealue \d+$/;
+  const areasWithDefaultName = areas.filter((area) => defaultNameRegExp.test(area.nimi || ''));
+  const areaWithMaxName = maxBy(areasWithDefaultName, (area) => getAreaNumber(area));
+  const maxAreaNumber: number = getAreaNumber(areaWithMaxName);
+
+  return `Hankealue ${maxAreaNumber + 1}`;
 }

--- a/src/domain/hanke/edit/utils.ts
+++ b/src/domain/hanke/edit/utils.ts
@@ -125,9 +125,10 @@ export function getAreaDefaultName(areas?: HankeAlueFormState[]) {
   }
 
   const defaultNameRegExp = /^Hankealue \d+$/;
-  const areasWithDefaultName = areas.filter((area) => defaultNameRegExp.test(area.nimi || ''));
-  const areaWithMaxName = maxBy(areasWithDefaultName, (area) => getAreaNumber(area));
-  const maxAreaNumber: number = getAreaNumber(areaWithMaxName);
+  const maxAreaNumber = areas
+    .filter((area) => defaultNameRegExp.test(area.nimi || ''))
+    .map(getAreaNumber)
+    .reduce((a, b) => Math.max(a, b), 0);
 
   return `Hankealue ${maxAreaNumber + 1}`;
 }

--- a/src/domain/hanke/hankeIndexes/CompressedAreaIndex.tsx
+++ b/src/domain/hanke/hankeIndexes/CompressedAreaIndex.tsx
@@ -32,7 +32,8 @@ const CompressedAreaIndex: React.FC<Props> = ({ area, haittaIndex, index, classN
     >
       <div>
         <Text tag="p" styleAs="body-m" weight="bold" spacingBottom="2-xs">
-          {t('hanke:alue:title', { index: index + 1 })} ({formatSurfaceArea(areaGeometry)})
+          {area.nimi || t('hanke:alue:title', { index: index + 1 })} (
+          {formatSurfaceArea(areaGeometry)})
         </Text>
         <Text tag="p" styleAs="body-s">
           {areaStartDate}–{areaEndDate}

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -71,7 +71,7 @@ const HankeAreaInfo: React.FC<AreaProps> = ({ area, hankeIndexData, index }) => 
   return (
     <Accordion
       language={locale}
-      heading={t('hanke:alue:title', { index: index + 1 })}
+      heading={area.nimi || t('hanke:alue:title', { index: index + 1 })}
       initiallyOpen
       className={styles.hankeAreaContainer}
     >

--- a/src/domain/types/hanke.ts
+++ b/src/domain/types/hanke.ts
@@ -169,6 +169,7 @@ export type HankeAlue = {
   meluHaitta: HANKE_MELUHAITTA_KEY | null;
   polyHaitta: HANKE_POLYHAITTA | null;
   tarinaHaitta: HANKE_TARINAHAITTA_KEY | null;
+  nimi?: string | null;
 };
 
 export enum HANKE_INDEX_TYPE {


### PR DESCRIPTION
# Description

Added text input for hanke area tab in areas page of hanke form, which allows user to enter name for each hanke area.

Name input has a default value that is Hankealue + the next running number of the default names of other hanke areas. For example if there are names Hankealue 1, Hankealue 2 and Hankealue 4, the next default name would be Hankealue 5. User can then edit the default name if they want to.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2008

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new hanke and fill the first page
2. Go to the second page and draw an area to the map
3. Tab for the new area should appear below and it should have a name "Hankealue 1"
4. Edit the name to be something else
5. Changes should reflect to the tab name also
6. Draw a new area --> it should get the name "Hankealue 1"
7. Draw two new areas --> they should be named "Hankealue 2" and "Hankealue 3"
8. Try deleting "Hankealue 2" and drawing a new area --> it should be named "Hankealue 4"

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
