### PR TITLE
HAI Fix regex warning

### DIFF
--- a/src/domain/hanke/edit/utils.ts
+++ b/src/domain/hanke/edit/utils.ts
@@ -2,7 +2,7 @@ import { Feature } from 'ol';
 import Polygon from 'ol/geom/Polygon';
 import { Polygon as GeoJSONPolygon } from 'geojson';
 import { max, min } from 'date-fns';
-import { HankeDataDraft, HankeContact, HankeMuuTaho, HankeAlue } from '../../types/hanke';
+import { HankeAlue, HankeContact, HankeDataDraft, HankeMuuTaho } from '../../types/hanke';
 import { FORMFIELD, HankeAlueFormState, HankeDataFormState } from './types';
 import { formatFeaturesToHankeGeoJSON, getFeatureFromHankeGeometry } from '../../map/utils';
 import { getSurfaceArea } from '../../../common/components/map/utils';
@@ -112,6 +112,8 @@ export function canHankeBeCancelled(applications: Application[]): boolean {
   return applications.every((application) => isApplicationPending(application.alluStatus));
 }
 
+const defaultNameRegExp = /^Hankealue (\d+)$/;
+
 /**
  * Get default name for hanke area
  */
@@ -121,15 +123,11 @@ export function getAreaDefaultName(areas?: HankeAlueFormState[]) {
   }
 
   function getAreaNumber(area?: HankeAlueFormState): number {
-    const areaNumber = area?.nimi?.match(/\d+$/);
-    return areaNumber ? Number(areaNumber[0]) : 0;
+    const areaNumber = area?.nimi?.match(defaultNameRegExp);
+    return areaNumber ? Number(areaNumber[1]) : 0;
   }
 
-  const defaultNameRegExp = /^Hankealue \d+$/;
-  const maxAreaNumber = areas
-    .filter((area) => defaultNameRegExp.test(area.nimi || ''))
-    .map(getAreaNumber)
-    .reduce((a, b) => Math.max(a, b), 0);
+  const maxAreaNumber = areas.map(getAreaNumber).reduce((a, b) => Math.max(a, b), 0);
 
   return `Hankealue ${maxAreaNumber + 1}`;
 }


### PR DESCRIPTION
# Description

Sonarcloud has been reporting abot a potential problem with the regex `/\d+$/`. This can be avoided by using a capture group.

Use a capture group to find the number of the area, if the area name is a default name. Both matching and finding the number can be done with the same regex. This also removes the need to have a separate filtering step.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Other

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: