### PR TITLE
HAI-2071 Only one contact person for owner

### DIFF
--- a/src/domain/forms/components/Contact.tsx
+++ b/src/domain/forms/components/Contact.tsx
@@ -44,7 +44,8 @@ const Contact = <T,>({
 
   const addSubContact = useCallback(() => {
     appendSubContact(emptySubContact);
-  }, [appendSubContact, emptySubContact]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appendSubContact]);
 
   useEffect(() => {
     if (subContactFields.length === 0 && subContactTemplate) {

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -144,6 +144,7 @@ describe('HankeForm', () => {
     // Hanke owner
     await user.click(screen.getByText(/hankkeen omistajan tiedot/i));
     await user.click(screen.getByText(/lisää omistaja/i));
+    expect(screen.getAllByRole('tablist')[0].childElementCount).toBe(1); // initially there is one contact
 
     await user.click(screen.getByRole('button', { name: /tyyppi/i }));
     await user.click(screen.getByText(/yritys/i));


### PR DESCRIPTION
# Description

Hanke owner should have only one contact person by default.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2071

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Create a new Hanke, open Yhteystiedot (after filling previous sections), when adding a new owner there should be only one contact person for it.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
