### PR TITLE
HAI-2089 Remove information requirements on hanke form

### DIFF
--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -13,28 +13,6 @@ jest.setTimeout(30000);
 const nimi = 'test kuoppa';
 const hankkeenKuvaus = 'Tässä on kuvaus';
 const hankkeenOsoite = 'Sankaritie 3';
-/* Highly recommend to revise these tests to use typed constants like so
-const hankeData: HankeDataDraft = {
-  nimi: 'test kuoppa',
-  kuvaus: 'Tässä on kuvaus',
-  tyomaaKatuosoite: 'Sankaritie 3',
-  alkuPvm: '24.03.2025',
-  loppuPvm: '25.03.2025',
-  vaihe: 'OHJELMOINTI',
-  omistajat: [
-    {
-      id: null,
-      etunimi: 'Matti',
-      email: 'Matti@haitaton.hel.fi',
-      sukunimi: 'Meikäläinen',
-      organisaatioId: null,
-      organisaatioNimi: 'Matin organisaatio',
-      osasto: '',
-      puhelinnumero: '12341234',
-    },
-  ],
-};
-*/
 
 function fillBasicInformation(
   options: {
@@ -121,6 +99,27 @@ describe('HankeForm', () => {
     expect(screen.getByTestId(FORMFIELD.KUVAUS)).toHaveValue(hankkeenKuvaus);
   });
 
+  test('Should not allow next page if hanke name is not set', async () => {
+    const { user } = render(<HankeFormContainer />);
+
+    await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+    expect(screen.queryByText('Vaihe 1/5: Perustiedot')).toBeInTheDocument();
+    expect(screen.queryByText('Kentän pituus oltava vähintään 3 merkkiä')).toBeInTheDocument();
+  });
+
+  test('Should allow next page if hanke name is set', async () => {
+    const { user } = render(<HankeFormContainer />);
+    fireEvent.change(screen.getByRole('textbox', { name: /hankkeen nimi/i }), {
+      target: { value: nimi },
+    });
+
+    await user.click(screen.getByRole('button', { name: /seuraava/i }));
+    await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+    expect(screen.queryByText('Vaihe 3/5: Haitat')).toBeInTheDocument();
+  });
+
   test('Hanke nimi should be limited to 100 characters and not exceed the limit with additional characters', async () => {
     const { user } = render(<HankeFormContainer />);
     const initialName = 'b'.repeat(90);
@@ -205,8 +204,8 @@ describe('HankeForm', () => {
 
     await user.click(screen.getByRole('button', { name: 'Tallenna ja keskeytä' }));
 
-    expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-13');
-    expect(screen.getByText(`Hanke ${nimi} (HAI22-13) tallennettu omiin hankkeisiin.`));
+    expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-14');
+    expect(screen.getByText(`Hanke ${nimi} (HAI22-14) tallennettu omiin hankkeisiin.`));
   });
 
   test('Should be able to save hanke in the last page', async () => {

--- a/src/domain/hanke/edit/HankeForm.tsx
+++ b/src/domain/hanke/edit/HankeForm.tsx
@@ -5,7 +5,7 @@ import { useMutation } from 'react-query';
 import { Button, IconCross, IconPlusCircle, IconSaveDiskette, StepState } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { FormNotification, HankeDataFormState } from './types';
+import { FORMFIELD, FormNotification, HankeDataFormState } from './types';
 import { hankeSchema } from './hankeSchema';
 import HankeFormAlueet from './HankeFormAlueet';
 import HankeFormPerustiedot from './HankeFormPerustiedot';
@@ -22,6 +22,7 @@ import FormActions from '../../forms/components/FormActions';
 import { useLocalizedRoutes } from '../../../common/hooks/useLocalizedRoutes';
 import ApplicationAddDialog from '../../application/components/ApplicationAddDialog';
 import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
+import { changeFormStep } from '../../forms/utils';
 
 async function saveHanke(data: HankeDataFormState) {
   const requestData = {
@@ -69,6 +70,7 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
     formState: { errors, isDirty },
     getValues,
     setValue,
+    trigger,
   } = formContext;
 
   const isNewHanke = !formData.hankeTunnus;
@@ -170,14 +172,20 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
       />
       <div className="hankeForm">
         <MultipageForm heading={formHeading} formSteps={formSteps} onStepChange={save}>
-          {function renderFormActions(activeStepIndex, handlePrevious, handleNext) {
-            const lastStep = activeStepIndex === formSteps.length - 1;
+          {function renderFormActions(activeStep, handlePrevious, handleNext) {
+            const lastStep = activeStep === formSteps.length - 1;
+
+            const handleNextPage = () =>
+              activeStep === 0
+                ? changeFormStep(handleNext, [FORMFIELD.NIMI], trigger)
+                : handleNext();
+
             return (
               <FormActions
-                activeStepIndex={activeStepIndex}
+                activeStepIndex={activeStep}
                 totalSteps={formSteps.length}
                 onPrevious={handlePrevious}
-                onNext={handleNext}
+                onNext={handleNextPage}
               >
                 {isNewHanke && (
                   <Button

--- a/src/domain/hanke/edit/HankeFormPerustiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormPerustiedot.tsx
@@ -20,12 +20,18 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
   formData,
 }) => {
   const { t } = useTranslation();
-  const { watch } = useFormContext();
+  const { setValue, watch } = useFormContext();
   const { JOHTOSELVITYSHAKEMUS } = useLocalizedRoutes();
   useFormPage();
 
   // Subscribe to vaihe changes in order to update the selected radio button
   const hankeVaiheField = watch(FORMFIELD.VAIHE);
+
+  // Allow unselect vaihe, important for draft.
+  const handleVaiheClick = (value: HANKE_VAIHE) => {
+    const newValue = hankeVaiheField === value ? null : value;
+    setValue(FORMFIELD.VAIHE, newValue);
+  };
 
   return (
     <div className="form0">
@@ -54,13 +60,11 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
           invalid={!!errors[FORMFIELD.KUVAUS]}
           {...register(FORMFIELD.KUVAUS)}
           data-testid={FORMFIELD.KUVAUS}
-          required
           errorText={getInputErrorText(t, errors[FORMFIELD.KUVAUS])}
         />
       </div>
       <div className="formWpr formWprShort">
         <TextInput
-          required
           name={FORMFIELD.KATUOSOITE}
           tooltip={{
             tooltipText: t(`hankeForm:toolTips:${FORMFIELD.KATUOSOITE}`),
@@ -74,7 +78,6 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
         <SelectionGroup
           direction="horizontal"
           label={t(`hankeForm:labels:${FORMFIELD.VAIHE}`)}
-          required
           errorText={getInputErrorText(t, errors[FORMFIELD.VAIHE])}
         >
           {$enum(HANKE_VAIHE).map((value) => {
@@ -86,6 +89,7 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
                 value={value}
                 label={t(`hanke:vaihe:${value}`)}
                 checked={hankeVaiheField === value}
+                onClick={() => handleVaiheClick(value)}
               />
             );
           })}
@@ -121,7 +125,6 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
           id={FORMFIELD.YKT_HANKE}
           name={FORMFIELD.YKT_HANKE}
           label={t(`hankeForm:labels:${FORMFIELD.YKT_HANKE}`)}
-          rules={{ required: true }}
         />
       </div>
     </div>

--- a/src/domain/hanke/edit/HankeFormPerustiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormPerustiedot.tsx
@@ -79,6 +79,9 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
           direction="horizontal"
           label={t(`hankeForm:labels:${FORMFIELD.VAIHE}`)}
           errorText={getInputErrorText(t, errors[FORMFIELD.VAIHE])}
+          tooltipLabel={t(`hankeForm:labels:${FORMFIELD.VAIHE}`)}
+          tooltipButtonLabel={t(`hankeForm:toolTips:tipOpenLabel`)}
+          tooltipText={t(`hankeForm:toolTips:${FORMFIELD.VAIHE}`)}
         >
           {$enum(HANKE_VAIHE).map((value) => {
             return (

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -382,7 +382,6 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
                   <TextInput
                     name={`${fieldPath}.${CONTACT_FORMFIELD.ROOLI}`}
                     label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.ROOLI}`)}
-                    required
                     placeholder={t('form:yhteystiedot:placeholders:otherPartyRole')}
                     helperText={t('form:yhteystiedot:helperTexts:otherPartyRole')}
                   />
@@ -391,7 +390,6 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
                   <TextInput
                     name={`${fieldPath}.${CONTACT_FORMFIELD.NIMI}`}
                     label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.NIMI}`)}
-                    required
                   />
                   <TextInput
                     name={`${fieldPath}.${CONTACT_FORMFIELD.ORGANISAATIO}`}
@@ -404,7 +402,6 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
                   <TextInput
                     name={`${fieldPath}.${CONTACT_FORMFIELD.EMAIL}`}
                     label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.EMAIL}`)}
-                    required
                   />
                   <TextInput
                     name={`${fieldPath}.${CONTACT_FORMFIELD.PUHELINNUMERO}`}

--- a/src/domain/hanke/edit/components/Haitat.tsx
+++ b/src/domain/hanke/edit/components/Haitat.tsx
@@ -72,13 +72,11 @@ const Haitat: React.FC<Props> = ({ index, onRemoveArea }) => {
           name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.HAITTA_ALKU_PVM}`}
           label={t(`hankeForm:labels:${FORMFIELD.HAITTA_ALKU_PVM}`)}
           locale={locale}
-          required
         />
         <DatePicker
           name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.HAITTA_LOPPU_PVM}`}
           label={t(`hankeForm:labels:${FORMFIELD.HAITTA_LOPPU_PVM}`)}
           locale={locale}
-          required
           minDate={minEndDate || undefined}
         />
         <Spacer />
@@ -94,7 +92,6 @@ const Haitat: React.FC<Props> = ({ index, onRemoveArea }) => {
           }))}
           defaultValue={formValues[index][FORMFIELD.MELUHAITTA] || ''}
           label={t(`hankeForm:labels:${FORMFIELD.MELUHAITTA}`)}
-          required
         />
         <Dropdown
           name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.POLYHAITTA}`}
@@ -105,7 +102,6 @@ const Haitat: React.FC<Props> = ({ index, onRemoveArea }) => {
           }))}
           defaultValue={formValues[index][FORMFIELD.POLYHAITTA] || ''}
           label={t(`hankeForm:labels:${FORMFIELD.POLYHAITTA}`)}
-          required
         />
         <Dropdown
           name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.TARINAHAITTA}`}
@@ -116,7 +112,6 @@ const Haitat: React.FC<Props> = ({ index, onRemoveArea }) => {
           }))}
           defaultValue={formValues[index][FORMFIELD.TARINAHAITTA] || ''}
           label={t(`hankeForm:labels:${FORMFIELD.TARINAHAITTA}`)}
-          required
         />
       </div>
 
@@ -130,7 +125,6 @@ const Haitat: React.FC<Props> = ({ index, onRemoveArea }) => {
           }))}
           defaultValue={formValues[index][FORMFIELD.KAISTAHAITTA] || ''}
           label={t(`hankeForm:labels:${FORMFIELD.KAISTAHAITTA}`)}
-          required
         />
         <Dropdown
           name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.KAISTAPITUUSHAITTA}`}
@@ -141,7 +135,6 @@ const Haitat: React.FC<Props> = ({ index, onRemoveArea }) => {
           }))}
           defaultValue={formValues[index][FORMFIELD.KAISTAPITUUSHAITTA] || ''}
           label={t(`hankeForm:labels:${FORMFIELD.KAISTAPITUUSHAITTA}`)}
-          required
         />
       </div>
 

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -47,17 +47,16 @@ const contactSchema = yup
 const otherPartySchema = contactSchema
   .omit([CONTACT_FORMFIELD.TYYPPI, CONTACT_FORMFIELD.TUNNUS])
   .shape({
-    [CONTACT_FORMFIELD.ROOLI]: yup.string().required(),
+    [CONTACT_FORMFIELD.ROOLI]: yup.string(),
     [CONTACT_FORMFIELD.ORGANISAATIO]: yup.string(),
     [CONTACT_FORMFIELD.OSASTO]: yup.string(),
   });
 
 export const hankeAlueSchema = yup.object().shape({
   [FORMFIELD.NIMI]: yup.string(),
-  [FORMFIELD.HAITTA_ALKU_PVM]: yup.date().required(),
+  [FORMFIELD.HAITTA_ALKU_PVM]: yup.date(),
   [FORMFIELD.HAITTA_LOPPU_PVM]: yup
     .date()
-    .required()
     .when(FORMFIELD.HAITTA_ALKU_PVM, (alkuPvm: Date, schema: yup.DateSchema) => {
       try {
         return alkuPvm ? schema.min(alkuPvm) : schema;
@@ -65,22 +64,21 @@ export const hankeAlueSchema = yup.object().shape({
         return schema;
       }
     }),
-  [FORMFIELD.MELUHAITTA]: yup.mixed().oneOf($enum(HANKE_MELUHAITTA).getValues()).required(),
-  [FORMFIELD.POLYHAITTA]: yup.mixed().oneOf($enum(HANKE_POLYHAITTA).getValues()).required(),
-  [FORMFIELD.TARINAHAITTA]: yup.mixed().oneOf($enum(HANKE_TARINAHAITTA).getValues()).required(),
-  [FORMFIELD.KAISTAHAITTA]: yup.mixed().oneOf($enum(HANKE_KAISTAHAITTA).getValues()).required(),
+  [FORMFIELD.MELUHAITTA]: yup.mixed().oneOf([...$enum(HANKE_MELUHAITTA).getValues(), null]),
+  [FORMFIELD.POLYHAITTA]: yup.mixed().oneOf([...$enum(HANKE_POLYHAITTA).getValues(), null]),
+  [FORMFIELD.TARINAHAITTA]: yup.mixed().oneOf([...$enum(HANKE_TARINAHAITTA).getValues(), null]),
+  [FORMFIELD.KAISTAHAITTA]: yup.mixed().oneOf([...$enum(HANKE_KAISTAHAITTA).getValues(), null]),
   [FORMFIELD.KAISTAPITUUSHAITTA]: yup
     .mixed()
-    .oneOf($enum(HANKE_KAISTAPITUUSHAITTA).getValues())
-    .required(),
+    .oneOf([...$enum(HANKE_KAISTAPITUUSHAITTA).getValues(), null]),
 });
 
 export const hankeSchema = yup.object().shape({
   hankeTunnus: yup.string().required(),
   [FORMFIELD.NIMI]: yup.string().min(3).required(),
-  [FORMFIELD.KUVAUS]: yup.string().required().min(1),
-  [FORMFIELD.KATUOSOITE]: yup.string().required(),
-  [FORMFIELD.VAIHE]: yup.mixed().oneOf($enum(HANKE_VAIHE).getValues()).required(),
+  [FORMFIELD.KUVAUS]: yup.string(),
+  [FORMFIELD.KATUOSOITE]: yup.string(),
+  [FORMFIELD.VAIHE]: yup.mixed().oneOf([...$enum(HANKE_VAIHE).getValues(), null]),
   [FORMFIELD.HANKEALUEET]: yup.array().ensure().of(hankeAlueSchema),
   [FORMFIELD.OMISTAJAT]: yup.array().length(1).ensure().of(contactSchema),
   [FORMFIELD.RAKENNUTTAJAT]: yup.array().ensure().of(contactSchema),


### PR DESCRIPTION
# Description

Only hanke name is required for saving a hanke.

Additional, do not allow proceeding if hanke name is not set on the first step of the form.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2089

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing
Filling out a draft hanke:
- Hanke name is marked mandatory.
- A contact person is mandatory for every added contact.
Everything else is optional.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
