### PR TITLE
HAI-2083 Fix application edit and delete buttons not displayed (#400)

### DIFF
--- a/src/domain/hanke/hankeUsers/UserRightsCheck.test.tsx
+++ b/src/domain/hanke/hankeUsers/UserRightsCheck.test.tsx
@@ -41,3 +41,21 @@ test('Should not render children if user does not have required right', async ()
     expect(screen.queryByText('Children')).not.toBeInTheDocument();
   });
 });
+
+test('Should render children when access right feature is not enabled', async () => {
+  const OLD_ENV = window._env_;
+  window._env_.REACT_APP_FEATURE_ACCESS_RIGHTS = 0;
+
+  render(
+    <UserRightsCheck requiredRight="EDIT" hankeTunnus="HAI22-2">
+      <p>Children</p>
+    </UserRightsCheck>,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByText('Children')).toBeInTheDocument();
+  });
+
+  jest.resetModules();
+  window._env_ = OLD_ENV;
+});

--- a/src/domain/hanke/hankeUsers/UserRightsCheck.tsx
+++ b/src/domain/hanke/hankeUsers/UserRightsCheck.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import useUserRightsForHanke from './hooks/useUserRightsForHanke';
 import { Rights } from './hankeUser';
+import { useFeatureFlags } from '../../../common/components/featureFlags/FeatureFlagsContext';
 
 /**
  * Check that user has required rights.
@@ -18,6 +19,11 @@ function UserRightsCheck({
   children: React.ReactElement | null;
 }) {
   const { data: signedInUser } = useUserRightsForHanke(hankeTunnus);
+  const features = useFeatureFlags();
+
+  if (!features.accessRights) {
+    return children;
+  }
 
   if (signedInUser?.kayttooikeudet.includes(requiredRight)) {
     return children;


### PR DESCRIPTION
Fixed a problem where application edit and delete buttons would not be displayed in application view when access rights feature was disabled. Made it so that when the feature is disabled, buttons are rendered without checking for user permissions.