### PR TITLE
HAI-2065 Implement file upload component

### DIFF
--- a/src/common/components/fileUpload/FileUpload.module.scss
+++ b/src/common/components/fileUpload/FileUpload.module.scss
@@ -1,0 +1,16 @@
+.uploadContainer {
+  min-height: 250px;
+  margin-bottom: var(--spacing-s);
+}
+
+.loadingContainer {
+  margin-left: var(--spacing-m);
+
+  .loadingSpinner {
+    margin-right: var(--spacing-s);
+  }
+
+  .loadingText {
+    font-weight: 500;
+  }
+}

--- a/src/common/components/fileUpload/FileUpload.test.tsx
+++ b/src/common/components/fileUpload/FileUpload.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { rest } from 'msw';
+import { act, fireEvent, render, screen, waitFor } from '../../../testUtils/render';
+import api from '../../../domain/api/api';
+import FileUpload from './FileUpload';
+import { server } from '../../../domain/mocks/test-server';
+
+async function uploadAttachment({ id, file }: { id: number; file: File }) {
+  const { data } = await api.post(`/hakemukset/${id}/liitteet`, {
+    liite: file,
+  });
+  return data;
+}
+
+function uploadFunction(file: File) {
+  return uploadAttachment({
+    id: 1,
+    file,
+  });
+}
+
+test('Should upload files successfully and loading indicator is displayed', async () => {
+  server.use(
+    rest.post('/api/hakemukset/:id/liitteet', async (req, res, ctx) => {
+      return res(ctx.delay(), ctx.status(200));
+    }),
+  );
+
+  const inputLabel = 'Choose a file';
+  const { user } = render(
+    <FileUpload
+      id="test-file-upload"
+      label={inputLabel}
+      accept=".png,.jpg"
+      multiple
+      uploadFunction={uploadFunction}
+    />,
+  );
+  const fileUpload = screen.getByLabelText(inputLabel);
+  user.upload(fileUpload, [
+    new File(['test-a'], 'test-file-a.png', { type: 'image/png' }),
+    new File(['test-b'], 'test-file-b.jpg', { type: 'image/jpg' }),
+  ]);
+
+  await waitFor(() => screen.findByText('Tallennetaan tiedostoja'));
+  await act(async () => {
+    waitFor(() => expect(screen.queryByText('Tallennetaan tiedostoja')).not.toBeInTheDocument());
+  });
+  await waitFor(() => {
+    expect(screen.queryByText('2/2 tiedosto(a) tallennettu')).toBeInTheDocument();
+  });
+});
+
+test('Should show amount of successful files uploaded correctly when file fails in validation', async () => {
+  const inputLabel = 'Choose a file';
+  const { user } = render(
+    <FileUpload
+      id="test-file-upload"
+      label={inputLabel}
+      accept=".png"
+      multiple
+      uploadFunction={uploadFunction}
+    />,
+    undefined,
+    undefined,
+    { applyAccept: false },
+  );
+  const fileUpload = screen.getByLabelText(inputLabel);
+  user.upload(fileUpload, [
+    new File(['test-a'], 'test-file-a.png', { type: 'image/png' }),
+    new File(['test-b'], 'test-file-b.pdf', { type: 'application/pdf' }),
+  ]);
+
+  await waitFor(() => {
+    expect(screen.queryByText('1/2 tiedosto(a) tallennettu')).toBeInTheDocument();
+  });
+});
+
+test('Should show amount of successful files uploaded correctly when request fails', async () => {
+  server.use(
+    rest.post('/api/hakemukset/:id/liitteet', async (req, res, ctx) => {
+      return res(ctx.status(400), ctx.json({ errorMessage: 'Failed for testing purposes' }));
+    }),
+  );
+
+  const inputLabel = 'Choose a file';
+  const { user } = render(
+    <FileUpload
+      id="test-file-upload"
+      label={inputLabel}
+      accept=".png,.jpg"
+      multiple
+      uploadFunction={uploadFunction}
+    />,
+  );
+  const fileUpload = screen.getByLabelText(inputLabel);
+  user.upload(fileUpload, [new File(['test-a'], 'test-file-a.png', { type: 'image/png' })]);
+
+  await waitFor(() => {
+    expect(screen.queryByText('0/1 tiedosto(a) tallennettu')).toBeInTheDocument();
+  });
+});
+
+test('Should upload files when user drops them into drag-and-drop area', async () => {
+  const inputLabel = 'Choose files';
+  const file = new File(['test-file'], 'test-file-a', { type: 'image/png' });
+  const file2 = new File(['test-file'], 'test-file-b', { type: 'image/png' });
+  const file3 = new File(['test-file'], 'test-file-c', { type: 'image/png' });
+  render(
+    <FileUpload
+      id="test-file-input"
+      label={inputLabel}
+      multiple
+      dragAndDrop
+      uploadFunction={uploadFunction}
+    />,
+  );
+  fireEvent.drop(screen.getByText('Raahaa tiedostot tänne'), {
+    dataTransfer: {
+      files: [file, file2, file3],
+    },
+  });
+
+  await waitFor(() => {
+    expect(screen.queryByText('3/3 tiedosto(a) tallennettu')).toBeInTheDocument();
+  });
+});

