### PR TITLE
HAI-2098 Change application attachments to use new download component

### DIFF
--- a/src/common/components/fileDownloadList/FileDownloadList.tsx
+++ b/src/common/components/fileDownloadList/FileDownloadList.tsx
@@ -2,12 +2,15 @@ import { IconDocument } from 'hds-react';
 import FileDownloadLink from '../fileDownloadLink/FileDownloadLink';
 import { AttachmentMetadata } from '../../types/attachment';
 
-type Props = {
-  files: AttachmentMetadata[];
-  fileDownLoadFunction: (file: AttachmentMetadata) => Promise<string>;
+type FileDownloadListProps<T extends AttachmentMetadata> = {
+  files: T[];
+  download: (file: T) => Promise<string>;
 };
 
-export default function FileDownloadList({ files, fileDownLoadFunction }: Readonly<Props>) {
+export default function FileDownloadList<T extends AttachmentMetadata>({
+  files,
+  download,
+}: Readonly<FileDownloadListProps<T>>) {
   return (
     <ul>
       {files.map((file) => (
@@ -17,7 +20,7 @@ export default function FileDownloadList({ files, fileDownLoadFunction }: Readon
             linkText={file.fileName}
             fileName={file.fileName}
             queryKey={['attachmentContent', file.id]}
-            queryFunction={() => fileDownLoadFunction(file)}
+            queryFunction={() => download(file)}
           />
         </li>
       ))}

--- a/src/domain/application/components/AttachmentSummary.tsx
+++ b/src/domain/application/components/AttachmentSummary.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { IconDocument } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import {
   FormSummarySection,
@@ -7,6 +6,8 @@ import {
   SectionItemTitle,
 } from '../../forms/components/FormSummarySection';
 import { ApplicationAttachmentMetadata } from '../types/application';
+import FileDownloadList from '../../../common/components/fileDownloadList/FileDownloadList';
+import { getAttachmentFile } from '../attachments';
 
 type Props = {
   attachments: ApplicationAttachmentMetadata[];
@@ -15,16 +16,14 @@ type Props = {
 function AttachmentSummary({ attachments }: Props) {
   const { t } = useTranslation();
 
+  const download = (file: ApplicationAttachmentMetadata) =>
+    getAttachmentFile(file.applicationId, file.id);
+
   return (
     <FormSummarySection>
       <SectionItemTitle>{t('hankePortfolio:tabit:liitteet')}</SectionItemTitle>
       <SectionItemContent>
-        {attachments.map((attachment) => (
-          <p key={attachment.id}>
-            <IconDocument aria-hidden size="xs" style={{ marginRight: 'var(--spacing-3-xs)' }} />
-            {attachment.fileName}
-          </p>
-        ))}
+        <FileDownloadList files={attachments} download={download} />
       </SectionItemContent>
     </FormSummarySection>
   );

--- a/src/domain/hanke/edit/components/AttachmentSummary.tsx
+++ b/src/domain/hanke/edit/components/AttachmentSummary.tsx
@@ -17,15 +17,13 @@ type Props = {
 function AttachmentSummary({ hankeTunnus, attachments }: Readonly<Props>) {
   const { t } = useTranslation();
 
-  function downloadFile(file: AttachmentMetadata) {
-    return getAttachmentFile(hankeTunnus, file.id);
-  }
+  const download = (file: AttachmentMetadata) => getAttachmentFile(hankeTunnus, file.id);
 
   return (
     <FormSummarySection>
       <SectionItemTitle>{t('form:labels:addedFiles')}</SectionItemTitle>
       <SectionItemContent>
-        <FileDownloadList files={attachments} fileDownLoadFunction={downloadFile} />
+        <FileDownloadList files={attachments} download={download} />
       </SectionItemContent>
     </FormSummarySection>
   );

--- a/src/domain/hanke/hooks/useNavigateToApplicationList.ts
+++ b/src/domain/hanke/hooks/useNavigateToApplicationList.ts
@@ -18,7 +18,7 @@ function useNavigateToApplicationList(hankeTunnus?: string) {
       ? getHankeViewPath({ hankeTunnus: hankeTunnusToUse })
       : HANKEPORTFOLIO.path;
 
-    navigate(path, { state: { initiallyActiveTab: 4 } });
+    navigate(path, { state: { initiallyActiveTab: 5 } });
   }
 
   return navigateToApplicationList;

--- a/src/domain/hanke/portfolio/HankePortfolio.test.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolio.test.tsx
@@ -37,7 +37,7 @@ const initSignedInUserResponse = (response: SignedInUserByHanke) => {
   );
 };
 
-describe('HankePortfolio', () => {
+describe('HankePortfolioComponent', () => {
   test('Changing search text filters correct number of projects', async () => {
     const { user } = render(
       <HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />,

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -10,7 +10,6 @@ import hankkeet from '../mocks/data/hankkeet-data';
 import applications from '../mocks/data/hakemukset-data';
 import { JohtoselvitysFormValues } from './types';
 import * as applicationApi from '../application/utils';
-import * as attachmentApi from '../application/attachments';
 import api from '../api/api';
 import {
   Application,
@@ -762,7 +761,7 @@ test('Should list existing attachments in the attachments page and in summary pa
 
 test('Summary should show attachments and they are downloadable', async () => {
   const fetchContentMock = jest
-    .spyOn(attachmentApi, 'getAttachmentFile')
+    .spyOn(applicationAttachmentsApi, 'getAttachmentFile')
     .mockImplementation(jest.fn());
 
   const testApplication = applications[0];


### PR DESCRIPTION
# Description

HAI-2098 Change application attachments to use new download component

Use new file download component and also provide attachments as downloadable in application summary.

Additional: Fix bug in useNavigationToApplicationList which led to wrong initially open tab.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2098

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Add attachment(s) for johtoselvitys
2. Verify from summary page that the files can be downloaded and are correct files.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
