### PR TITLE
HAI-2077 Remove hanke perustaja

### DIFF
--- a/src/common/components/fileUpload/FileUpload.test.tsx
+++ b/src/common/components/fileUpload/FileUpload.test.tsx
@@ -286,10 +286,15 @@ test('Should show 404 error message if deleting file fails with status 404', asy
     existingAttachments: files,
     fileDeleteFunction: (file) => deleteAttachment({ applicationId: 1, attachmentId: file?.id }),
   });
+  // Delete and wait for confirm dialog
   await user.click(screen.getByRole('button', { name: 'Poista' }));
-  const { getByRole: getByRoleInDialog } = within(screen.getByRole('dialog'));
+  const { getByRole: getByRoleInDialog } = within(await screen.findByRole('dialog'));
+
+  // Confirm delete
   await user.click(getByRoleInDialog('button', { name: 'Poista' }));
-  const { getByText: getByTextInDialog } = within(screen.getByRole('dialog'));
+  const { getByText: getByTextInDialog } = within(await screen.findByRole('dialog'));
+
+  // Wait for error dialog and confirm content
   expect(
     getByTextInDialog(
       'Tiedostoa, jonka yritit poistaa ei löydy (virhe 404). Yritä myöhemmin uudelleen.',

--- a/src/common/components/fileUpload/FileUpload.test.tsx
+++ b/src/common/components/fileUpload/FileUpload.test.tsx
@@ -313,10 +313,16 @@ test('Should show server error message if deleting file fails with server error'
     existingAttachments: files,
     fileDeleteFunction: (file) => deleteAttachment({ applicationId: 1, attachmentId: file?.id }),
   });
+
+  // Delete and wait for confrim dialog
   await user.click(screen.getByRole('button', { name: 'Poista' }));
-  const { getByRole: getByRoleInDialog } = within(screen.getByRole('dialog'));
+  const { getByRole: getByRoleInDialog } = within(await screen.findByRole('dialog'));
+
+  // Confirm delete
   await user.click(getByRoleInDialog('button', { name: 'Poista' }));
-  const { getByText: getByTextInDialog } = within(screen.getByRole('dialog'));
+
+  // Wait for error dialog and confirm content
+  const { getByText: getByTextInDialog } = within(await screen.findByRole('dialog'));
   expect(
     getByTextInDialog(
       'Palvelimeen ei saada yhteyttä, eikä valittua tiedostoa saada poistettua. Yritä myöhemmin uudelleen.',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -487,8 +487,7 @@
       "organisaatio": "Organisation",
       "omaOrganisaatio": "Add your own organisation",
       "insertOmaOrganisaatio": "Enter your own organisation",
-      "rights": "Your access rights to the project",
-      "perustaja": "Established by"
+      "rights": "Your access rights to the project"
     },
     "toolTips": {
       "tipOpenLabel": "Instruction",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -505,8 +505,7 @@
       "organisaatio": "Organisaatio",
       "omaOrganisaatio": "Lisää oma organisaatio",
       "insertOmaOrganisaatio": "Syötä oma organisaatio",
-      "rights": "Käyttöoikeutesi hankkeelle",
-      "perustaja": "Perustaja"
+      "rights": "Käyttöoikeutesi hankkeelle"
     },
     "toolTips": {
       "tipOpenLabel": "Ohje",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -487,8 +487,7 @@
       "organisaatio": "Organisation",
       "omaOrganisaatio": "Lägg till den egna organisationen",
       "insertOmaOrganisaatio": "Skriv in den egna organisationen",
-      "rights": "Din användarrätt för projektet",
-      "perustaja": "Grundare"
+      "rights": "Din användarrätt för projektet"
     },
     "toolTips": {
       "tipOpenLabel": "Anvisningen",


### PR DESCRIPTION
# Description

Remove hanke perustaja from basic information summary, which is used in summaries and hanke page. This was actually done as a part of HAI-1400.

This commit just removes the related translations.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2077

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

There should be no hanke perustaja information in hanke summary or in hanke page.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
