### PR TITLE
HAI-2091 Contact person fixes

### DIFF
--- a/cypress/integration/E2E.spec.ts
+++ b/cypress/integration/E2E.spec.ts
@@ -75,6 +75,14 @@ const hankeMock: HankeDataDraft = {
       puhelinnumero: '12341234',
       tyyppi: 'YKSITYISHENKILO',
       ytunnus: 'tunnus',
+      alikontaktit: [
+        {
+          etunimi: 'Yrjö',
+          sukunimi: 'Yhteys',
+          email: 'yrjo.yhteys@hankekatu.foo',
+          puhelinnumero: '12341234',
+        },
+      ],
     },
   ],
 };

--- a/src/domain/forms/components/Contact.tsx
+++ b/src/domain/forms/components/Contact.tsx
@@ -11,8 +11,12 @@ interface Props<T> {
   contactType: T;
   index?: number;
   onRemoveContact?: UseFieldArrayRemove;
-  renderSubContact?: (subContactIndex: number, remove: UseFieldArrayRemove) => JSX.Element;
   subContactTemplate?: boolean;
+  renderSubContact?: (
+    subContactIndex: number,
+    subContactCount: number,
+    remove: UseFieldArrayRemove,
+  ) => JSX.Element;
   subContactPath: string;
   emptySubContact: unknown;
   children: React.ReactNode;
@@ -88,7 +92,7 @@ const Contact = <T,>({
           {subContactFields.map((subContact, subContactIndex) => {
             return (
               <TabPanel key={subContact.id}>
-                {renderSubContact(subContactIndex, removeSubContact)}
+                {renderSubContact(subContactIndex, subContactFields.length, removeSubContact)}
               </TabPanel>
             );
           })}

--- a/src/domain/forms/components/Contact.tsx
+++ b/src/domain/forms/components/Contact.tsx
@@ -10,7 +10,8 @@ import useFieldArrayWithStateUpdate from '../../../common/hooks/useFieldArrayWit
 interface Props<T> {
   contactType: T;
   index?: number;
-  onRemoveContact?: UseFieldArrayRemove;
+  canBeRemoved?: boolean;
+  onRemove?: UseFieldArrayRemove;
   subContactTemplate?: boolean;
   renderSubContact?: (
     subContactIndex: number,
@@ -25,7 +26,8 @@ interface Props<T> {
 const Contact = <T,>({
   contactType,
   index,
-  onRemoveContact,
+  canBeRemoved = true,
+  onRemove,
   renderSubContact,
   subContactTemplate = false,
   subContactPath,
@@ -59,11 +61,11 @@ const Contact = <T,>({
   return (
     <>
       <Flex justify="right" align="center" mb="var(--spacing-s)">
-        {onRemoveContact && (
+        {canBeRemoved && onRemove && (
           <Button
             variant="supplementary"
             iconLeft={<IconCross aria-hidden />}
-            onClick={() => onRemoveContact(index)}
+            onClick={() => onRemove(index)}
           >
             {t(`form:yhteystiedot:buttons:remove:${contactType}`)}
           </Button>

--- a/src/domain/forms/components/Contact.tsx
+++ b/src/domain/forms/components/Contact.tsx
@@ -44,7 +44,8 @@ const Contact = <T,>({
 
   const addSubContact = useCallback(() => {
     appendSubContact(emptySubContact);
-  }, [appendSubContact, emptySubContact]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appendSubContact]);
 
   useEffect(() => {
     if (subContactFields.length === 0 && subContactTemplate) {

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -235,14 +235,17 @@ describe('HankeForm', () => {
     await user.click(screen.getByText(/rakennuttajan tiedot/i));
     await user.click(screen.getByText(/lisää rakennuttaja/i));
     expect(screen.getAllByText('Rakennuttaja')).toHaveLength(1);
+    expect(screen.getAllByRole('tablist')[1].childElementCount).toBe(1); // initially there is one contact
 
     await user.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
     await user.click(screen.getByText(/yksityishenkilö/i));
     expect(screen.getAllByLabelText(/y-tunnus/i)[1]).toBeDisabled();
 
     await user.click(screen.getAllByText(/lisää yhteyshenkilö/i)[1]);
-    expect(screen.getAllByRole('tablist')[1].childElementCount).toBe(2); // many contacts can be added
+    await user.click(screen.getAllByText(/lisää yhteyshenkilö/i)[1]);
+    expect(screen.getAllByRole('tablist')[1].childElementCount).toBe(3); // many contacts can be added
 
+    await user.click(screen.getByText(/poista yhteyshenkilö/i));
     await user.click(screen.getByText(/poista yhteyshenkilö/i));
     expect(screen.queryByText(/poista yhteyshenkilö/i)).not.toBeInTheDocument(); // cannot remove last one
 

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -254,7 +254,7 @@ describe('HankeForm', () => {
     await user.click(screen.getByText(/lisää rakennuttaja/i)); // add second rakennuttaja
     expect(screen.getAllByText('Rakennuttaja')).toHaveLength(2);
     await user.click(screen.getAllByText(/poista rakennuttaja/i)[1]); // remove second rakennuttaja
-    await user.click(screen.getByText(/poista rakennuttaja/i)); // remove first (and last) rakennuttajaqq
+    await user.click(screen.getByText(/poista rakennuttaja/i)); // remove first (and last) rakennuttaja
     expect(screen.queryByText('Rakennuttaja')).not.toBeInTheDocument();
 
     // Check Other types are present and clickable

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -200,6 +200,7 @@ describe('HankeForm', () => {
     // Hanke owner
     await user.click(screen.getByText(/hankkeen omistajan tiedot/i));
     await user.click(screen.getByText(/lisää omistaja/i));
+    expect(screen.getAllByRole('tablist')[0].childElementCount).toBe(1); // initially there is one contact
 
     await user.click(screen.getByRole('button', { name: /tyyppi/i }));
     await user.click(screen.getByText(/yritys/i));

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -197,10 +197,9 @@ describe('HankeForm', () => {
   test('Yhteystiedot can be filled', async () => {
     const { user } = await setupYhteystiedotPage(<HankeFormContainer hankeTunnus="HAI22-1" />);
 
-    // Hanke owner
-    await user.click(screen.getByText(/hankkeen omistajan tiedot/i));
-    await user.click(screen.getByText(/lisää omistaja/i));
-    expect(screen.getAllByRole('tablist')[0].childElementCount).toBe(1); // initially there is one contact
+    // Hanke owner (accordion open by default)
+    expect(screen.getAllByRole('tablist')[0].childElementCount).toBe(1); // initially there is one sub-contact
+    expect(screen.queryByText(/poista yhteyshenkilö/i)).not.toBeInTheDocument(); // owner sub-contacts cannot all be removed
 
     await user.click(screen.getByRole('button', { name: /tyyppi/i }));
     await user.click(screen.getByText(/yritys/i));
@@ -236,7 +235,7 @@ describe('HankeForm', () => {
     await user.click(screen.getByText(/rakennuttajan tiedot/i));
     await user.click(screen.getByText(/lisää rakennuttaja/i));
     expect(screen.getAllByText('Rakennuttaja')).toHaveLength(1);
-    expect(screen.getAllByRole('tablist')[1].childElementCount).toBe(1); // initially there is one contact
+    expect(screen.getAllByRole('tablist')).toHaveLength(1); // initially there is no sub-contacts for rakennuttaja ('tablist' is only for owner)
 
     await user.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
     await user.click(screen.getByText(/yksityishenkilö/i));
@@ -244,16 +243,19 @@ describe('HankeForm', () => {
 
     await user.click(screen.getAllByText(/lisää yhteyshenkilö/i)[1]);
     await user.click(screen.getAllByText(/lisää yhteyshenkilö/i)[1]);
-    expect(screen.getAllByRole('tablist')[1].childElementCount).toBe(3); // many contacts can be added
+    expect(screen.getAllByRole('tablist')[1].childElementCount).toBe(2); // many contacts can be added
 
+    expect(screen.queryByText(/poista yhteyshenkilö/i)).toBeInTheDocument(); // first sub-contact can be removed
     await user.click(screen.getByText(/poista yhteyshenkilö/i));
+    expect(screen.queryByText(/poista yhteyshenkilö/i)).toBeInTheDocument(); // second (and last) sub-contact can be removed
     await user.click(screen.getByText(/poista yhteyshenkilö/i));
-    expect(screen.queryByText(/poista yhteyshenkilö/i)).not.toBeInTheDocument(); // cannot remove last one
+    expect(screen.queryByText(/poista yhteyshenkilö/i)).not.toBeInTheDocument(); // all contacts can be removed (except for owner)
 
-    await user.click(screen.getByText(/lisää rakennuttaja/i));
+    await user.click(screen.getByText(/lisää rakennuttaja/i)); // add second rakennuttaja
     expect(screen.getAllByText('Rakennuttaja')).toHaveLength(2);
-    await user.click(screen.getAllByText(/poista rakennuttaja/i)[1]);
-    await user.click(screen.getByText(/poista rakennuttaja/i));
+    await user.click(screen.getAllByText(/poista rakennuttaja/i)[1]); // remove second rakennuttaja
+    await user.click(screen.getByText(/poista rakennuttaja/i)); // remove first (and last) rakennuttajaqq
+    expect(screen.queryByText('Rakennuttaja')).not.toBeInTheDocument();
 
     // Check Other types are present and clickable
     await user.click(screen.getByText(/toteuttajan tiedot/i));

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -272,7 +272,6 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               subContactPath={`${HANKE_CONTACT_TYPE.RAKENNUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
               subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
-              showInitialEmpty={true}
               renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
                 const fieldPath = `${HANKE_CONTACT_TYPE.RAKENNUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (
@@ -333,7 +332,6 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               subContactPath={`${HANKE_CONTACT_TYPE.TOTEUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
               subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
-              showInitialEmpty={true}
               renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
                 const fieldPath = `${HANKE_CONTACT_TYPE.TOTEUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (
@@ -396,7 +394,6 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               subContactPath={`${HANKE_CONTACT_TYPE.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
               subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
-              showInitialEmpty={true}
               renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
                 const subContactFieldPath = `${HANKE_CONTACT_TYPE.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -200,6 +200,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
         language={locale}
         headingLevel={3}
         heading={t('form:yhteystiedot:titles:omistajaInfo')}
+        initiallyOpen={Array.isArray(omistajat) && omistajat.length > 0}
       >
         {omistajat.map((item, index) => {
           return (
@@ -211,12 +212,12 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               subContactPath={`${HANKE_CONTACT_TYPE.OMISTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
               subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
-              renderSubContact={(subContactIndex, removeSubContact) => {
+              renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
                 const fieldPath = `${HANKE_CONTACT_TYPE.OMISTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (
                   <SubContactFields
                     fieldPath={fieldPath}
-                    canBeRemoved={subContactIndex > 0}
+                    canBeRemoved={subContactCount > 1}
                     onRemove={() => removeSubContact(subContactIndex)}
                   />
                 );
@@ -259,6 +260,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
         language={locale}
         headingLevel={3}
         heading={t('form:yhteystiedot:titles:propertyDeveloperInfo')}
+        initiallyOpen={Array.isArray(rakennuttajat) && rakennuttajat.length > 0}
       >
         {rakennuttajat.map((item, index) => {
           return (
@@ -270,12 +272,12 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               subContactPath={`${HANKE_CONTACT_TYPE.RAKENNUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
               subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
-              renderSubContact={(subContactIndex, removeSubContact) => {
+              renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
                 const fieldPath = `${HANKE_CONTACT_TYPE.RAKENNUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (
                   <SubContactFields
                     fieldPath={fieldPath}
-                    canBeRemoved={subContactIndex > 0}
+                    canBeRemoved={subContactCount > 1}
                     onRemove={() => removeSubContact(subContactIndex)}
                   />
                 );
@@ -318,6 +320,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
         language={locale}
         headingLevel={3}
         heading={t('form:yhteystiedot:titles:implementerInfo')}
+        initiallyOpen={Array.isArray(toteuttajat) && toteuttajat.length > 0}
       >
         {toteuttajat.map((item, index) => {
           return (
@@ -329,12 +332,12 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               subContactPath={`${HANKE_CONTACT_TYPE.TOTEUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
               subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
-              renderSubContact={(subContactIndex, removeSubContact) => {
+              renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
                 const fieldPath = `${HANKE_CONTACT_TYPE.TOTEUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (
                   <SubContactFields
                     fieldPath={fieldPath}
-                    canBeRemoved={subContactIndex > 0}
+                    canBeRemoved={subContactCount > 1}
                     onRemove={() => removeSubContact(subContactIndex)}
                   />
                 );
@@ -377,6 +380,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
         language={locale}
         headingLevel={3}
         heading={t('form:yhteystiedot:titles:otherInfo')}
+        initiallyOpen={Array.isArray(muutTahot) && muutTahot.length > 0}
       >
         {muutTahot.map((item, index) => {
           const fieldPath = `${FORMFIELD.MUUTTAHOT}.${index}`;
@@ -390,12 +394,12 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               subContactPath={`${HANKE_CONTACT_TYPE.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
               subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
-              renderSubContact={(subContactIndex, removeSubContact) => {
+              renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
                 const subContactFieldPath = `${HANKE_CONTACT_TYPE.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (
                   <SubContactFields
                     fieldPath={subContactFieldPath}
-                    canBeRemoved={subContactIndex > 0}
+                    canBeRemoved={subContactCount > 1}
                     onRemove={() => removeSubContact(subContactIndex)}
                   />
                 );

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -270,7 +270,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
         language={locale}
         headingLevel={3}
         heading={t('form:yhteystiedot:titles:propertyDeveloperInfo')}
-        initiallyOpen={Array.isArray(rakennuttajat) && rakennuttajat.length > 0}
+        initiallyOpen={rakennuttajat.length > 0}
       >
         {rakennuttajat.map((item, index) => {
           return (
@@ -328,7 +328,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
         language={locale}
         headingLevel={3}
         heading={t('form:yhteystiedot:titles:implementerInfo')}
-        initiallyOpen={Array.isArray(toteuttajat) && toteuttajat.length > 0}
+        initiallyOpen={toteuttajat.length > 0}
       >
         {toteuttajat.map((item, index) => {
           return (
@@ -386,7 +386,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
         language={locale}
         headingLevel={3}
         heading={t('form:yhteystiedot:titles:otherInfo')}
-        initiallyOpen={Array.isArray(muutTahot) && muutTahot.length > 0}
+        initiallyOpen={muutTahot.length > 0}
       >
         {muutTahot.map((item, index) => {
           const fieldPath = `${FORMFIELD.MUUTTAHOT}.${index}`;

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -272,6 +272,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               subContactPath={`${HANKE_CONTACT_TYPE.RAKENNUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
               subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
+              showInitialEmpty={true}
               renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
                 const fieldPath = `${HANKE_CONTACT_TYPE.RAKENNUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (
@@ -332,6 +333,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               subContactPath={`${HANKE_CONTACT_TYPE.TOTEUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
               subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
+              showInitialEmpty={true}
               renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
                 const fieldPath = `${HANKE_CONTACT_TYPE.TOTEUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (
@@ -394,6 +396,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               subContactPath={`${HANKE_CONTACT_TYPE.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
               subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
+              showInitialEmpty={true}
               renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
                 const subContactFieldPath = `${HANKE_CONTACT_TYPE.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { $enum } from 'ts-enum-util';
 import { Accordion, Button, Fieldset, IconCross, IconPlusCircle } from 'hds-react';
@@ -61,11 +61,13 @@ function getEmptySubContact(): HankeSubContact {
   };
 }
 
-const SubContactFields: React.FC<{
+interface SubContactFieldProps {
   fieldPath: string;
-  canBeRemoved: boolean;
+  canBeRemoved?: boolean;
   onRemove: () => void;
-}> = ({ fieldPath, canBeRemoved, onRemove }) => {
+}
+
+const SubContactFields = ({ fieldPath, canBeRemoved = true, onRemove }: SubContactFieldProps) => {
   const { t } = useTranslation();
 
   return (
@@ -78,24 +80,20 @@ const SubContactFields: React.FC<{
         <TextInput
           name={`${fieldPath}.${SUBCONTACT_FORMFIELD.ETUNIMI}`}
           label={t(`form:yhteystiedot:labels:${SUBCONTACT_FORMFIELD.ETUNIMI}`)}
-          required
         />
         <TextInput
           name={`${fieldPath}.${SUBCONTACT_FORMFIELD.SUKUNIMI}`}
           label={t(`form:yhteystiedot:labels:${SUBCONTACT_FORMFIELD.SUKUNIMI}`)}
-          required
         />
       </ResponsiveGrid>
       <ResponsiveGrid>
         <TextInput
           name={`${fieldPath}.${SUBCONTACT_FORMFIELD.EMAIL}`}
           label={t(`form:yhteystiedot:labels:${SUBCONTACT_FORMFIELD.EMAIL}`)}
-          required
         />
         <TextInput
           name={`${fieldPath}.${SUBCONTACT_FORMFIELD.PUHELINNUMERO}`}
           label={t(`form:yhteystiedot:labels:${SUBCONTACT_FORMFIELD.PUHELINNUMERO}`)}
-          required
         />
         {canBeRemoved && (
           <Button
@@ -189,6 +187,17 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
     name: FORMFIELD.MUUTTAHOT,
   });
 
+  const addOmistaja = useCallback(() => {
+    appendOmistaja(getEmptyContact());
+  }, [appendOmistaja]);
+
+  // initialize Omistaja to have at least one contact
+  useEffect(() => {
+    if (omistajat.length === 0) {
+      addOmistaja();
+    }
+  }, [omistajat, addOmistaja]);
+
   return (
     <div className="form2">
       <Text tag="p" styleAs="body-m" spacingBottom="s">
@@ -200,7 +209,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
         language={locale}
         headingLevel={3}
         heading={t('form:yhteystiedot:titles:omistajaInfo')}
-        initiallyOpen={Array.isArray(omistajat) && omistajat.length > 0}
+        initiallyOpen={true}
       >
         {omistajat.map((item, index) => {
           return (
@@ -208,7 +217,8 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.OMISTAJAT}
               index={index}
-              onRemoveContact={removeOmistaja}
+              canBeRemoved={omistajat.length > 1}
+              onRemove={removeOmistaja}
               subContactPath={`${HANKE_CONTACT_TYPE.OMISTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
               subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
@@ -268,16 +278,14 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.RAKENNUTTAJAT}
               index={index}
-              onRemoveContact={removeRakennuttaja}
+              onRemove={removeRakennuttaja}
               subContactPath={`${HANKE_CONTACT_TYPE.RAKENNUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
-              subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
-              renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
+              renderSubContact={(subContactIndex, _, removeSubContact) => {
                 const fieldPath = `${HANKE_CONTACT_TYPE.RAKENNUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (
                   <SubContactFields
                     fieldPath={fieldPath}
-                    canBeRemoved={subContactCount > 1}
                     onRemove={() => removeSubContact(subContactIndex)}
                   />
                 );
@@ -328,16 +336,14 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.TOTEUTTAJAT}
               index={index}
-              onRemoveContact={removeToteuttaja}
+              onRemove={removeToteuttaja}
               subContactPath={`${HANKE_CONTACT_TYPE.TOTEUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
-              subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
-              renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
+              renderSubContact={(subContactIndex, _, removeSubContact) => {
                 const fieldPath = `${HANKE_CONTACT_TYPE.TOTEUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (
                   <SubContactFields
                     fieldPath={fieldPath}
-                    canBeRemoved={subContactCount > 1}
                     onRemove={() => removeSubContact(subContactIndex)}
                   />
                 );
@@ -390,16 +396,14 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.MUUTTAHOT}
               index={index}
-              onRemoveContact={removeMuuTaho}
+              onRemove={removeMuuTaho}
               subContactPath={`${HANKE_CONTACT_TYPE.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
-              subContactTemplate={true}
               emptySubContact={getEmptySubContact()}
-              renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
+              renderSubContact={(subContactIndex, _, removeSubContact) => {
                 const subContactFieldPath = `${HANKE_CONTACT_TYPE.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
                 return (
                   <SubContactFields
                     fieldPath={subContactFieldPath}
-                    canBeRemoved={subContactCount > 1}
                     onRemove={() => removeSubContact(subContactIndex)}
                   />
                 );

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -41,7 +41,7 @@ const contactSchema = yup
       }),
     [CONTACT_FORMFIELD.EMAIL]: yup.string().email().max(100),
     [CONTACT_FORMFIELD.PUHELINNUMERO]: yup.string().nullable().default(null).max(20),
-    [CONTACT_FORMFIELD.ALIKONTAKTIT]: yup.array().ensure().of(subContactSchema),
+    [CONTACT_FORMFIELD.ALIKONTAKTIT]: yup.array().ensure().of(subContactSchema).required().min(1),
   });
 
 const otherPartySchema = contactSchema

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -17,10 +17,10 @@ const subContactSchema = yup
   .nullable()
   .default(null)
   .shape({
-    [SUBCONTACT_FORMFIELD.SUKUNIMI]: yup.string().max(50).required(),
-    [SUBCONTACT_FORMFIELD.ETUNIMI]: yup.string().max(50).required(),
-    [SUBCONTACT_FORMFIELD.EMAIL]: yup.string().email().max(100).required(),
-    [SUBCONTACT_FORMFIELD.PUHELINNUMERO]: yup.string().nullable().default(null).max(20).required(),
+    [SUBCONTACT_FORMFIELD.SUKUNIMI]: yup.string().max(50),
+    [SUBCONTACT_FORMFIELD.ETUNIMI]: yup.string().max(50),
+    [SUBCONTACT_FORMFIELD.EMAIL]: yup.string().email().max(100),
+    [SUBCONTACT_FORMFIELD.PUHELINNUMERO]: yup.string().nullable().default(null).max(20),
   });
 
 const contactSchema = yup
@@ -29,7 +29,11 @@ const contactSchema = yup
   .default(null)
   .shape({
     [CONTACT_FORMFIELD.NIMI]: yup.string().max(100),
-    [CONTACT_FORMFIELD.TYYPPI]: yup.string().oneOf($enum(CONTACT_TYYPPI).getValues()),
+    [CONTACT_FORMFIELD.TYYPPI]: yup
+      .mixed()
+      .nullable()
+      .oneOf([null, ...$enum(CONTACT_TYYPPI).getValues()])
+      .notRequired(),
     [CONTACT_FORMFIELD.TUNNUS]: yup
       .string()
       .nullable()
@@ -41,7 +45,7 @@ const contactSchema = yup
       }),
     [CONTACT_FORMFIELD.EMAIL]: yup.string().email().max(100),
     [CONTACT_FORMFIELD.PUHELINNUMERO]: yup.string().nullable().default(null).max(20),
-    [CONTACT_FORMFIELD.ALIKONTAKTIT]: yup.array().ensure().of(subContactSchema).required().min(1),
+    [CONTACT_FORMFIELD.ALIKONTAKTIT]: yup.array().ensure().of(subContactSchema),
   });
 
 const otherPartySchema = contactSchema

--- a/src/domain/johtoselvitys/Contacts.tsx
+++ b/src/domain/johtoselvitys/Contacts.tsx
@@ -326,7 +326,7 @@ export const Contacts: React.FC<{ hankeContacts?: HankeContacts }> = ({ hankeCon
         contactType="customerWithContacts"
         subContactPath="applicationData.customerWithContacts.contacts"
         emptySubContact={getEmptyContact()}
-        renderSubContact={(subContactIndex, removeSubContact) => {
+        renderSubContact={(subContactIndex, _subContactCount, removeSubContact) => {
           return (
             <ContactFields
               customerType="customerWithContacts"
@@ -355,7 +355,7 @@ export const Contacts: React.FC<{ hankeContacts?: HankeContacts }> = ({ hankeCon
           contactType="contractorWithContacts"
           subContactPath="applicationData.contractorWithContacts.contacts"
           emptySubContact={getEmptyContact()}
-          renderSubContact={(subContactIndex, removeSubContact) => {
+          renderSubContact={(subContactIndex, _subContactCount, removeSubContact) => {
             return (
               <ContactFields
                 customerType="contractorWithContacts"
@@ -387,7 +387,7 @@ export const Contacts: React.FC<{ hankeContacts?: HankeContacts }> = ({ hankeCon
             onRemoveContact={handleRemovePropertyDeveloper}
             subContactPath="applicationData.propertyDeveloperWithContacts.contacts"
             emptySubContact={getEmptyContact()}
-            renderSubContact={(subContactIndex, removeSubContact) => {
+            renderSubContact={(subContactIndex, _subContactCount, removeSubContact) => {
               return (
                 <ContactFields
                   customerType="propertyDeveloperWithContacts"
@@ -430,7 +430,7 @@ export const Contacts: React.FC<{ hankeContacts?: HankeContacts }> = ({ hankeCon
             onRemoveContact={handleRemoveRepresentative}
             subContactPath="applicationData.representativeWithContacts.contacts"
             emptySubContact={getEmptyContact()}
-            renderSubContact={(subContactIndex, removeSubContact) => {
+            renderSubContact={(subContactIndex, _subContactCount, removeSubContact) => {
               return (
                 <ContactFields
                   customerType="representativeWithContacts"

--- a/src/domain/johtoselvitys/Contacts.tsx
+++ b/src/domain/johtoselvitys/Contacts.tsx
@@ -384,7 +384,7 @@ export const Contacts: React.FC<{ hankeContacts?: HankeContacts }> = ({ hankeCon
         {isPropertyDeveloper && (
           <Contact<CustomerType>
             contactType="propertyDeveloperWithContacts"
-            onRemoveContact={handleRemovePropertyDeveloper}
+            onRemove={handleRemovePropertyDeveloper}
             subContactPath="applicationData.propertyDeveloperWithContacts.contacts"
             emptySubContact={getEmptyContact()}
             renderSubContact={(subContactIndex, _subContactCount, removeSubContact) => {
@@ -427,7 +427,7 @@ export const Contacts: React.FC<{ hankeContacts?: HankeContacts }> = ({ hankeCon
         {isRepresentative && (
           <Contact<CustomerType>
             contactType="representativeWithContacts"
-            onRemoveContact={handleRemoveRepresentative}
+            onRemove={handleRemoveRepresentative}
             subContactPath="applicationData.representativeWithContacts.contacts"
             emptySubContact={getEmptyContact()}
             renderSubContact={(subContactIndex, _subContactCount, removeSubContact) => {

--- a/src/domain/types/hanke.ts
+++ b/src/domain/types/hanke.ts
@@ -108,7 +108,7 @@ export interface HankeContact {
   email: string;
   puhelinnumero: string;
   ytunnus: string | null;
-  alikontaktit?: HankeSubContact[];
+  alikontaktit: HankeSubContact[];
 }
 
 export type HankeMuuTaho = {
@@ -118,7 +118,7 @@ export type HankeMuuTaho = {
   osasto: string;
   email: string;
   puhelinnumero?: string;
-  alikontaktit?: HankeSubContact[];
+  alikontaktit: HankeSubContact[];
 };
 
 export type HankeContacts = Array<(HankeContact | HankeMuuTaho)[] | undefined>;


### PR DESCRIPTION
# Description

- owner section is initially open and that owner have initially one contact person
- constructor, implementor and other have initially no contacts (or contact persons)
- all contacts and contact persons can be removed - except for owner which has to have one contact and contact person
- if there are constructor, implementor or other types of contacts, that section should be open by default (owner section is open because it has at least one contact which has at least one contact person)
- contact type can have empty value without validation error message
- contact person can have empty data without validation error messages
- contact person fields have no asterisk (*) marking them mandatory

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2091

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing
Create a new or open an existing Hanke. See that contacts and contact persons behave as described above.


# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
