### PR TITLE
HAI-1787 Add cable report application link to top bar

### DIFF
--- a/src/common/components/header/Header.test.tsx
+++ b/src/common/components/header/Header.test.tsx
@@ -30,6 +30,7 @@ describe('Header', () => {
 
     expect(screen.getByText('Hankkeet yleisillä alueilla')).toBeInTheDocument();
     expect(screen.getByText('Luo uusi hanke')).toBeInTheDocument();
+    expect(screen.getByText('Tee johtoselvityshakemus')).toBeInTheDocument();
     expect(screen.getByText('Omat hankkeet')).toBeInTheDocument();
     expect(screen.getByText('Työohjeet')).toBeInTheDocument();
   });

--- a/src/common/components/header/Header.tsx
+++ b/src/common/components/header/Header.tsx
@@ -17,8 +17,14 @@ const languageLabels = {
 };
 
 const Header: React.FC<React.PropsWithChildren<unknown>> = () => {
-  const { HOME, PUBLIC_HANKKEET, PUBLIC_HANKKEET_MAP, HANKEPORTFOLIO, NEW_HANKE } =
-    useLocalizedRoutes();
+  const {
+    HOME,
+    PUBLIC_HANKKEET,
+    PUBLIC_HANKKEET_MAP,
+    HANKEPORTFOLIO,
+    NEW_HANKE,
+    JOHTOSELVITYSHAKEMUS,
+  } = useLocalizedRoutes();
   const { t, i18n } = useTranslation();
   const { data: user } = useUser();
   const isAuthenticated = Boolean(user?.profile);
@@ -31,6 +37,10 @@ const Header: React.FC<React.PropsWithChildren<unknown>> = () => {
   const isNewHankePath = useMatch({
     path: NEW_HANKE.path,
     end: false,
+  });
+  const isCableReportApplicationPath = useMatch({
+    path: JOHTOSELVITYSHAKEMUS.path,
+    end: true,
   });
   const isHankePortfolioPath = useMatch({
     path: HANKEPORTFOLIO.path,
@@ -82,6 +92,14 @@ const Header: React.FC<React.PropsWithChildren<unknown>> = () => {
           ) : (
             <></>
           )}
+          <Navigation.Item
+            as={NavLink}
+            to={JOHTOSELVITYSHAKEMUS.path}
+            active={Boolean(isCableReportApplicationPath)}
+            data-testid="cableReportApplicationLink"
+          >
+            {t('homepage:johtotietoselvitys:title')}
+          </Navigation.Item>
           <Navigation.Item
             as={NavLink}
             to={HANKEPORTFOLIO.path}


### PR DESCRIPTION
# Description

Top bar was missing a link to cable report application form so added it there.

### Jira Issue:

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check that "Tee johtoselvityshakemus" link is in top bar and that it takes you to cable report application form.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
