### PR TITLE
HAI-2060 Fix homepage links in login error page

### DIFF
--- a/src/domain/auth/components/OidcCallback.test.tsx
+++ b/src/domain/auth/components/OidcCallback.test.tsx
@@ -27,11 +27,12 @@ describe('<OidcCallback />', () => {
   it('as a user I want to see an generic error message about failed authentication', async () => {
     jest.spyOn(authService, 'endLogin').mockRejectedValue(new Error('foobar'));
 
-    const { queryByText } = getWrapper();
+    const { queryByText, getByRole } = getWrapper();
 
     await waitFor(() =>
       expect(queryByText('Kirjautumisessa tapahtui virhe. Yritä uudestaan.')).toBeInTheDocument(),
     );
+    expect(getByRole('link', { name: 'etusivulle.' })).toHaveAttribute('href', '/fi/');
   });
 
   it('as a user I want to see an error message about incorrect device time, because only I can fix it', async () => {

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -14,6 +14,7 @@ i18n
       fi,
       sv,
     },
+    supportedLngs: ['fi', 'sv', 'en'],
     detection: {
       order: ['path', 'localStorage', 'sessionStorage'],
       excludeCacheFor: ['login'],


### PR DESCRIPTION
# Description

There was a problem in links back to homepage in login error page that user is directed to after failed login. Links had href /login instead of /fi, /sv or /en based on language, which was caused by language being set to 'login'. Fixed that by defining supportedLngs in i18n init options.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2060

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Change REACT_APP_OIDC_CLIENT_ID from 'haitaton-admin-ui-dev' to 'haitaton-ui-dev' in .env to use Suomi.fi login
2. Click 'Log in' in the top bar
3. Cancel the login in Suomi.fi
4. Link to front page in the Haitaton error page should take you to Haitaton front page

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
