### PR TITLE
HAI-1811 Fix focus on page change

### DIFF
--- a/src/common/components/mainHeading/MainHeading.tsx
+++ b/src/common/components/mainHeading/MainHeading.tsx
@@ -1,0 +1,22 @@
+import { SKIP_TO_ELEMENT_ID } from '../../constants/constants';
+import Text, { Props as TextProps } from '../text/Text';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function MainHeading({ children, ...rest }: Readonly<Props & Partial<TextProps>>) {
+  return (
+    <Text
+      tag="h1"
+      styleAs="h1"
+      weight="bold"
+      id={SKIP_TO_ELEMENT_ID}
+      tabIndex={-1}
+      aria-live="polite"
+      {...rest}
+    >
+      {children}
+    </Text>
+  );
+}

--- a/src/common/components/scrollToTop/ScrollToTop.test.tsx
+++ b/src/common/components/scrollToTop/ScrollToTop.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '../../../testUtils/render';
+import ScrollToTop from './ScrollToTop';
+
+test('Focus should be on the div after route change', () => {
+  render(<ScrollToTop />, undefined, '/fi/');
+
+  expect(screen.getByTestId('scroll-to-top-div')).toHaveFocus();
+});

--- a/src/common/components/scrollToTop/ScrollToTop.tsx
+++ b/src/common/components/scrollToTop/ScrollToTop.tsx
@@ -13,5 +13,5 @@ export default function ScrollToTop() {
     ref.current?.focus();
   }, [pathname]);
 
-  return <div ref={ref} tabIndex={-1} />;
+  return <div ref={ref} tabIndex={-1} data-testid="scroll-to-top-div" />;
 }

--- a/src/common/components/scrollToTop/ScrollToTop.tsx
+++ b/src/common/components/scrollToTop/ScrollToTop.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
 /**
@@ -6,10 +6,12 @@ import { useLocation } from 'react-router-dom';
  */
 export default function ScrollToTop() {
   const { pathname } = useLocation();
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     window.scrollTo(0, 0);
+    ref.current?.focus();
   }, [pathname]);
 
-  return null;
+  return <div ref={ref} tabIndex={-1} />;
 }

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -4,7 +4,6 @@ import { Box } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import Geometry from 'ol/geom/Geometry';
 import Text from '../../../common/components/text/Text';
