### PR TITLE
HAI-1776 Add Content-Security-Policy header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN REACT_APP_DISABLE_SENTRY=0 yarn build
 FROM nginx:stable
 EXPOSE 8000
 COPY --from=staticbuilder ./builder/build /usr/share/nginx/html
-COPY --from=staticbuilder ./builder/nginx/nginx.conf /etc/nginx/nginx.conf
 WORKDIR /usr/share/nginx/html
 
 # Create the environment file so that the user that will run the backend has
@@ -22,6 +21,15 @@ COPY --from=staticbuilder ./builder/.env /opt/.env
 COPY --from=staticbuilder ./builder/package.json /opt/package.json
 RUN chmod +x /opt/env.sh
 
+# Copy script that injects environment variables to nginx.conf
+COPY ./scripts/nginx-env.sh /opt/nginx-env.sh
+# The script copies /opt/nginx.conf to /etc/nginx/nginx.conf
+# while replacing the environment variables
+COPY --from=staticbuilder ./builder/nginx/nginx.conf /opt/nginx.conf
+RUN chmod +x /opt/nginx-env.sh
+
+RUN chmod a+w /etc/nginx/nginx.conf
+
 ENV REACT_APP_DISABLE_SENTRY=0
 
-CMD ["/bin/bash", "-c", "/opt/env.sh /opt /usr/share/nginx/html && nginx -g \"daemon off;\""]
+CMD ["/bin/bash", "-c", "/opt/env.sh /opt /usr/share/nginx/html && /opt/nginx-env.sh && nginx -g \"daemon off;\""]

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,13 +1,22 @@
 FROM node:16-alpine as staticbuilder
-COPY . /builder/
+# Copy files needed for downloading dependencies
+COPY ./package.json /builder/package.json
+COPY ./yarn.lock /builder/yarn.lock
 WORKDIR /builder
+# The sources are not copied yet, so this step is cached between different builds
+# with modified sources, as long as the files above have not changed.
 RUN yarn && yarn cache clean --force
+
+# Copy the sources and build the app.
+# Changes in other files won't invalidate the cached build.
+COPY ./src /builder/src
+COPY ./public /builder/public
+COPY ./tsconfig.json /builder/tsconfig.json
 RUN REACT_APP_DISABLE_SENTRY=1 yarn build
 
 FROM nginx:stable
 EXPOSE 8000
 COPY --from=staticbuilder ./builder/build /usr/share/nginx/html
-COPY --from=staticbuilder ./builder/nginx/nginx.conf /etc/nginx/nginx.conf
 WORKDIR /usr/share/nginx/html
 
 # Copy default environment config and setup script
@@ -17,6 +26,15 @@ COPY .env /opt/.env
 COPY package.json /opt/package.json
 RUN chmod +x /opt/env.sh
 
+#COPY ./nginx/variables.conf /etc/nginx/templates/10-variables.conf.template
+
+# Copy script that injects environment variables to nginx.conf
+COPY ./scripts/nginx-env.sh /opt/nginx-env.sh
+# The script copies /opt/nginx.conf to /etc/nginx/nginx.conf
+# while replacing the environment variables
+COPY ./nginx/nginx.conf /opt/nginx.conf
+RUN chmod +x /opt/nginx-env.sh
+
 ENV REACT_APP_DISABLE_SENTRY=1
 
-CMD ["/bin/bash", "-c", "/opt/env.sh /opt /usr/share/nginx/html && nginx -g \"daemon off;\""]
+CMD ["/bin/bash", "-c", "/opt/env.sh /opt /usr/share/nginx/html && /opt/nginx-env.sh && nginx -g \"daemon off;\""]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -26,6 +26,19 @@ http {
         listen          8000;
         server_name     localhost;
         root            /usr/share/nginx/html;
+
+        set $DEFAULT_SRC "default-src 'self'";
+        set $STYLE_SRC "style-src 'self'";
+        set $STYLE_SRC "${STYLE_SRC} 'unsafe-inline'";
+        set $IMG_SRC "img-src 'self'";
+        set $IMG_SRC "${IMG_SRC} https://kartta.hel.fi";
+        set $IMG_SRC "${IMG_SRC} data:";
+        set $CONNECT_SRC "connect-src 'self'";
+        set $CONNECT_SRC "${CONNECT_SRC} https://o394401.ingest.sentry.io";
+        set $CONNECT_SRC "${CONNECT_SRC} ${LOGIN_SERVER}";
+        set $CONNECT_SRC "${CONNECT_SRC} https://kartta.hel.fi";
+        add_header Content-Security-Policy "${DEFAULT_SRC}; ${STYLE_SRC}; ${IMG_SRC}; ${CONNECT_SRC};" always;
+
         location / {
             root        /usr/share/nginx/html;
             try_files   $uri /index.html;

--- a/scripts/nginx-env.sh
+++ b/scripts/nginx-env.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+input_file=/opt/nginx.conf
+output_file=/etc/nginx/nginx.conf
+
+substitutions=''
+substitutions="$substitutions \$LOGIN_SERVER"
+
+# Replace the specified environment variables in the configuration file with
+# values from the environment.
+envsubst "${substitutions}" < ${input_file} > ${output_file}


### PR DESCRIPTION
# Description

Add a Content-Security-Policy header to the nginx configuration. The header tells the browser where it should download content from. This is added security for exploits like XSS.

When building the docker image, copy nginx.conf under /opt. When the container is started, run a script at startup that substitutes the environment variables and copies nging.conf to /etc/nginx/nginx.conf. The script only substitutes the environment variables specified in the script so it won't overwrite nginx variables.

Also, modify the docker file for building UI images for the local Docker Compose environment. Copy the files to the builder image selectively, so only changes in those files invalidate Docker's cache. Separate `yarn install` from `yarn build`, so that only changes in package.json or yarn.lock will trigger a new `yarn install`. This means that the longest step in building the UI image can be cached most of the time when switching branches etc.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1776

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Other

# Instructions for testing

1. Run the container.
2. See that the frontend responses contain the Content-Security-Policy header.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: