### PR TITLE
HAI-2067 Add error messages to file upload component

### DIFF
--- a/src/common/components/fileUpload/FileUpload.test.tsx
+++ b/src/common/components/fileUpload/FileUpload.test.tsx
@@ -22,12 +22,6 @@ function uploadFunction(file: File) {
 }
 
 test('Should upload files successfully and loading indicator is displayed', async () => {
-  server.use(
-    rest.post('/api/hakemukset/:id/liitteet', async (req, res, ctx) => {
-      return res(ctx.delay(), ctx.status(200));
-    }),
-  );
-
   const inputLabel = 'Choose a file';
   const { user } = render(
     <FileUpload
@@ -54,7 +48,23 @@ test('Should upload files successfully and loading indicator is displayed', asyn
   });
 });
 
-test('Should show amount of successful files uploaded correctly when file fails in validation', async () => {
+test('Should show amount of successful files uploaded and errors correctly when files fails in validation', async () => {
+  const fileNameA = 'test-file-a.png';
+  const fileNameB = 'test-file-b.pdf';
+  const fileNameC = 'test-file-c.png';
+  const fileNameD = 'test-file-d.png';
+  const existingFileA: AttachmentMetadata = {
+    id: '4f08ce3f-a0de-43c6-8ccc-9fe93822ed18',
+    fileName: fileNameA,
+    createdByUserId: 'b9a58f4c-f5fe-11ec-997f-0a580a800284',
+    createdAt: '2023-07-04T12:07:52.324684Z',
+  };
+  const existingFileB: AttachmentMetadata = {
+    id: '4f08ce3f-a0de-43c6-8ccc-9fe93822ed20',
+    fileName: fileNameD,
+    createdByUserId: 'b9a58f4c-f5fe-11ec-997f-0a580a800284',
+    createdAt: '2023-07-04T12:08:52.324684Z',
+  };
   const inputLabel = 'Choose a file';
   const { user } = render(
     <FileUpload
@@ -64,6 +74,7 @@ test('Should show amount of successful files uploaded correctly when file fails 
       multiple
       uploadFunction={uploadFunction}
       fileDeleteFunction={() => Promise.resolve()}
+      existingAttachments={[existingFileA, existingFileB]}
     />,
     undefined,
     undefined,
@@ -71,22 +82,39 @@ test('Should show amount of successful files uploaded correctly when file fails 
   );
   const fileUpload = screen.getByLabelText(inputLabel);
   user.upload(fileUpload, [
-    new File(['test-a'], 'test-file-a.png', { type: 'image/png' }),
-    new File(['test-b'], 'test-file-b.pdf', { type: 'application/pdf' }),
+    new File(['test-a'], fileNameA, { type: 'image/png' }),
+    new File(['test-b'], fileNameB, { type: 'application/pdf' }),
+    new File(['test-c'], fileNameC, { type: 'image/png' }),
   ]);
 
   await waitFor(() => {
-    expect(screen.queryByText('1/2 tiedosto(a) tallennettu')).toBeInTheDocument();
+    expect(screen.queryByText('1/3 tiedosto(a) tallennettu')).toBeInTheDocument();
   });
+  expect(
+    screen.queryByText('Liitteen tallennus epäonnistui 2/3 tiedostolle', { exact: false }),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      `Tiedosto (${fileNameB}) on viallinen. Tarkistathan, että tiedostomuoto on oikea eikä sen koko ylitä sallittua maksimikokoa.`,
+      { exact: false },
+    ),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      `Valittu tiedostonimi (${fileNameA}) on jo käytössä. Nimeä tiedosto uudelleen.`,
+      { exact: false },
+    ),
+  ).toBeInTheDocument();
 });
 
-test('Should show amount of successful files uploaded correctly when request fails', async () => {
+test('Should show amount of successful files uploaded and errors correctly when request fails for bad request', async () => {
   server.use(
     rest.post('/api/hakemukset/:id/liitteet', async (req, res, ctx) => {
       return res(ctx.status(400), ctx.json({ errorMessage: 'Failed for testing purposes' }));
     }),
   );
 
+  const fileNameA = 'test-file-a.png';
   const inputLabel = 'Choose a file';
   const { user } = render(
     <FileUpload
@@ -99,11 +127,56 @@ test('Should show amount of successful files uploaded correctly when request fai
     />,
   );
   const fileUpload = screen.getByLabelText(inputLabel);
-  user.upload(fileUpload, [new File(['test-a'], 'test-file-a.png', { type: 'image/png' })]);
+  user.upload(fileUpload, [new File(['test-a'], fileNameA, { type: 'image/png' })]);
 
   await waitFor(() => {
     expect(screen.queryByText('0/1 tiedosto(a) tallennettu')).toBeInTheDocument();
   });
+  expect(
+    screen.queryByText('Liitteen tallennus epäonnistui 1/1 tiedostolle', { exact: false }),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      `Tiedosto (${fileNameA}) on viallinen. Tarkistathan, että tiedostomuoto on oikea eikä sen koko ylitä sallittua maksimikokoa.`,
+      { exact: false },
+    ),
+  ).toBeInTheDocument();
+});
+
+test('Should show correct error message when request fails for server error', async () => {
+  server.use(
+    rest.post('/api/hakemukset/:id/liitteet', async (req, res, ctx) => {
+      return res(ctx.status(500), ctx.json({ errorMessage: 'Failed for testing purposes' }));
+    }),
+  );
+
+  const fileNameA = 'test-file-a.png';
+  const inputLabel = 'Choose a file';
+  const { user } = render(
+    <FileUpload
+      id="test-file-upload"
+      label={inputLabel}
+      accept=".png,.jpg"
+      multiple
+      uploadFunction={uploadFunction}
+      fileDeleteFunction={() => Promise.resolve()}
+    />,
+  );
+  const fileUpload = screen.getByLabelText(inputLabel);
+  user.upload(fileUpload, [new File(['test-a'], fileNameA, { type: 'image/png' })]);
+
+  await waitFor(() => {
+    expect(screen.queryByText('0/1 tiedosto(a) tallennettu')).toBeInTheDocument();
+  });
+  expect(
+    screen.queryByText('Liitteen tallennus epäonnistui 1/1 tiedostolle', { exact: false }),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      `Tiedoston (${fileNameA}) lataus epäonnistui, yritä hetken päästä uudelleen.`,
+      { exact: false },
+    ),
+  ).toBeInTheDocument();
 });
 
 test('Should upload files when user drops them into drag-and-drop area', async () => {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -51,7 +51,8 @@
       },
       "fileUpload": {
         "loadingText": "Tallennetaan tiedostoja",
-        "successNotification": "{{successful}}/{{total}} tiedosto(a) tallennettu",
+        "successNotification": "{{successful}}/{{newFiles}} tiedosto(a) tallennettu",
+        "errorNotification": "Liitteen tallennus epäonnistui {{errors}}/{{newFiles}} tiedostolle:",
         "deleteError": {
           "title": "Tiedoston poistamisessa tapahtui virhe",
           "fileNotFound": "Tiedostoa, jonka yritit poistaa ei löydy (virhe 404). Yritä myöhemmin uudelleen.",
@@ -92,7 +93,8 @@
       "fileLoadError": "Tiedoston latauksessa tapahtui virhe",
       "selfIntersectingArea": "Alueen reunat eivät saa leikata toisiaan",
       "fileLoadTechnicalError": "Tiedoston ({{fileName}}) lataus epäonnistui, yritä hetken päästä uudelleen.",
-      "fileLoadBadFileError": "Tiedosto ({{fileName}}) on viallinen. Tarkistathan, että tiedostomuoto on oikea eikä sen koko ylitä sallittua maksimikokoa."
+      "fileLoadBadFileError": "Tiedosto ({{fileName}}) on viallinen. Tarkistathan, että tiedostomuoto on oikea eikä sen koko ylitä sallittua maksimikokoa.",
+      "duplicateFileError": "Valittu tiedostonimi ({{fileName}}) on jo käytössä. Nimeä tiedosto uudelleen."
     },
     "headers": {
       "perustiedot": "Perustiedot",


### PR DESCRIPTION
# Description

Show error message to user for each file that fails to be uploaded, either because the file is a duplicate, fails client side validation, fails validation in the server or fails because of other server error.

There are three kind of error messages. One for duplicate file, one for not passing client side or server side validation and one for other server errors.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2067

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

To test this you can replace FileInput component locally in src/domain/johtoselvitys/Attachments.tsx with FileUpload component, for example:
```
<FileUpload
  id="cable-report-file-upload"
  accept=".pdf,.jpg,.jpeg,.png,.dgn,.dwg,.docx,.txt,.gt"
  maxSize={104857600}
  dragAndDrop
  multiple
  existingAttachments={existingAttachments}
  uploadFunction={(file) =>
    uploadAttachment({
      applicationId: getValues('id')!,
      attachmentType: 'MUU',
      file,
    })
  }
  onUpload={(uploading: boolean) => {
    if (!uploading) {
      queryClient.invalidateQueries('attachments');
    }
  }}
  fileDownLoadFunction={(file) => getAttachmentFile(getValues('id')!, file.id)}
  fileDeleteFunction={(file) =>
    deleteAttachment({ applicationId: getValues('id'), attachmentId: file?.id })
  }
  onFileDelete={() => queryClient.invalidateQueries('attachments')}
  showDeleteButtonForFile={showDeleteButton}
/>
```

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