-import { SKIP_TO_ELEMENT_ID } from '../../../common/constants/constants';
 import {
   InformationViewContainer,
   InformationViewContentContainer,
@@ -39,6 +38,7 @@ import AttachmentSummary from '../components/AttachmentSummary';
 import useAttachments from '../hooks/useAttachments';
 import FeatureFlags from '../../../common/components/featureFlags/FeatureFlags';
 import { CheckRightsByHanke } from '../../hanke/hankeUsers/UserRightsCheck';
+import MainHeading from '../../../common/components/mainHeading/MainHeading';
 
 type Props = {
   application: Application;
@@ -81,9 +81,7 @@ function ApplicationView({ application, hanke, onEditApplication }: Props) {
   return (
     <InformationViewContainer>
       <InformationViewHeader backgroundColor="var(--color-suomenlinna-light)">
-        <Text tag="h1" styleAs="h1" weight="bold" id={SKIP_TO_ELEMENT_ID} tabIndex={-1}>
-          {name}
-        </Text>
+        <MainHeading>{name}</MainHeading>
         <Text tag="h2" styleAs="h3" weight="bold" spacingBottom="l">
           {applicationId}
         </Text>

--- a/src/domain/forms/MultipageForm.tsx
+++ b/src/domain/forms/MultipageForm.tsx
@@ -6,7 +6,7 @@ import useLocale from '../../common/hooks/useLocale';
 import Text from '../../common/components/text/Text';
 import { createStepReducer } from './formStepReducer';
 import { Action, ACTION_TYPE, StepperStep } from './types';
-import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
+import MainHeading from '../../common/components/mainHeading/MainHeading';
 
 function LoadingIndicator({ loadingText }: { loadingText?: string }) {
   return (
@@ -118,9 +118,7 @@ const MultipageForm: React.FC<Props> = ({
 
   return (
     <form className={styles.formContainer} onSubmit={onSubmit}>
-      <Text tag="h1" styleAs="h1" weight="bold" id={SKIP_TO_ELEMENT_ID} tabIndex={-1}>
-        {heading}
-      </Text>
+      <MainHeading>{heading}</MainHeading>
 
       {subHeading && (
         <Text tag="h2" styleAs="h4" spacingBottom="m">

--- a/src/domain/hanke/accessRights/AccessRightsView.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.tsx
@@ -28,7 +28,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import { $enum } from 'ts-enum-util';
 import { Link } from 'react-router-dom';
 import Text from '../../../common/components/text/Text';
-import { SKIP_TO_ELEMENT_ID } from '../../../common/constants/constants';
 import styles from './AccessRightsView.module.scss';
 import { Language } from '../../../common/types/language';
 import { HankeUser, AccessRightLevel, SignedInUser } from '../hankeUsers/hankeUser';
@@ -36,6 +35,7 @@ import useHankeViewPath from '../hooks/useHankeViewPath';
 import { resendInvitation, updateHankeUsers } from '../hankeUsers/hankeUsersApi';
 import Container from '../../../common/components/container/Container';
 import UserCard from './UserCard';
+import MainHeading from '../../../common/components/mainHeading/MainHeading';
 
 function sortCaseInsensitive(rowOneColumn: string, rowTwoColumn: string) {
   const rowOneColUpperCase = rowOneColumn.toUpperCase();
@@ -293,16 +293,7 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
               {hankeName} ({hankeTunnus})
             </Text>
           </Link>
-          <Text
-            tag="h1"
-            styleAs="h1"
-            weight="bold"
-            spacingBottom="l"
-            id={SKIP_TO_ELEMENT_ID}
-            tabIndex={-1}
-          >
-            {t('hankeUsers:manageRights')}
-          </Text>
+          <MainHeading spacingBottom="l">{t('hankeUsers:manageRights')}</MainHeading>
         </Container>
       </header>
 

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -37,7 +37,6 @@ import OwnHankeMap from '../../map/components/OwnHankeMap/OwnHankeMap';
 import OwnHankeMapHeader from '../../map/components/OwnHankeMap/OwnHankeMapHeader';
 import CompressedAreaIndex from '../hankeIndexes/CompressedAreaIndex';
 import HankeDraftStateNotification from '../edit/components/HankeDraftStateNotification';
-import { SKIP_TO_ELEMENT_ID } from '../../../common/constants/constants';
 import { useApplicationsForHanke } from '../../application/hooks/useApplications';
 import ApplicationList from '../../application/components/ApplicationList';
 import ErrorLoadingText from '../../../common/components/errorLoadingText/ErrorLoadingText';
@@ -55,6 +54,7 @@ import { SignedInUser } from '../hankeUsers/hankeUser';
 import { CheckRightsByHanke } from '../hankeUsers/UserRightsCheck';
 import AttachmentSummary from '../edit/components/AttachmentSummary';
 import useHankeAttachments from '../hankeAttachments/useHankeAttachments';
+import MainHeading from '../../../common/components/mainHeading/MainHeading';
 
 type AreaProps = {
   area: HankeAlue;
@@ -204,9 +204,7 @@ const HankeView: React.FC<Props> = ({
       />
 
       <InformationViewHeader backgroundColor="var(--color-summer-light)">
-        <Text tag="h1" styleAs="h1" weight="bold" id={SKIP_TO_ELEMENT_ID} tabIndex={-1}>
-          {hankeData?.nimi}
-        </Text>
+        <MainHeading>{hankeData?.nimi}</MainHeading>
         <Text tag="h2" styleAs="h3" weight="bold" spacingBottom="l">
           {hankeData?.hankeTunnus}
         </Text>

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -35,12 +35,12 @@ import OwnHankeMap from '../../map/components/OwnHankeMap/OwnHankeMap';
 import OwnHankeMapHeader from '../../map/components/OwnHankeMap/OwnHankeMapHeader';
 import HankeDraftStateNotification from '../edit/components/HankeDraftStateNotification';
 import Container from '../../../common/components/container/Container';
-import { SKIP_TO_ELEMENT_ID } from '../../../common/constants/constants';
 import useHankeViewPath from '../hooks/useHankeViewPath';
 import { useNavigateToApplicationList } from '../hooks/useNavigateToApplicationList';
 import FeatureFlags from '../../../common/components/featureFlags/FeatureFlags';
 import { CheckRightsByUser } from '../hankeUsers/UserRightsCheck';
 import { SignedInUser, SignedInUserByHanke } from '../hankeUsers/hankeUser';
+import MainHeading from '../../../common/components/mainHeading/MainHeading';
 
 type CustomAccordionProps = {
   hanke: HankeData;
@@ -468,17 +468,9 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
     <>
       <div className={styles.headerContainer}>
         <Container>
-          <Text
-            tag="h1"
-            data-testid="HankePortfolioPageHeader"
-            styleAs="h1"
-            spacingBottom="s"
-            weight="bold"
-            id={SKIP_TO_ELEMENT_ID}
-            tabIndex={-1}
-          >
+          <MainHeading data-testid="HankePortfolioPageHeader" spacingBottom="s">
             {t('hankePortfolio:pageHeader')}
-          </Text>
+          </MainHeading>
 
           <div
             className={styles.filters}

--- a/src/domain/homepage/HomepageComponent.tsx
+++ b/src/domain/homepage/HomepageComponent.tsx
@@ -15,12 +15,12 @@ import img4 from './kartta.png';
 import kalasatama from './kalasatama.webp';
 import Linkbox from '../../common/components/Linkbox/Linkbox';
 import useUser from '../auth/useUser';
-import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
 import FeatureFlags from '../../common/components/featureFlags/FeatureFlags';
 import {
   FeatureFlagsContextProps,
   useFeatureFlags,
 } from '../../common/components/featureFlags/FeatureFlagsContext';
+import MainHeading from '../../common/components/mainHeading/MainHeading';
 
 const Homepage: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation();
@@ -130,16 +130,7 @@ const Homepage: React.FC<React.PropsWithChildren<unknown>> = () => {
     <div className={clsx({ [styles.bgWhite]: !isAuthenticated && !features.publicHankkeet })}>
       <div className={styles.heroContainer}>
         <section className={styles.hero}>
-          <Text
-            tag="h1"
-            styleAs="h1"
-            spacing="s"
-            weight="bold"
-            id={SKIP_TO_ELEMENT_ID}
-            tabIndex={-1}
-          >
-            {pageTitle}
-          </Text>
+          <MainHeading spacing="s">{pageTitle}</MainHeading>
           <Text tag="h2" styleAs="h3" spacing="s" weight="bold">
             {pageSubtitle}
           </Text>

--- a/src/domain/mapAndList/MapAndListContainer.tsx
+++ b/src/domain/mapAndList/MapAndListContainer.tsx
@@ -5,25 +5,21 @@ import { IconMap, IconLayers } from 'hds-react/icons';
 import { useTranslation } from 'react-i18next';
 import { Outlet, NavLink } from 'react-router-dom';
 import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
-import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
+import MainHeading from '../../common/components/mainHeading/MainHeading';
 
 const MapAndListContainer: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { PUBLIC_HANKKEET_LIST, PUBLIC_HANKKEET_MAP } = useLocalizedRoutes();
   const { t } = useTranslation();
 
   return (
-    <Flex
-      direction="column"
-      height="100%"
-      marginBottom="var(--spacing-2-xl)"
-      id={SKIP_TO_ELEMENT_ID}
-      tabIndex={-1}
-    >
+    <Flex direction="column" height="100%" marginBottom="var(--spacing-2-xl)">
       <Flex
         margin="var(--spacing-xl) var(--spacing-xl) var(--spacing-l) var(--spacing-xl)"
         justify="center"
       >
-        <h1 className="heading-xl">{t('publicHankkeet:pageHeader')}</h1>
+        <MainHeading className="heading-xl" weight="normal">
+          {t('publicHankkeet:pageHeader')}
+        </MainHeading>
       </Flex>
       <Flex justify="center" align="center" margin="var(--spacing-m)">
         <div>

--- a/src/pages/staticPages/AccessibilityPage.tsx
+++ b/src/pages/staticPages/AccessibilityPage.tsx
@@ -5,7 +5,7 @@ import PageMeta from '../components/PageMeta';
 import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
 import Container from '../../common/components/container/Container';
 import Text from '../../common/components/text/Text';
-import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
+import MainHeading from '../../common/components/mainHeading/MainHeading';
 
 const AccessibilityPage: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { ACCESSIBILITY } = useLocalizedRoutes();
@@ -14,17 +14,9 @@ const AccessibilityPage: React.FC<React.PropsWithChildren<unknown>> = () => {
   return (
     <Container>
       <PageMeta routeData={ACCESSIBILITY} />
-      <Text
-        tag="h1"
-        styleAs="h1"
-        spacingTop="l"
-        spacingBottom="xl"
-        weight="bold"
-        id={SKIP_TO_ELEMENT_ID}
-        tabIndex={-1}
-      >
+      <MainHeading spacingTop="l" spacingBottom="xl">
         {t('staticPages:accessibility:title')}
-      </Text>
+      </MainHeading>
       <HdsContainer style={{ padding: '2rem', backgroundColor: 'white' }}>
         <Text tag="p">
           Tämä saavutettavuusseloste koskee Helsingin kaupungin Haitaton -verkkosivustoa. Sivuston

--- a/src/pages/staticPages/InfoPage.tsx
+++ b/src/pages/staticPages/InfoPage.tsx
@@ -5,7 +5,7 @@ import PageMeta from '../components/PageMeta';
 import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
 import Container from '../../common/components/container/Container';
 import Text from '../../common/components/text/Text';
-import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
+import MainHeading from '../../common/components/mainHeading/MainHeading';
 
 const InfoPage: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { HAITATON_INFO } = useLocalizedRoutes();
@@ -14,17 +14,9 @@ const InfoPage: React.FC<React.PropsWithChildren<unknown>> = () => {
   return (
     <Container>
       <PageMeta routeData={HAITATON_INFO} />
-      <Text
-        tag="h1"
-        styleAs="h1"
-        spacingTop="l"
-        spacingBottom="xl"
-        weight="bold"
-        id={SKIP_TO_ELEMENT_ID}
-        tabIndex={-1}
-      >
+      <MainHeading spacingTop="l" spacingBottom="xl">
         {t('staticPages:infoPage:title')}
-      </Text>
+      </MainHeading>
 
       <HdsContainer style={{ padding: '2rem', backgroundColor: 'white' }}>
         <Text tag="h2" styleAs="h2" spacingBottom="s">

--- a/src/pages/staticPages/ManualPage.tsx
+++ b/src/pages/staticPages/ManualPage.tsx
@@ -5,7 +5,7 @@ import PageMeta from '../components/PageMeta';
 import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
 import Container from '../../common/components/container/Container';
 import Text from '../../common/components/text/Text';
-import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
+import MainHeading from '../../common/components/mainHeading/MainHeading';
 
 const ManualPage: React.FC = () => {
   const { MANUAL } = useLocalizedRoutes();
@@ -14,17 +14,9 @@ const ManualPage: React.FC = () => {
   return (
     <Container>
       <PageMeta routeData={MANUAL} />
-      <Text
-        tag="h1"
-        styleAs="h1"
-        spacingTop="l"
-        spacingBottom="xl"
-        weight="bold"
-        id={SKIP_TO_ELEMENT_ID}
-        tabIndex={-1}
-      >
+      <MainHeading spacingTop="l" spacingBottom="xl">
         {t('staticPages:manualPage:title')}
-      </Text>
+      </MainHeading>
 
       <HdsContainer style={{ padding: '2rem', backgroundColor: 'white' }}>
         <Text tag="p" spacingBottom="s">

--- a/src/pages/staticPages/PrivacyPolicyPage.tsx
+++ b/src/pages/staticPages/PrivacyPolicyPage.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from 'react-i18next';
 import PageMeta from '../components/PageMeta';
 import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
 import Container from '../../common/components/container/Container';
-import Text from '../../common/components/text/Text';
-import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
+import MainHeading from '../../common/components/mainHeading/MainHeading';
 
 const PrivacyPolicyPage: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { PRIVACY_POLICY } = useLocalizedRoutes();
@@ -14,17 +13,9 @@ const PrivacyPolicyPage: React.FC<React.PropsWithChildren<unknown>> = () => {
   return (
     <Container>
       <PageMeta routeData={PRIVACY_POLICY} />
-      <Text
-        tag="h1"
-        styleAs="h1"
-        spacingTop="l"
-        spacingBottom="xl"
-        weight="bold"
-        id={SKIP_TO_ELEMENT_ID}
-        tabIndex={-1}
-      >
+      <MainHeading spacingTop="l" spacingBottom="xl">
         {t('staticPages:privacyPolicy:title')}
-      </Text>
+      </MainHeading>
 
       <HdsContainer style={{ padding: '2rem', backgroundColor: 'white' }}>
         <p style={{ marginBottom: 'var(--spacing-s)' }}>

--- a/src/pages/staticPages/ReferencesPage.tsx
+++ b/src/pages/staticPages/ReferencesPage.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from 'react-i18next';
 import PageMeta from '../components/PageMeta';
 import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
 import Container from '../../common/components/container/Container';
-import Text from '../../common/components/text/Text';
-import { SKIP_TO_ELEMENT_ID } from '../../common/constants/constants';
+import MainHeading from '../../common/components/mainHeading/MainHeading';
 
 const ReferencesPage: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { HAITATON_INFO } = useLocalizedRoutes();
@@ -15,9 +14,7 @@ const ReferencesPage: React.FC<React.PropsWithChildren<unknown>> = () => {
   return (
     <Container>
       <PageMeta routeData={HAITATON_INFO} />
-      <Text tag="h1" styleAs="h2" spacing="s" weight="bold" id={SKIP_TO_ELEMENT_ID} tabIndex={-1}>
-        {t('staticPages:references:title')}
-      </Text>
+      <MainHeading spacing="s">{t('staticPages:references:title')}</MainHeading>
       <HdsContainer style={{ padding: '2rem', backgroundColor: 'white' }}>
         <p>{t('staticPages:references:content')}</p>
         {referenceKeys.map((referenceKey) => (


### PR DESCRIPTION
# Description

Focus was not set to top of the page when navigating to a different page. Fixed that by setting the focus to empty div on top of the page so that pressing tab sets the focus to Skip to main content link. Also added aria-live regions to main page headings.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1811

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

When navigating to a new page press tab and check that focus is in "Siirry pääsisältöön" link.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
