### PR TITLE
HAI-1508: Remove feature object from API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ Then either rebuild the docker container or run `yarn update-runtime-env` as dis
 
 In the cloud instances, dev uses Helsinki AD identification while others use Suomi.fi.
 
+### Windows Subsystem for Linux (WSL)
+
+If you use WSL as your local development environment and you bump into pre-push validation errors
+in `git push` that other developers (with e.g. Mac) do not have, you could try to set `WSL=true`
+in your local environment, e.g. in `~/.huskyrc` (Husky git hooks automatically loads this file):
+
+```
+export WSL=true
+```
+
+This setting adds `--runInBand` parameter for Jest tests (see https://jestjs.io/docs/cli#--runinband).
+
 ## Excel for translations
 
 You can export an Excel-file with current translations. This can then be sent to translators.

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "yarn run type-check && yarn testCI"
+      "pre-push": "yarn run type-check && if test \"$WSL\" = \"true\" ; then yarn testCI --runInBand ; else yarn testCI ; fi"
     }
   },
   "lint-staged": {

--- a/src/domain/hanke/edit/utils.test.ts
+++ b/src/domain/hanke/edit/utils.test.ts
@@ -1,8 +1,10 @@
-import { HankeAlueFormState } from './types';
-import { getAreaDefaultName } from './utils';
+import { Feature } from 'ol';
+import { HankeAlueFormState, HankeDataFormState } from './types';
+import { convertFormStateToHankeData, getAreaDefaultName } from './utils';
 
 function getArea(areaName: string): HankeAlueFormState {
   return {
+    feature: new Feature(),
     nimi: areaName,
     id: null,
     haittaAlkuPvm: '2023-01-12T00:00:00Z',
@@ -12,6 +14,15 @@ function getArea(areaName: string): HankeAlueFormState {
     meluHaitta: null,
     polyHaitta: null,
     tarinaHaitta: null,
+  };
+}
+
+function getHankeData(): HankeDataFormState {
+  return {
+    alueet: [getArea('Hankealue 1')],
+    rakennuttajat: [],
+    toteuttajat: [],
+    muut: [],
   };
 }
 
@@ -48,4 +59,11 @@ test('Should get correct default area name based on other areas', () => {
   ]);
 
   expect(thirdAreaName).toBe('Hankealue 8');
+});
+
+test('Should get area data without feature', () => {
+  const hankeData = convertFormStateToHankeData(getHankeData());
+
+  expect(hankeData.alueet![0].feature).toBeUndefined();
+  expect(hankeData.alueet![0].nimi).toBe('Hankealue 1');
 });

--- a/src/domain/hanke/edit/utils.ts
+++ b/src/domain/hanke/edit/utils.ts
@@ -38,8 +38,10 @@ export const convertFormStateToHankeData = (hankeData: HankeDataFormState): Hank
   return {
     ...hankeData,
     [FORMFIELD.HANKEALUEET]: hankeData[FORMFIELD.HANKEALUEET]?.map((alue) => {
+      // eslint-disable-next-line
+      const { feature, ...hankeAlue } = alue; // exclude virtual field 'feature' from API call
       return {
-        ...alue,
+        ...hankeAlue,
         geometriat: {
           featureCollection: formatFeaturesToHankeGeoJSON(alue.feature ? [alue.feature] : []),
         },


### PR DESCRIPTION
# Description

Exclude `feature` field from hanke data `alueet[n]`.

PLUS: Made pre-push hook to be conditional on `WSL=true` and add `--runInBand` for Jest tests if it is set. 

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1508

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Create a new Hanke (can be done locally in just ui with `yarn start-msw`), add some geometry on it, check the API call UI makes when saving or changing view to a different page. There should not be `feature` field any more.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [x] I have made necessary changes to the documentation, link to confluence
      or other location: README.md

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
