### PR TITLE
HAI-1974 Add generated notification for generated hanke

### DIFF
--- a/src/domain/hanke/edit/components/HankeGeneratedStateNotification.tsx
+++ b/src/domain/hanke/edit/components/HankeGeneratedStateNotification.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next';
+import { Notification } from 'hds-react';
+
+type Props = {
+  generated?: boolean;
+  className?: string;
+};
+
+const HankeGeneratedStateNotification: React.FC<Props> = ({ generated, className }) => {
+  const { t } = useTranslation();
+
+  if (!generated) {
+    return null;
+  }
+
+  return (
+    <Notification
+      size="small"
+      className={className}
+      label={t('hankePortfolio:generatedStateLabel')}
+    >
+      {t('hankePortfolio:generatedState')}
+    </Notification>
+  );
+};
+
+export default HankeGeneratedStateNotification;

--- a/src/domain/hanke/hankeView/HankeView.module.scss
+++ b/src/domain/hanke/hankeView/HankeView.module.scss
@@ -1,6 +1,6 @@
 @import 'src/assets/styles/layout.scss';
 
-.draftStateNotification {
+.stateNotification {
   margin-bottom: var(--spacing-s);
   margin-top: var(--spacing-s);
 

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -57,6 +57,28 @@ test('Draft state notification is not rendered when hanke is not in draft state'
   expect(draftStateElements.length).toBe(0);
 });
 
+test('Generated state notification is rendered when hanke is in generated state', async () => {
+  render(<HankeViewContainer hankeTunnus="HAI22-11" />);
+
+  await waitForLoadingToFinish();
+  const generatedStateElements = screen.queryAllByText(
+    /hanke on muodostettu johtoselvityksen perusteella/i,
+    { exact: false },
+  );
+  expect(generatedStateElements.length).toBe(1);
+});
+
+test('Generated state notification is not rendered when hanke is not generated', async () => {
+  render(<HankeViewContainer hankeTunnus="HAI22-1" />);
+
+  await waitForLoadingToFinish();
+  const generatedStateElements = screen.queryAllByText(
+    /hanke on muodostettu johtoselvityksen perusteella/i,
+    { exact: false },
+  );
+  expect(generatedStateElements.length).toBe(0);
+});
+
 test('Correct information about hanke should be displayed', async () => {
   const { user } = render(<HankeViewContainer hankeTunnus="HAI22-3" />);
 

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -55,6 +55,7 @@ import { CheckRightsByHanke } from '../hankeUsers/UserRightsCheck';
 import AttachmentSummary from '../edit/components/AttachmentSummary';
 import useHankeAttachments from '../hankeAttachments/useHankeAttachments';
 import MainHeading from '../../../common/components/mainHeading/MainHeading';
+import HankeGeneratedStateNotification from '../edit/components/HankeGeneratedStateNotification';
 
 type AreaProps = {
   area: HankeAlue;
@@ -279,9 +280,11 @@ const HankeView: React.FC<Props> = ({
       <InformationViewContentContainer>
         <InformationViewMainContent>
           <FeatureFlags flags={['hanke']}>
-            <div className={styles.draftStateNotification}>
-              <HankeDraftStateNotification hanke={hankeData} />
-            </div>
+            <HankeGeneratedStateNotification
+              generated={hankeData.generated}
+              className={styles.stateNotification}
+            />
+            <HankeDraftStateNotification hanke={hankeData} className={styles.stateNotification} />
           </FeatureFlags>
 
           <Tabs initiallyActiveTab={features.hanke ? initiallyActiveTab : 0}>

--- a/src/domain/hanke/portfolio/HankePortfolio.module.scss
+++ b/src/domain/hanke/portfolio/HankePortfolio.module.scss
@@ -60,7 +60,7 @@
       }
     }
 
-    .draftNotification {
+    .stateNotification {
       margin-top: var(--spacing-s);
     }
 

--- a/src/domain/hanke/portfolio/HankePortfolio.test.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolio.test.tsx
@@ -159,6 +159,22 @@ describe('HankePortfolioComponent', () => {
       ),
     ).toHaveLength(1);
   });
+
+  test('Should show generated state notification for hankkeet that are generated', async () => {
+    const generatedHanke = {
+      generated: true,
+      ...hankeList[0],
+    };
+    const editedHankeList = [generatedHanke, ...hankeList.slice(1)];
+    const userData = userDataByHanke(editedHankeList.map((h) => h.hankeTunnus));
+
+    render(<HankePortfolioComponent hankkeet={editedHankeList} signedInUserByHanke={userData} />);
+
+    expect(editedHankeList).toHaveLength(2);
+    expect(
+      screen.getAllByText('Tämä hanke on muodostettu johtoselvityksen perusteella.'),
+    ).toHaveLength(1);
+  });
 });
 
 describe('HankePortfolioContainer', () => {

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -34,6 +34,7 @@ import { Language } from '../../../common/types/language';
 import OwnHankeMap from '../../map/components/OwnHankeMap/OwnHankeMap';
 import OwnHankeMapHeader from '../../map/components/OwnHankeMap/OwnHankeMapHeader';
 import HankeDraftStateNotification from '../edit/components/HankeDraftStateNotification';
+import HankeGeneratedStateNotification from '../edit/components/HankeGeneratedStateNotification';
 import Container from '../../../common/components/container/Container';
 import useHankeViewPath from '../hooks/useHankeViewPath';
 import { useNavigateToApplicationList } from '../hooks/useNavigateToApplicationList';
@@ -146,7 +147,11 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke, signedInUser, 
           </button>
         </div>
         <FeatureFlags flags={['hanke']}>
-          <HankeDraftStateNotification hanke={hanke} className={styles.draftNotification} />
+          <HankeGeneratedStateNotification
+            generated={hanke.generated}
+            className={styles.stateNotification}
+          />
+          <HankeDraftStateNotification hanke={hanke} className={styles.stateNotification} />
         </FeatureFlags>
       </>
       <div className={styles.hankeCardContent} {...contentProps}>

--- a/src/domain/mocks/data/hankkeet-data.ts
+++ b/src/domain/mocks/data/hankkeet-data.ts
@@ -501,6 +501,7 @@ const hankkeet: HankeDataDraft[] = [
     toteuttajat: [],
     muut: [],
     tyomaaTyyppi: [],
+    generated: true,
   },
 ];
 

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -245,4 +245,8 @@ export const handlers = [
   rest.delete(`${apiUrl}/hakemukset/:id/liitteet/:attachmentId`, async (req, res, ctx) => {
     return res(ctx.status(200));
   }),
+
+  rest.get(`${apiUrl}/hankkeet/:hankeTunnus/liitteet`, async (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json([]));
+  }),
 ];

--- a/src/domain/types/hanke.ts
+++ b/src/domain/types/hanke.ts
@@ -204,6 +204,7 @@ export interface HankeData {
   createdAt?: string;
   modifiedBy?: null | string;
   modifiedAt?: null | string;
+  generated?: boolean;
 }
 
 export interface HankeIndexData {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -779,6 +779,8 @@
     "showApplicationsButton": "Näytä hankkeen hakemukset",
     "draftStateLabel": "Hanke on luonnostilassa",
     "draftState": "Hanke on luonnostilassa. Alueiden haittatiedot ja muut pakolliset tiedot on täytettävä hankkeen julkaisemiseksi ja lupien lisäämiseksi.",
+    "generatedStateLabel": "Hanke muodostettu johtoselvityksen perusteella",
+    "generatedState": "Tämä hanke on muodostettu johtoselvityksen perusteella.",
     "clearFiltersButton": "Tyhjennä hakuehdot",
     "filtersInfoText": "Hakuehtojen muuttaminen päivittää hankelistan.",
     "tabit": {


### PR DESCRIPTION
# Description

Add generated notification for generated hanke in hanke listing and hanke view.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1974

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing
1. Create johtoselvitys
2. In hanke listing, check that the generated hanke based on your application has the correct notification.
3. The notification should also be on that hanke's view.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
