### PR TITLE
HAI-2041 Fetch current users permissions in a single request

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -38,7 +38,7 @@ import { ApplicationCancel } from '../components/ApplicationCancel';
 import AttachmentSummary from '../components/AttachmentSummary';
 import useAttachments from '../hooks/useAttachments';
 import FeatureFlags from '../../../common/components/featureFlags/FeatureFlags';
-import UserRightsCheck from '../../hanke/hankeUsers/UserRightsCheck';
+import { CheckRightsByHanke } from '../../hanke/hankeUsers/UserRightsCheck';
 
 type Props = {
   application: Application;
@@ -120,7 +120,7 @@ function ApplicationView({ application, hanke, onEditApplication }: Props) {
 
         <InformationViewHeaderButtons>
           {isPending ? (
-            <UserRightsCheck requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>
+            <CheckRightsByHanke requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>
               <Button
                 theme="coat"
                 iconLeft={<IconPen aria-hidden="true" />}
@@ -128,17 +128,17 @@ function ApplicationView({ application, hanke, onEditApplication }: Props) {
               >
                 {t('hakemus:buttons:editApplication')}
               </Button>
-            </UserRightsCheck>
+            </CheckRightsByHanke>
           ) : null}
           {hanke ? (
-            <UserRightsCheck requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>
+            <CheckRightsByHanke requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>
               <ApplicationCancel
                 applicationId={id}
                 alluStatus={alluStatus}
                 hankeTunnus={hanke?.hankeTunnus}
                 buttonIcon={<IconTrash aria-hidden />}
               />
-            </UserRightsCheck>
+            </CheckRightsByHanke>
           ) : null}
         </InformationViewHeaderButtons>
       </InformationViewHeader>

--- a/src/domain/hanke/accessRights/AccessRightsViewContainer.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsViewContainer.tsx
@@ -7,7 +7,7 @@ import ErrorLoadingText from '../../../common/components/errorLoadingText/ErrorL
 import { useHankeUsers } from '../hankeUsers/hooks/useHankeUsers';
 import useHanke from '../hooks/useHanke';
 import AccessRightsView from './AccessRightsView';
-import useUserRightsForHanke from '../hankeUsers/hooks/useUserRightsForHanke';
+import { usePermissionsForHanke } from '../hankeUsers/hooks/useUserRightsForHanke';
 
 type Props = {
   hankeTunnus: string;
@@ -17,7 +17,7 @@ function AccessRightsViewContainer({ hankeTunnus }: Props) {
   const { t } = useTranslation();
   const { data: hankeUsers, isLoading, isError, error } = useHankeUsers(hankeTunnus);
   const { data: hankeData } = useHanke(hankeTunnus);
-  const { data: signedInUser } = useUserRightsForHanke(hankeTunnus);
+  const { data: signedInUser } = usePermissionsForHanke(hankeTunnus);
 
   if (isLoading) {
     return (

--- a/src/domain/hanke/hankeUsers/UserRightsCheck.test.tsx
+++ b/src/domain/hanke/hankeUsers/UserRightsCheck.test.tsx
@@ -2,60 +2,108 @@ import React from 'react';
 import { rest } from 'msw';
 import { render, screen, waitFor } from '../../../testUtils/render';
 import { server } from '../../mocks/test-server';
-import { SignedInUser } from './hankeUser';
-import UserRightsCheck from './UserRightsCheck';
+import { AccessRightLevel, SignedInUser } from './hankeUser';
+import { CheckRightsByHanke, CheckRightsByUser } from './UserRightsCheck';
+import { userData } from '../../mocks/signedInUser';
 
-test('Should render children if user has required right', async () => {
-  render(
-    <UserRightsCheck requiredRight="EDIT" hankeTunnus="HAI22-2">
-      <p>Children</p>
-    </UserRightsCheck>,
-  );
+describe('CheckRightsByHanke', () => {
+  test('Should render children if user has required right', async () => {
+    render(
+      <CheckRightsByHanke requiredRight="EDIT" hankeTunnus="HAI22-2">
+        <p>Children</p>
+      </CheckRightsByHanke>,
+    );
 
-  await waitFor(() => {
-    expect(screen.getByText('Children')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Children')).toBeInTheDocument();
+    });
+  });
+
+  test('Should not render children if user does not have required right', async () => {
+    server.use(
+      rest.get('/api/hankkeet/:hankeTunnus/whoami', async (_, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json<SignedInUser>({
+            hankeKayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            kayttooikeustaso: 'KATSELUOIKEUS',
+            kayttooikeudet: ['VIEW'],
+          }),
+        );
+      }),
+    );
+
+    render(
+      <CheckRightsByHanke requiredRight="EDIT" hankeTunnus="HAI22-2">
+        <p>Children</p>
+      </CheckRightsByHanke>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Children')).not.toBeInTheDocument();
+    });
+  });
+
+  test('Should render children when access right feature is not enabled', async () => {
+    const OLD_ENV = { ...window._env_ };
+    window._env_ = { ...OLD_ENV, REACT_APP_FEATURE_ACCESS_RIGHTS: 0 };
+
+    render(
+      <CheckRightsByHanke requiredRight="EDIT" hankeTunnus="HAI22-2">
+        <p>Children</p>
+      </CheckRightsByHanke>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Children')).toBeInTheDocument();
+    });
+    jest.resetModules();
+    window._env_ = OLD_ENV;
   });
 });
 
-test('Should not render children if user does not have required right', async () => {
-  server.use(
-    rest.get('/api/hankkeet/:hankeTunnus/whoami', async (req, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json<SignedInUser>({
-          hankeKayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-          kayttooikeustaso: 'KATSELUOIKEUS',
-          kayttooikeudet: ['VIEW'],
-        }),
-      );
-    }),
-  );
+describe('CheckRightsByUser', () => {
+  const ALL_RIGHTS_USER = userData(AccessRightLevel.KAIKKI_OIKEUDET);
+  const VIEW_RIGHT_USER = userData(AccessRightLevel.KATSELUOIKEUS);
 
-  render(
-    <UserRightsCheck requiredRight="EDIT" hankeTunnus="HAI22-2">
-      <p>Children</p>
-    </UserRightsCheck>,
-  );
+  test('Should render children on required right', async () => {
+    render(
+      <CheckRightsByUser requiredRight="EDIT" signedInUser={ALL_RIGHTS_USER}>
+        <p>Children</p>
+      </CheckRightsByUser>,
+    );
 
-  await waitFor(() => {
-    expect(screen.queryByText('Children')).not.toBeInTheDocument();
-  });
-});
-
-test('Should render children when access right feature is not enabled', async () => {
-  const OLD_ENV = window._env_;
-  window._env_.REACT_APP_FEATURE_ACCESS_RIGHTS = 0;
-
-  render(
-    <UserRightsCheck requiredRight="EDIT" hankeTunnus="HAI22-2">
-      <p>Children</p>
-    </UserRightsCheck>,
-  );
-
-  await waitFor(() => {
-    expect(screen.getByText('Children')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Children')).toBeInTheDocument();
+    });
   });
 
-  jest.resetModules();
-  window._env_ = OLD_ENV;
+  test('Should not render children if not enough rights', async () => {
+    render(
+      <CheckRightsByUser requiredRight="EDIT" signedInUser={VIEW_RIGHT_USER}>
+        <p>Children</p>
+      </CheckRightsByUser>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Children')).not.toBeInTheDocument();
+    });
+  });
+
+  test('Should render children if feature not enabled regardless of permission', async () => {
+    const OLD_ENV = { ...window._env_ };
+    window._env_ = { ...OLD_ENV, REACT_APP_FEATURE_ACCESS_RIGHTS: 0 };
+
+    render(
+      <CheckRightsByUser requiredRight="EDIT" signedInUser={VIEW_RIGHT_USER}>
+        <p>Children</p>
+      </CheckRightsByUser>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Children')).toBeInTheDocument();
+    });
+    jest.resetModules();
+    window._env_ = OLD_ENV;
+  });
 });

--- a/src/domain/hanke/hankeUsers/UserRightsCheck.tsx
+++ b/src/domain/hanke/hankeUsers/UserRightsCheck.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import useUserRightsForHanke from './hooks/useUserRightsForHanke';
-import { Rights } from './hankeUser';
+import { Rights, SignedInUser } from './hankeUser';
 import { useFeatureFlags } from '../../../common/components/featureFlags/FeatureFlagsContext';
+import { usePermissionsForHanke } from './hooks/useUserRightsForHanke';
 
 /**
  * Check that user has required rights.
  * If they have, render children.
  */
-function UserRightsCheck({
+export function CheckRightsByHanke({
   requiredRight,
   hankeTunnus,
   children,
@@ -18,7 +18,7 @@ function UserRightsCheck({
   hankeTunnus?: string;
   children: React.ReactElement | null;
 }) {
-  const { data: signedInUser } = useUserRightsForHanke(hankeTunnus);
+  const { data: signedInUser } = usePermissionsForHanke(hankeTunnus);
   const features = useFeatureFlags();
 
   if (!features.accessRights) {
@@ -32,4 +32,20 @@ function UserRightsCheck({
   return null;
 }
 
-export default UserRightsCheck;
+export function CheckRightsByUser({
+  requiredRight,
+  signedInUser,
+  children,
+}: {
+  requiredRight: keyof typeof Rights;
+  signedInUser: SignedInUser;
+  children: React.ReactElement | null;
+}) {
+  const features = useFeatureFlags();
+
+  if (!features.accessRights) {
+    return children;
+  }
+
+  return signedInUser?.kayttooikeudet?.includes(requiredRight) ? children : null;
+}

--- a/src/domain/hanke/hankeUsers/hankeUser.ts
+++ b/src/domain/hanke/hankeUsers/hankeUser.ts
@@ -34,6 +34,10 @@ export type SignedInUser = {
   kayttooikeudet: UserRights;
 };
 
+export type SignedInUserByHanke = {
+  [hankeTunnus: string]: SignedInUser;
+};
+
 export type IdentificationResponse = {
   kayttajaId: string;
   hankeTunnus: string;

--- a/src/domain/hanke/hankeUsers/hankeUsersApi.ts
+++ b/src/domain/hanke/hankeUsers/hankeUsersApi.ts
@@ -1,5 +1,5 @@
 import api from '../../api/api';
-import { HankeUser, IdentificationResponse, SignedInUser } from './hankeUser';
+import { HankeUser, IdentificationResponse, SignedInUser, SignedInUserByHanke } from './hankeUser';
 
 export async function getHankeUsers(hankeTunnus: string) {
   const { data } = await api.get<{ kayttajat: HankeUser[] }>(`hankkeet/${hankeTunnus}/kayttajat`);
@@ -20,6 +20,11 @@ export async function updateHankeUsers({
 // Get user id and rights of the signed in user for a hanke
 export async function getSignedInUserForHanke(hankeTunnus?: string): Promise<SignedInUser> {
   const { data } = await api.get<SignedInUser>(`hankkeet/${hankeTunnus}/whoami`);
+  return data;
+}
+
+export async function getSignedInUserByHanke(): Promise<SignedInUserByHanke> {
+  const { data } = await api.get<SignedInUserByHanke>('my-permissions');
   return data;
 }
 

--- a/src/domain/hanke/hankeUsers/hooks/useUserRightsForHanke.ts
+++ b/src/domain/hanke/hankeUsers/hooks/useUserRightsForHanke.ts
@@ -1,9 +1,9 @@
 import { useQuery } from 'react-query';
-import { SignedInUser } from '../hankeUser';
-import { getSignedInUserForHanke } from '../hankeUsersApi';
+import { SignedInUser, SignedInUserByHanke } from '../hankeUser';
+import { getSignedInUserForHanke, getSignedInUserByHanke } from '../hankeUsersApi';
 import { useFeatureFlags } from '../../../../common/components/featureFlags/FeatureFlagsContext';
 
-export default function useSignedInUserRightsForHanke(hankeTunnus?: string) {
+export function usePermissionsForHanke(hankeTunnus?: string) {
   const features = useFeatureFlags();
 
   return useQuery<SignedInUser>(
@@ -13,4 +13,12 @@ export default function useSignedInUserRightsForHanke(hankeTunnus?: string) {
       enabled: Boolean(hankeTunnus) && features.accessRights,
     },
   );
+}
+
+export function usePermissionsByHanke() {
+  const features = useFeatureFlags();
+
+  return useQuery<SignedInUserByHanke>(['signedInUserByHanke'], () => getSignedInUserByHanke(), {
+    enabled: features.accessRights,
+  });
 }

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -52,7 +52,7 @@ import {
 import FeatureFlags from '../../../common/components/featureFlags/FeatureFlags';
 import { useFeatureFlags } from '../../../common/components/featureFlags/FeatureFlagsContext';
 import { SignedInUser } from '../hankeUsers/hankeUser';
-import UserRightsCheck from '../hankeUsers/UserRightsCheck';
+import { CheckRightsByHanke } from '../hankeUsers/UserRightsCheck';
 
 type AreaProps = {
   area: HankeAlue;
@@ -217,7 +217,7 @@ const HankeView: React.FC<Props> = ({
 
         <InformationViewHeaderButtons>
           <FeatureFlags flags={['hanke']}>
-            <UserRightsCheck requiredRight="EDIT" hankeTunnus={hankeData.hankeTunnus}>
+            <CheckRightsByHanke requiredRight="EDIT" hankeTunnus={hankeData.hankeTunnus}>
               <Button
                 onClick={onEditHanke}
                 variant="primary"
@@ -226,8 +226,11 @@ const HankeView: React.FC<Props> = ({
               >
                 {t('hankeList:buttons:edit')}
               </Button>
-            </UserRightsCheck>
-            <UserRightsCheck requiredRight="EDIT_APPLICATIONS" hankeTunnus={hankeData.hankeTunnus}>
+            </CheckRightsByHanke>
+            <CheckRightsByHanke
+              requiredRight="EDIT_APPLICATIONS"
+              hankeTunnus={hankeData.hankeTunnus}
+            >
               {isHankePublic ? (
                 <Button
                   variant="primary"
@@ -238,7 +241,7 @@ const HankeView: React.FC<Props> = ({
                   {t('hankeList:buttons:addApplication')}
                 </Button>
               ) : null}
-            </UserRightsCheck>
+            </CheckRightsByHanke>
           </FeatureFlags>
           <FeatureFlags flags={['hanke', 'accessRights']}>
             <Button
@@ -251,14 +254,14 @@ const HankeView: React.FC<Props> = ({
             </Button>
           </FeatureFlags>
           <FeatureFlags flags={['hanke']}>
-            <UserRightsCheck requiredRight="DELETE" hankeTunnus={hankeData.hankeTunnus}>
+            <CheckRightsByHanke requiredRight="DELETE" hankeTunnus={hankeData.hankeTunnus}>
               <Button variant="primary" iconLeft={<IconCross aria-hidden="true" />} theme="black">
                 {t('hankeList:buttons:endHanke')}
               </Button>
-            </UserRightsCheck>
+            </CheckRightsByHanke>
           </FeatureFlags>
           {!isLoading && isCancelPossible && (
-            <UserRightsCheck requiredRight="DELETE" hankeTunnus={hankeData.hankeTunnus}>
+            <CheckRightsByHanke requiredRight="DELETE" hankeTunnus={hankeData.hankeTunnus}>
               <Button
                 onClick={onCancelHanke}
                 variant="danger"
@@ -266,7 +269,7 @@ const HankeView: React.FC<Props> = ({
               >
                 {t('hankeForm:cancelButton')}
               </Button>
-            </UserRightsCheck>
+            </CheckRightsByHanke>
           )}
         </InformationViewHeaderButtons>
       </InformationViewHeader>

--- a/src/domain/hanke/hankeView/HankeViewContainer.tsx
+++ b/src/domain/hanke/hankeView/HankeViewContainer.tsx
@@ -5,7 +5,7 @@ import { ROUTES } from '../../../common/types/route';
 import HankeDelete from '../edit/components/HankeDelete';
 import useHanke from '../hooks/useHanke';
 import HankeView from './HankeView';
-import useUserRightsForHanke from '../hankeUsers/hooks/useUserRightsForHanke';
+import { usePermissionsForHanke } from '../hankeUsers/hooks/useUserRightsForHanke';
 
 type Props = {
   hankeTunnus?: string;
@@ -13,7 +13,7 @@ type Props = {
 
 const HankeViewContainer: React.FC<Props> = ({ hankeTunnus }) => {
   const { data: hankeData } = useHanke(hankeTunnus);
-  const { data: signedInUser } = useUserRightsForHanke(hankeTunnus);
+  const { data: signedInUser } = usePermissionsForHanke(hankeTunnus);
   const getEditHankePath = useLinkPath(ROUTES.EDIT_HANKE);
   const getEditRightsPath = useLinkPath(ROUTES.ACCESS_RIGHTS);
   const navigate = useNavigate();

--- a/src/domain/hanke/portfolio/HankePortfolio.test.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolio.test.tsx
@@ -6,6 +6,8 @@ import HankePortfolioComponent from './HankePortfolioComponent';
 import { render, screen, waitFor } from '../../../testUtils/render';
 import hankeList from '../../mocks/hankeList';
 import { changeFilterDate } from '../../../testUtils/helperFunctions';
+import { USER_VIEW, userDataByHanke } from '../../mocks/signedInUser';
+import { SignedInUserByHanke } from '../hankeUsers/hankeUser';
 
 const startDateLabel = 'Ajanjakson alku';
 const endDateLabel = 'Ajanjakson loppu';
@@ -16,7 +18,9 @@ jest.setTimeout(30000);
 
 describe.only('HankePortfolio', () => {
   test('Changing search text filters correct number of projects', async () => {
-    const { user } = render(<HankePortfolioComponent hankkeet={hankeList} />);
+    const { user } = render(
+      <HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />,
+    );
 
     await user.type(screen.getByLabelText('Haku'), 'Mannerheimintie autottomaksi');
     await waitFor(() => {
@@ -41,7 +45,9 @@ describe.only('HankePortfolio', () => {
   });
 
   test('Changing filter startDates filters correct number of projects', async () => {
-    const renderedComponent = render(<HankePortfolioComponent hankkeet={hankeList} />);
+    const renderedComponent = render(
+      <HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />,
+    );
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('2');
     changeFilterDate(startDateLabel, renderedComponent, '02.10.2022');
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('2');
@@ -56,7 +62,9 @@ describe.only('HankePortfolio', () => {
   });
 
   test('Changing filter endDates filters correct number of projects', async () => {
-    const renderedComponent = render(<HankePortfolioComponent hankkeet={hankeList} />);
+    const renderedComponent = render(
+      <HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />,
+    );
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('2');
     changeFilterDate(endDateLabel, renderedComponent, '01.10.2022');
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('0');
@@ -72,7 +80,9 @@ describe.only('HankePortfolio', () => {
   });
 
   test('Changing Hanke type filters correct number of projects', async () => {
-    const renderedComponent = render(<HankePortfolioComponent hankkeet={hankeList} />);
+    const renderedComponent = render(
+      <HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />,
+    );
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('2');
     await renderedComponent.user.click(
       renderedComponent.getByRole('button', { name: 'Työn tyyppi' }),
@@ -98,13 +108,19 @@ describe.only('HankePortfolio', () => {
   });
 
   test('Having no projects renders correct text', () => {
-    render(<HankePortfolioComponent hankkeet={[]} />);
+    render(<HankePortfolioComponent hankkeet={[]} signedInUserByHanke={{}} />);
 
     expect(screen.queryByText('Hankesalkussasi ei ole hankkeita')).toBeInTheDocument();
   });
 
   test('Should render edit hanke links for hankkeet that user has edit rights', async () => {
-    render(<HankePortfolioComponent hankkeet={hankeList} />);
+    const hankeTunnusList = hankeList.map((hanke) => hanke.hankeTunnus);
+    const signedUserData: SignedInUserByHanke = {
+      ...userDataByHanke(hankeTunnusList),
+      [hankeTunnusList[0]]: USER_VIEW,
+    };
+
+    render(<HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={signedUserData} />);
 
     await waitFor(() => {
       expect(screen.queryAllByTestId('hankeEditLink')).toHaveLength(1);
@@ -112,7 +128,7 @@ describe.only('HankePortfolio', () => {
   });
 
   test('Should show draft state notification for hankkeet that are in draft state', async () => {
-    render(<HankePortfolioComponent hankkeet={hankeList} />);
+    render(<HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />);
 
     expect(
       screen.getAllByText(

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -39,13 +39,18 @@ import { SKIP_TO_ELEMENT_ID } from '../../../common/constants/constants';
 import useHankeViewPath from '../hooks/useHankeViewPath';
 import { useNavigateToApplicationList } from '../hooks/useNavigateToApplicationList';
 import FeatureFlags from '../../../common/components/featureFlags/FeatureFlags';
-import UserRightsCheck from '../hankeUsers/UserRightsCheck';
+import { CheckRightsByUser } from '../hankeUsers/UserRightsCheck';
+import { SignedInUser, SignedInUserByHanke } from '../hankeUsers/hankeUser';
 
 type CustomAccordionProps = {
   hanke: HankeData;
+  signedInUser: SignedInUser;
 };
 
-const CustomAccordion: React.FC<React.PropsWithChildren<CustomAccordionProps>> = ({ hanke }) => {
+const CustomAccordion: React.FC<React.PropsWithChildren<CustomAccordionProps>> = ({
+  hanke,
+  signedInUser,
+}) => {
   const getEditHankePath = useLinkPath(ROUTES.EDIT_HANKE);
   const hankeViewPath = useHankeViewPath(hanke?.hankeTunnus);
   const navigateToApplications = useNavigateToApplicationList(hanke?.hankeTunnus);
@@ -115,7 +120,7 @@ const CustomAccordion: React.FC<React.PropsWithChildren<CustomAccordionProps>> =
               <IconEye aria-hidden />
             </Link>
             <FeatureFlags flags={['hanke']}>
-              <UserRightsCheck requiredRight="EDIT" hankeTunnus={hanke.hankeTunnus}>
+              <CheckRightsByUser requiredRight="EDIT" signedInUser={signedInUser}>
                 <Link
                   to={getEditHankePath({ hankeTunnus: hanke.hankeTunnus })}
                   aria-label={
@@ -127,7 +132,7 @@ const CustomAccordion: React.FC<React.PropsWithChildren<CustomAccordionProps>> =
                 >
                   <IconPen aria-hidden />
                 </Link>
-              </UserRightsCheck>
+              </CheckRightsByUser>
             </FeatureFlags>
           </div>
           <button type="button" className={styles.iconWrapper}>
@@ -233,10 +238,14 @@ export type Column = {
 };
 
 export interface PagedRowsProps {
-  data: Array<HankeData>;
+  hankkeet: Array<HankeData>;
+  signedInUserByHanke: SignedInUserByHanke;
 }
 
-const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({ data }) => {
+const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
+  hankkeet,
+  signedInUserByHanke,
+}) => {
   const {
     hankeFilterStartDate,
     hankeFilterEndDate,
@@ -346,7 +355,7 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
   } = useTable(
     {
       columns,
-      data,
+      data: hankkeet,
       initialState: {
         pageSize: 10,
         sortBy: useMemo(() => [{ id: 'alkuPvm', desc: false }], []),
@@ -571,10 +580,12 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
             </Text>
 
             {rows.length > 0 &&
-              page.map((row) => {
+              page.map(({ original: hanke }) => {
+                const { hankeTunnus } = hanke;
+                const signedInUser = signedInUserByHanke[hankeTunnus];
                 return (
-                  <div key={row.original.hankeTunnus}>
-                    <CustomAccordion hanke={row.original} />
+                  <div key={hankeTunnus}>
+                    <CustomAccordion hanke={hanke} signedInUser={signedInUser} />
                   </div>
                 );
               })}
@@ -615,12 +626,16 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
 
 type Props = {
   hankkeet: HankeData[];
+  signedInUserByHanke: SignedInUserByHanke;
 };
 
-const HankePortfolio: React.FC<React.PropsWithChildren<Props>> = ({ hankkeet }) => {
+const HankePortfolio: React.FC<React.PropsWithChildren<Props>> = ({
+  hankkeet,
+  signedInUserByHanke,
+}) => {
   return (
     <div className={styles.hankesalkkuContainer}>
-      <PaginatedPortfolio data={hankkeet} />
+      <PaginatedPortfolio hankkeet={hankkeet} signedInUserByHanke={signedInUserByHanke} />
     </div>
   );
 };

--- a/src/domain/hanke/portfolio/HankePortfolioContainer.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioContainer.tsx
@@ -3,6 +3,7 @@ import { useQuery } from 'react-query';
 import api from '../../api/api';
 import { HankeData } from '../../types/hanke';
 import HankePortfolioComponent from './HankePortfolioComponent';
+import { usePermissionsByHanke } from '../hankeUsers/hooks/useUserRightsForHanke';
 
 const getHankkeet = async () => {
   const { data } = await api.get<HankeData[]>(`/hankkeet`, {
@@ -16,10 +17,16 @@ const getHankkeet = async () => {
 const useHankeList = () => useQuery<HankeData[]>(['project'], getHankkeet);
 
 const HankePortfolioContainer: React.FC<React.PropsWithChildren<unknown>> = () => {
-  const { data } = useHankeList();
+  const { data: hankkeet } = useHankeList();
+  const { data: signedInUserByHanke } = usePermissionsByHanke();
+  const userData = signedInUserByHanke ?? {};
 
   // Add header to fix Axe "page-has-heading-one"-error
-  return data ? <HankePortfolioComponent hankkeet={data} /> : <></>;
+  return hankkeet ? (
+    <HankePortfolioComponent hankkeet={hankkeet} signedInUserByHanke={userData} />
+  ) : (
+    <></>
+  );
 };
 
 export default HankePortfolioContainer;

--- a/src/domain/mocks/signedInUser.ts
+++ b/src/domain/mocks/signedInUser.ts
@@ -1,0 +1,67 @@
+import {
+  AccessRightLevel,
+  Rights,
+  SignedInUser,
+  SignedInUserByHanke,
+} from '../hanke/hankeUsers/hankeUser';
+
+export const USER_ALL: SignedInUser = {
+  hankeKayttajaId: 'cc0376be-9609-4b2b-bb10-5a385bdea1d8',
+  kayttooikeustaso: AccessRightLevel.KAIKKI_OIKEUDET,
+  kayttooikeudet: Object.values(Rights),
+};
+
+export const USER_EDIT_ALL: SignedInUser = {
+  hankeKayttajaId: '79284308-d532-4f90-bae7-ea45f947a9c1',
+  kayttooikeustaso: AccessRightLevel.KAIKKIEN_MUOKKAUS,
+  kayttooikeudet: [
+    Rights.VIEW,
+    Rights.MODIFY_VIEW_PERMISSIONS,
+    Rights.EDIT,
+    Rights.MODIFY_EDIT_PERMISSIONS,
+    Rights.EDIT_APPLICATIONS,
+    Rights.MODIFY_APPLICATION_PERMISSIONS,
+    Rights.RESEND_INVITATION,
+  ],
+};
+
+export const USER_EDIT_HANKE: SignedInUser = {
+  hankeKayttajaId: '678585e0-11c5-4675-8847-46132ab0e60c',
+  kayttooikeustaso: AccessRightLevel.HANKEMUOKKAUS,
+  kayttooikeudet: [Rights.VIEW, Rights.EDIT, Rights.RESEND_INVITATION],
+};
+
+export const USER_HAKEMUSASIOINTI: SignedInUser = {
+  hankeKayttajaId: '448ef74f-bf6e-4011-b924-8f559f716a4c',
+  kayttooikeustaso: AccessRightLevel.HAKEMUSASIOINTI,
+  kayttooikeudet: [Rights.VIEW, Rights.EDIT_APPLICATIONS, Rights.RESEND_INVITATION],
+};
+
+export const USER_VIEW: SignedInUser = {
+  hankeKayttajaId: 'ecd6027f-a66f-4ee4-854e-20f0a66c40f8',
+  kayttooikeustaso: AccessRightLevel.KATSELUOIKEUS,
+  kayttooikeudet: [Rights.VIEW],
+};
+
+export const signedInUsers: SignedInUser[] = [
+  USER_ALL,
+  USER_EDIT_ALL,
+  USER_EDIT_HANKE,
+  USER_HAKEMUSASIOINTI,
+  USER_VIEW,
+];
+
+export const userData = (accessLevel: AccessRightLevel) =>
+  signedInUsers.find((user) => user.kayttooikeustaso === accessLevel) ?? USER_VIEW;
+
+export const userDataByHanke = (
+  hankeTunnusList: string[],
+  access: AccessRightLevel = AccessRightLevel.KAIKKI_OIKEUDET,
+): SignedInUserByHanke =>
+  hankeTunnusList.reduce(
+    (data: SignedInUserByHanke, tunnus: string) => ({
+      ...data,
+      [tunnus]: userData(access),
+    }),
+    {},
+  );


### PR DESCRIPTION
# Description

Add a functionality to fecth users permissions for all related hanke. This is used in hanke portfolio listing to prevent multiple whoami http calls

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2042

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Login to haitaton and view your own projects (hanke list). There should be no whoami calls, instead a single hankkeet/my-permissions call should be made. Hanke permissions should be set correctly based on what privileges you have. Note: this is only for the hanke listing page.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