--- a/src/common/components/fileUpload/FileUpload.tsx
+++ b/src/common/components/fileUpload/FileUpload.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef, useState } from 'react';
+import { QueryKey, useMutation, useQueryClient } from 'react-query';
+import { FileInput, IconCheckCircleFill, LoadingSpinner } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { differenceBy } from 'lodash';
+import { AxiosError } from 'axios';
+import useLocale from '../../hooks/useLocale';
+import { AttachmentMetadata } from '../../types/attachment';
+import { Flex } from '@chakra-ui/react';
+import Text from '../text/Text';
+import styles from './FileUpload.module.scss';
+import { removeDuplicateAttachments } from './utils';
+
+function useDroppedFiles() {
+  const ref = useRef<HTMLDivElement>(null);
+  const droppedFiles = useRef<File[]>([]);
+
+  useEffect(() => {
+    function dropHandler(ev: DragEvent) {
+      if (ev.dataTransfer) {
+        droppedFiles.current = Array.from(ev.dataTransfer.files);
+      }
+    }
+
+    if (ref.current) {
+      ref.current.ondrop = dropHandler;
+    }
+  }, []);
+
+  return { ref, droppedFiles };
+}
+
+function SuccessNotification({
+  successfulCount,
+  totalCount,
+}: {
+  successfulCount: number;
+  totalCount: number;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Flex color="var(--color-success)">
+      <IconCheckCircleFill style={{ marginRight: 'var(--spacing-2-xs)' }} />
+      <p>
+        {t('common:components:fileUpload:successNotification', {
+          successful: successfulCount,
+          total: totalCount,
+        })}
+      </p>
+    </Flex>
+  );
+}
+
+// TODO: Kutsujen perumisen voisi tehdä omassa
+// subtaskissaan, se on vielä mysteeri miten tehdään
+
+type Props<T extends AttachmentMetadata> = {
+  fileInputId: string;
+  accept: string | undefined;
+  maxSize: number | undefined;
+  dragAndDrop: boolean | undefined;
+  multiple: boolean | undefined;
+  queryKey: QueryKey;
+  existingAttachments?: T[];
+  uploadFunction: (file: File) => Promise<T>;
+  onUpload?: (isUploading: boolean) => void;
+};
+
+export default function FileUpload<T extends AttachmentMetadata>({
+  fileInputId,
+  accept,
+  maxSize,
+  dragAndDrop,
+  multiple,
+  queryKey,
+  existingAttachments = [],
+  uploadFunction,
+  onUpload,
+}: Props<T>) {
+  const { t } = useTranslation();
+  const locale = useLocale();
+  const queryClient = useQueryClient();
+  const [newFiles, setNewFiles] = useState<File[]>([]);
+  const [invalidFiles, setInvalidFiles] = useState<File[]>([]);
+  const uploadMutation = useMutation(uploadFunction, {
+    onError(error: AxiosError, file) {
+      // TODO: Invalid files pitäisi ehkä olla array of objects,
+      // joissa olisi virheen syy ja tiedosto,
+      // tai niin, että se on array of strings, joissa jokainen item on se
+      // error teksti
+      setInvalidFiles((files) => [...files, file]);
+    },
+  });
+  const [filesUploading, setFilesUploading] = useState(false);
+  const { ref: dropZoneRef, droppedFiles } = useDroppedFiles();
+
+  async function uploadFiles(files: File[]) {
+    setFilesUploading(true);
+    if (onUpload) {
+      onUpload(true);
+    }
+
+    const mutations = files.map((file) => {
+      return uploadMutation.mutateAsync(file);
+    });
+
+    await Promise.allSettled(mutations);
+
+    setFilesUploading(false);
+    queryClient.invalidateQueries(queryKey);
+    if (onUpload) {
+      onUpload(false);
+    }
+  }
+
+  function handleFilesChange(files: File[]) {
+    // Filter out attachments that have same names as those that have already been sent
+    const filesToSend = removeDuplicateAttachments(files, existingAttachments);
+
+    // Determine which files haven't passed HDS FileInput validation by comparing
+    // files in input element or files dropped into drop zone to files received as
+    // argument to this onChange function
+    const inputElem = document.getElementById(fileInputId) as HTMLInputElement;
+    const inputElemFiles = inputElem.files ? Array.from(inputElem.files) : [];
+    const allFiles = inputElemFiles.length > 0 ? inputElemFiles : droppedFiles.current;
+    const invalidFilesArr = differenceBy(allFiles, filesToSend, 'name');
+
+    setNewFiles(allFiles);
+    setInvalidFiles(invalidFilesArr);
+    uploadFiles(filesToSend);
+  }
+
+  return (
+    <div>
+      <Flex alignItems="center" className={styles.uploadContainer} ref={dropZoneRef}>
+        {filesUploading ? (
+          <Flex className={styles.loadingContainer}>
+            <LoadingSpinner small className={styles.loadingSpinner} />
+            <Text tag="p" className={styles.loadingText}>
+              {t('common:components:fileUpload:loadingText')}
+            </Text>
+          </Flex>
+        ) : (
+          <FileInput
+            id={fileInputId}
+            accept={accept}
+            label={t('form:labels:dragAttachments')}
+            dragAndDropLabel={t('form:labels:dragAttachments')}
+            language={locale}
+            maxSize={maxSize}
+            dragAndDrop={dragAndDrop}
+            multiple={multiple}
+            onChange={handleFilesChange}
+            defaultValue={[]}
+          />
+        )}
+      </Flex>
+
+      {!filesUploading && newFiles.length > 0 && (
+        <SuccessNotification
+          successfulCount={newFiles.length - invalidFiles.length}
+          totalCount={newFiles.length}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/common/components/fileUpload/FileUpload.tsx
+++ b/src/common/components/fileUpload/FileUpload.tsx
@@ -33,10 +33,10 @@ function useDragAndDropFiles() {
 function SuccessNotification({
   successfulCount,
   totalCount,
-}: {
+}: Readonly<{
   successfulCount: number;
   totalCount: number;
-}) {
+}>) {
   const { t } = useTranslation();
 
   return (
@@ -81,7 +81,7 @@ export default function FileUpload<T extends AttachmentMetadata>({
   existingAttachments = [],
   uploadFunction,
   onUpload,
-}: Props<T>) {
+}: Readonly<Props<T>>) {
   const { t } = useTranslation();
   const locale = useLocale();
   const [newFiles, setNewFiles] = useState<File[]>([]);

--- a/src/common/components/fileUpload/utils.ts
+++ b/src/common/components/fileUpload/utils.ts
@@ -1,0 +1,11 @@
+import { AttachmentMetadata } from '../../types/attachment';
+
+// Filter out duplicate files based on file name
+export function removeDuplicateAttachments<T extends AttachmentMetadata>(
+  files: File[],
+  attachments: T[] | undefined,
+): File[] {
+  return files.filter(
+    (file) => attachments?.every((attachment) => attachment.fileName !== file.name),
+  );
+}

--- a/src/common/components/fileUpload/utils.ts
+++ b/src/common/components/fileUpload/utils.ts
@@ -2,14 +2,14 @@ import { AttachmentMetadata } from '../../types/attachment';
 
 // Filter out duplicate files based on file name
 export function removeDuplicateAttachments<T extends AttachmentMetadata>(
-  files: File[],
-  attachments: T[] | undefined,
+  addedFiles: File[],
+  existingAttachments: T[] | undefined,
 ): [File[], File[]] {
-  const duplicateFiles = files.filter(
-    (file) => attachments?.some((attachment) => attachment.fileName === file.name),
+  const duplicateFiles = addedFiles.filter(
+    (file) => existingAttachments?.some((attachment) => attachment.fileName === file.name),
   );
-  const newFiles = files.filter(
-    (file) => attachments?.every((attachment) => attachment.fileName !== file.name),
+  const newFiles = addedFiles.filter(
+    (file) => existingAttachments?.every((attachment) => attachment.fileName !== file.name),
   );
   return [newFiles, duplicateFiles];
 }

--- a/src/common/components/fileUpload/utils.ts
+++ b/src/common/components/fileUpload/utils.ts
@@ -4,8 +4,12 @@ import { AttachmentMetadata } from '../../types/attachment';
 export function removeDuplicateAttachments<T extends AttachmentMetadata>(
   files: File[],
   attachments: T[] | undefined,
-): File[] {
-  return files.filter(
+): [File[], File[]] {
+  const duplicateFiles = files.filter(
+    (file) => attachments?.some((attachment) => attachment.fileName === file.name),
+  );
+  const newFiles = files.filter(
     (file) => attachments?.every((attachment) => attachment.fileName !== file.name),
   );
+  return [newFiles, duplicateFiles];
 }

--- a/src/common/types/attachment.ts
+++ b/src/common/types/attachment.ts
@@ -1,0 +1,6 @@
+export type AttachmentMetadata = {
+  id: string;
+  fileName: string;
+  createdByUserId: string;
+  createdAt: string;
+};

--- a/src/domain/application/attachments.test.ts
+++ b/src/domain/application/attachments.test.ts
@@ -1,4 +1,4 @@
-import { removeDuplicateAttachments } from './attachments';
+import { removeDuplicateAttachments } from '../../common/components/fileUpload/utils';
 import { ApplicationAttachmentMetadata } from './types/application';
 
 const attachments: ApplicationAttachmentMetadata[] = [

--- a/src/domain/application/attachments.test.ts
+++ b/src/domain/application/attachments.test.ts
@@ -47,8 +47,13 @@ test('Should filter out existing attachments', () => {
   ];
 
   expect(removeDuplicateAttachments(files, attachments)).toMatchObject([
-    { name: 'Haitaton_liite_uusi.pdf' },
-    { name: 'Haitaton_liite_uusi_2.jpg' },
+    [{ name: 'Haitaton_liite_uusi.pdf' }, { name: 'Haitaton_liite_uusi_2.jpg' }],
+    [
+      { name: 'Haitaton_liite.png' },
+      { name: 'Haitaton_liite_2.txt' },
+      { name: 'Haitaton_liite_3.jpg' },
+      { name: 'Haitaton_liite_4.pdf' },
+    ],
   ]);
 });
 
@@ -60,14 +65,20 @@ test('Should not filter out anything from only new files', () => {
   ];
 
   expect(removeDuplicateAttachments(files, attachments)).toMatchObject([
-    { name: 'Haitaton_liite_uusi.pdf' },
-    { name: 'Haitaton_liite_uusi_2.jpg' },
-    { name: 'Haitaton_liite_uusi_3.jpg' },
+    [
+      { name: 'Haitaton_liite_uusi.pdf' },
+      { name: 'Haitaton_liite_uusi_2.jpg' },
+      { name: 'Haitaton_liite_uusi_3.jpg' },
+    ],
+    [],
   ]);
 
   expect(removeDuplicateAttachments(files, [])).toMatchObject([
-    { name: 'Haitaton_liite_uusi.pdf' },
-    { name: 'Haitaton_liite_uusi_2.jpg' },
-    { name: 'Haitaton_liite_uusi_3.jpg' },
+    [
+      { name: 'Haitaton_liite_uusi.pdf' },
+      { name: 'Haitaton_liite_uusi_2.jpg' },
+      { name: 'Haitaton_liite_uusi_3.jpg' },
+    ],
+    [],
   ]);
 });

--- a/src/domain/application/attachments.ts
+++ b/src/domain/application/attachments.ts
@@ -4,7 +4,7 @@ import { ApplicationAttachmentMetadata, AttachmentType } from './types/applicati
 // Get attachments metadata related to an application
 export async function getAttachments(applicationId: number | null | undefined) {
   const { data } = await api.get<ApplicationAttachmentMetadata[]>(
-    `/hakemukset/${applicationId}/liitteet`
+    `/hakemukset/${applicationId}/liitteet`,
   );
   return data;
 }
@@ -26,7 +26,7 @@ export async function uploadAttachment({
       headers: {
         'Content-Type': 'multipart/form-data',
       },
-    }
+    },
   );
   return data;
 }
@@ -35,7 +35,7 @@ export async function uploadAttachment({
 export async function getAttachmentFile(applicationId: number, attachmentId: string) {
   const { data } = await api.get<Blob>(
     `/hakemukset/${applicationId}/liitteet/${attachmentId}/content`,
-    { responseType: 'blob' }
+    { responseType: 'blob' },
   );
   return URL.createObjectURL(data);
 }
@@ -49,14 +49,4 @@ export async function deleteAttachment({
   attachmentId: string | undefined;
 }) {
   await api.delete(`/hakemukset/${applicationId}/liitteet/${attachmentId}`);
-}
-
-// Filter out duplicate files based on file name
-export function removeDuplicateAttachments(
-  files: File[],
-  attachments: ApplicationAttachmentMetadata[] | undefined
-) {
-  return files.filter((file) =>
-    attachments?.every((attachment) => attachment.fileName !== file.name)
-  );
 }

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -1,3 +1,4 @@
+import { AttachmentMetadata } from './../../../common/types/attachment';
 import { Polygon, Position } from 'geojson';
 import { Coordinate } from 'ol/coordinate';
 import { CRS } from '../../../common/types/hanke';
@@ -100,14 +101,10 @@ export type ApplicationArea = {
 
 export type AttachmentType = 'MUU' | 'LIIKENNEJARJESTELY' | 'VALTAKIRJA';
 
-export type ApplicationAttachmentMetadata = {
-  id: string;
-  fileName: string;
-  createdByUserId: string;
-  createdAt: string;
+export interface ApplicationAttachmentMetadata extends AttachmentMetadata {
   applicationId: number;
   attachmentType: AttachmentType;
-};
+}
 
 export type JohtoselvitysData = {
   applicationType: ApplicationType;

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -290,7 +290,7 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
     }
 
     // Filter out attachments that have same names as those that have already been sent
-    const filesToSend = removeDuplicateAttachments(newAttachments, existingAttachments);
+    const [filesToSend] = removeDuplicateAttachments(newAttachments, existingAttachments);
 
     const mutations = filesToSend.map((file) =>
       attachmentUploadMutation.mutateAsync({

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -34,9 +34,10 @@ import useHanke from '../hanke/hooks/useHanke';
 import { AlluStatus, Application } from '../application/types/application';
 import Attachments from './Attachments';
 import ConfirmationDialog from '../../common/components/HDSConfirmationDialog/ConfirmationDialog';
-import { removeDuplicateAttachments, uploadAttachment } from '../application/attachments';
+import { uploadAttachment } from '../application/attachments';
 import useAttachments from '../application/hooks/useAttachments';
 import { APPLICATION_ID_STORAGE_KEY } from '../application/constants';
+import { removeDuplicateAttachments } from '../../common/components/fileUpload/utils';
 
 type Props = {
   hankeData?: HankeData;

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -233,4 +233,8 @@ export const handlers = [
   rest.post(`${apiUrl}/kayttajat/:kayttajaId/kutsu`, async (req, res, ctx) => {
     return res(ctx.delay(), ctx.status(204));
   }),
+
+  rest.post(`${apiUrl}/hakemukset/:id/liitteet`, async (req, res, ctx) => {
+    return res(ctx.delay(), ctx.status(200));
+  }),
 ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -51,7 +51,7 @@
       },
       "fileUpload": {
         "loadingText": "Tallennetaan tiedostoja",
-        "successNotification": "{{successful}}/{{total}} tiedostoa tallennettu"
+        "successNotification": "{{successful}}/{{total}} tiedosto(a) tallennettu"
       }
     },
     "error": "Tapahtui virhe. Yritä uudestaan.",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -48,6 +48,10 @@
       "errorLoadingInfo": {
         "textTop": "Virhe tietojen lataamisessa.",
         "textBottom": "Yritä hetken päästä uudelleen."
+      },
+      "fileUpload": {
+        "loadingText": "Tallennetaan tiedostoja",
+        "successNotification": "{{successful}}/{{total}} tiedostoa tallennettu"
       }
     },
     "error": "Tapahtui virhe. Yritä uudestaan.",

--- a/src/testUtils/render.tsx
+++ b/src/testUtils/render.tsx
@@ -42,11 +42,17 @@ const AllTheProviders = ({ children }: Props) => {
   );
 };
 
-const customRender = (ui: React.ReactElement, options: RenderOptions = {}, route = '/') => {
+const customRender = (
+  ui: React.ReactElement,
+  options: RenderOptions = {},
+  route = '/',
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userEventOptions?: any,
+) => {
   window.history.pushState({}, 'Test page', route);
   window.scrollTo = function () {};
   return {
-    user: userEvent.setup(),
+    user: userEvent.setup(userEventOptions),
     ...render(ui, {
       wrapper: AllTheProviders as React.ComponentType<React.PropsWithChildren<unknown>>,
       ...options,


### PR DESCRIPTION
# Description

File upload component uses HDS FileInput internally to handle user adding files from their machine and immediately sends added files to backend and shows a loading spinner and loading text while upload is in process.

Listing of files and deleting them as well as displaying error messages are done in separate tasks.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2065

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Only way to manually test this is to replace FileInput component locally in src/domain/johtoselvitys/Attachments.tsx with this new component, for example:
```
function handleFileUpload(uploading: boolean) {
  if (!uploading) {
    queryClient.invalidateQueries('attachments');
  }
}

<FileUpload
  id="cable-report-file-upload"
  accept=".pdf,.jpg,.jpeg,.png,.dgn,.dwg,.docx,.txt,.gt"
  maxSize={104857600}
  dragAndDrop
  multiple
  existingAttachments={existingAttachments}
  uploadFunction={(file) =>
    uploadAttachment({
      applicationId: getValues('id')!,
      attachmentType: 'MUU',
      file,
    })
  }
  onUpload={handleFileUpload}
/>
```

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
