### PR TITLE
HAI-1495 Replace textinput with searchinput in omat hankkeet

### DIFF
--- a/src/domain/hanke/portfolio/HankePortfolio.test.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolio.test.tsx
@@ -14,8 +14,9 @@ import hankkeet from '../../mocks/data/hankkeet-data';
 import { HankeDataDraft } from '../../types/hanke';
 import HankePortfolioContainer from './HankePortfolioContainer';
 
-const startDateLabel = 'Ajanjakson alku';
-const endDateLabel = 'Ajanjakson loppu';
+const START_DATE_LABEL = 'Ajanjakson alku';
+const END_DATE_LABEL = 'Ajanjakson loppu';
+const SEARCH_PLACEHOLDER = 'Esim. hankkeen nimi tai tunnus';
 
 afterEach(cleanup);
 
@@ -43,13 +44,16 @@ describe('HankePortfolio', () => {
       <HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />,
     );
 
-    await user.type(screen.getByLabelText('Haku'), 'Mannerheimintie autottomaksi');
+    await user.type(
+      screen.getByPlaceholderText(SEARCH_PLACEHOLDER),
+      'Mannerheimintie autottomaksi',
+    );
     await waitFor(() => {
       expect(screen.getByText('1 hakutulos'));
     });
     expect(screen.getByTestId('numberOfFilteredRows')).toHaveTextContent('1');
 
-    await user.type(screen.getByLabelText('Haku'), 'elielin');
+    await user.type(screen.getByPlaceholderText(SEARCH_PLACEHOLDER), 'elielin');
     await waitFor(() => {
       expect(screen.getByText('0 hakutulosta'));
     });
@@ -70,16 +74,16 @@ describe('HankePortfolio', () => {
       <HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />,
     );
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('2');
-    changeFilterDate(startDateLabel, renderedComponent, '02.10.2022');
+    changeFilterDate(START_DATE_LABEL, renderedComponent, '02.10.2022');
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('2');
-    changeFilterDate(startDateLabel, renderedComponent, '06.10.2022');
+    changeFilterDate(START_DATE_LABEL, renderedComponent, '06.10.2022');
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('1');
-    changeFilterDate(startDateLabel, renderedComponent, '11.10.2022');
+    changeFilterDate(START_DATE_LABEL, renderedComponent, '11.10.2022');
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('0');
     expect(
       screen.queryByText('Valitsemillasi hakuehdoilla ei löytynyt yhtään hanketta'),
     ).toBeInTheDocument();
-    changeFilterDate(startDateLabel, renderedComponent, null);
+    changeFilterDate(START_DATE_LABEL, renderedComponent, null);
   });
 
   test('Changing filter endDates filters correct number of projects', async () => {
@@ -87,16 +91,16 @@ describe('HankePortfolio', () => {
       <HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />,
     );
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('2');
-    changeFilterDate(endDateLabel, renderedComponent, '01.10.2022');
+    changeFilterDate(END_DATE_LABEL, renderedComponent, '01.10.2022');
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('0');
     expect(
       screen.queryByText('Valitsemillasi hakuehdoilla ei löytynyt yhtään hanketta'),
     ).toBeInTheDocument();
-    changeFilterDate(endDateLabel, renderedComponent, '05.10.2022');
+    changeFilterDate(END_DATE_LABEL, renderedComponent, '05.10.2022');
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('2');
-    changeFilterDate(endDateLabel, renderedComponent, '11.10.2022');
+    changeFilterDate(END_DATE_LABEL, renderedComponent, '11.10.2022');
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('2');
-    changeFilterDate(endDateLabel, renderedComponent, null);
+    changeFilterDate(END_DATE_LABEL, renderedComponent, null);
     expect(renderedComponent.getByTestId('numberOfFilteredRows')).toHaveTextContent('2');
   });
 

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -9,7 +9,7 @@ import {
   useAsyncDebounce,
   useSortBy,
 } from 'react-table';
-import { useAccordion, Card, Select, TextInput, Button, Pagination } from 'hds-react';
+import { useAccordion, Card, Select, Button, Pagination, SearchInput } from 'hds-react';
 import {
   IconAngleDown,
   IconAngleUp,
@@ -485,12 +485,13 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
             aria-label={t('hankePortfolio:filters')}
             aria-describedby={t('hankePortfolio:filtersInfoText')}
           >
-            <TextInput
+            <SearchInput
               className={styles.hankeSearch}
-              id="searchHanke"
-              value={hankeSearchValue}
-              onChange={(e) => setHankeSearchValue(e.target.value)}
               label={t('hankePortfolio:search')}
+              placeholder={t('hankePortfolio:searchPlaceholder')}
+              value={hankeSearchValue}
+              onChange={setHankeSearchValue}
+              onSubmit={setHankeSearchValue}
             />
             <FeatureFlags flags={['hanke']}>
               <div className={styles.dateRange}>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -760,6 +760,7 @@
     "filters": "Rajausehdot",
     "pageHeader": "Omat hankkeet",
     "search": "Haku",
+    "searchPlaceholder": "Esim. hankkeen nimi tai tunnus",
     "searchHelperText": "Hae hankkeen nimellä tai tunnuksella",
     "searchResults": "{{count}} hakutulos",
     "searchResults_plural": "{{count}} hakutulosta",


### PR DESCRIPTION
# Description

HAI-1495 Replace textinput with searchinput in omat hankkeet. 

This is done to match the figma design.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1495

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Go to omat hankkeet. Verify that the implementation matches figma. Verify that the search filtering works.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
