### PR TITLE
HAI-2145 Fix changing language redirecting user to front page

### DIFF
--- a/src/common/components/header/Header.test.tsx
+++ b/src/common/components/header/Header.test.tsx
@@ -59,4 +59,30 @@ describe('Header', () => {
     expect(i18next.language).toBe('fi');
     expect(window.location.pathname).toBe('/fi/julkisethankkeet/kartta');
   });
+
+  test('should navigate to correct url when changing language when url contains hankeTunnus', async () => {
+    await i18next.changeLanguage('fi');
+    const { user } = render(<Header />, undefined, '/fi/hankesalkku/HAI23-1');
+
+    await user.click(screen.getAllByRole('button', { name: /suomi/i })[0]);
+    await user.click(screen.getAllByText(/english/i)[0]);
+    expect(window.location.pathname).toBe('/en/projectportfolio/HAI23-1');
+
+    await user.click(screen.getAllByRole('button', { name: /english/i })[0]);
+    await user.click(screen.getAllByText(/svenska/i)[0]);
+    expect(window.location.pathname).toBe('/sv/projektportfolj/HAI23-1');
+  });
+
+  test('should navigate to correct url when changing language when url contains application id', async () => {
+    await i18next.changeLanguage('fi');
+    const { user } = render(<Header />, undefined, '/fi/hakemus/1');
+
+    await user.click(screen.getAllByRole('button', { name: /suomi/i })[0]);
+    await user.click(screen.getAllByText(/english/i)[0]);
+    expect(window.location.pathname).toBe('/en/application/1');
+
+    await user.click(screen.getAllByRole('button', { name: /english/i })[0]);
+    await user.click(screen.getAllByText(/svenska/i)[0]);
+    expect(window.location.pathname).toBe('/sv/ansokan/1');
+  });
 });

--- a/src/common/components/header/Header.test.tsx
+++ b/src/common/components/header/Header.test.tsx
@@ -3,12 +3,20 @@ import { render, cleanup, screen } from '../../../testUtils/render';
 import Header from './Header';
 import useUser from '../../../domain/auth/useUser';
 import i18next from '../../../locales/i18nForTests';
+import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
 
 jest.setTimeout(10000);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockedUseUser = useUser as jest.Mock<any>;
 jest.mock('../../../domain/auth/useUser');
+
+type Language = 'Suomi' | 'English' | 'Svenska';
+
+async function changeLanguage(user: UserEvent, lang: Language, newLang: Language) {
+  await user.click(screen.getAllByRole('button', { name: lang })[0]);
+  await user.click(screen.getAllByText(newLang)[0]);
+}
 
 describe('Header', () => {
   beforeEach(() => {
@@ -44,32 +52,26 @@ describe('Header', () => {
   test('when user changes language it should change the UI language and the url based on the selected language', async () => {
     const { user } = render(<Header />, undefined, '/fi/julkisethankkeet/kartta');
 
-    await user.click(screen.getAllByRole('button', { name: /suomi/i })[0]);
-    await user.click(screen.getAllByText(/english/i)[0]);
+    await changeLanguage(user, 'Suomi', 'English');
     expect(i18next.language).toBe('en');
     expect(window.location.pathname).toBe('/en/publicprojects/map');
 
-    await user.click(screen.getAllByRole('button', { name: /english/i })[0]);
-    await user.click(screen.getAllByText(/svenska/i)[0]);
+    await changeLanguage(user, 'English', 'Svenska');
     expect(i18next.language).toBe('sv');
     expect(window.location.pathname).toBe('/sv/allmannaprojekt/karta');
 
-    await user.click(screen.getAllByRole('button', { name: /svenska/i })[0]);
-    await user.click(screen.getAllByText(/suomi/i)[0]);
+    await changeLanguage(user, 'Svenska', 'Suomi');
     expect(i18next.language).toBe('fi');
     expect(window.location.pathname).toBe('/fi/julkisethankkeet/kartta');
   });
 
   test('should navigate to correct url when changing language when url contains hankeTunnus', async () => {
-    await i18next.changeLanguage('fi');
     const { user } = render(<Header />, undefined, '/fi/hankesalkku/HAI23-1');
 
-    await user.click(screen.getAllByRole('button', { name: /suomi/i })[0]);
-    await user.click(screen.getAllByText(/english/i)[0]);
+    await changeLanguage(user, 'Suomi', 'English');
     expect(window.location.pathname).toBe('/en/projectportfolio/HAI23-1');
 
-    await user.click(screen.getAllByRole('button', { name: /english/i })[0]);
-    await user.click(screen.getAllByText(/svenska/i)[0]);
+    await changeLanguage(user, 'English', 'Svenska');
     expect(window.location.pathname).toBe('/sv/projektportfolj/HAI23-1');
   });
 
@@ -77,12 +79,10 @@ describe('Header', () => {
     await i18next.changeLanguage('fi');
     const { user } = render(<Header />, undefined, '/fi/hakemus/1');
 
-    await user.click(screen.getAllByRole('button', { name: /suomi/i })[0]);
-    await user.click(screen.getAllByText(/english/i)[0]);
+    await changeLanguage(user, 'Suomi', 'English');
     expect(window.location.pathname).toBe('/en/application/1');
 
-    await user.click(screen.getAllByRole('button', { name: /english/i })[0]);
-    await user.click(screen.getAllByText(/svenska/i)[0]);
+    await changeLanguage(user, 'English', 'Svenska');
     expect(window.location.pathname).toBe('/sv/ansokan/1');
   });
 });

--- a/src/common/components/header/Header.tsx
+++ b/src/common/components/header/Header.tsx
@@ -60,10 +60,10 @@ const Header: React.FC<React.PropsWithChildren<unknown>> = () => {
   const navigate = useNavigate();
 
   function getPathForLanguage(lang: Language, routeKey: string): string {
-    const hankeTunnusMatches = location.pathname.match(HANKETUNNUS_REGEXP);
-    const hankeTunnus = hankeTunnusMatches && hankeTunnusMatches[0];
-    const applicationIdMatches = location.pathname.match(APPLICATION_ID_REGEXP);
-    const applicationId = applicationIdMatches && applicationIdMatches[0];
+    const hankeTunnusMatches = HANKETUNNUS_REGEXP.exec(location.pathname);
+    const hankeTunnus = hankeTunnusMatches?.[0];
+    const applicationIdMatches = APPLICATION_ID_REGEXP.exec(location.pathname);
+    const applicationId = applicationIdMatches?.[0];
 
     let path = lang + t(`routes:${routeKey}.path`);
     if (hankeTunnus) {

--- a/src/common/components/header/Header.tsx
+++ b/src/common/components/header/Header.tsx
@@ -3,7 +3,12 @@ import { IconLinkExternal, IconSignout, LogoLanguage, Navigation } from 'hds-rea
 import { useTranslation } from 'react-i18next';
 import { NavLink, useMatch, useLocation, useNavigate } from 'react-router-dom';
 import { $enum } from 'ts-enum-util';
-import { getMatchingRouteKey, useLocalizedRoutes } from '../../hooks/useLocalizedRoutes';
+import {
+  getMatchingRouteKey,
+  useLocalizedRoutes,
+  HANKETUNNUS_REGEXP,
+  APPLICATION_ID_REGEXP,
+} from '../../hooks/useLocalizedRoutes';
 import authService from '../../../domain/auth/authService';
 import useUser from '../../../domain/auth/useUser';
 import { Language, LANGUAGES } from '../../types/language';
@@ -54,11 +59,27 @@ const Header: React.FC<React.PropsWithChildren<unknown>> = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
+  function getPathForLanguage(lang: Language, routeKey: string): string {
+    const hankeTunnusMatches = location.pathname.match(HANKETUNNUS_REGEXP);
+    const hankeTunnus = hankeTunnusMatches && hankeTunnusMatches[0];
+    const applicationIdMatches = location.pathname.match(APPLICATION_ID_REGEXP);
+    const applicationId = applicationIdMatches && applicationIdMatches[0];
+
+    let path = lang + t(`routes:${routeKey}.path`);
+    if (hankeTunnus) {
+      path = path.replace(':hankeTunnus', hankeTunnus);
+    }
+    if (applicationId) {
+      path = path.replace(':id', applicationId);
+    }
+    return path;
+  }
+
   async function setLanguage(lang: Language) {
     const routeKey = getMatchingRouteKey(i18n, i18n.language as Language, location.pathname);
     await i18n.changeLanguage(lang);
-    const to = lang + t(`routes:${routeKey}.path`);
-    navigate(to);
+    const path = getPathForLanguage(lang, routeKey);
+    navigate(path);
   }
 
   return (

--- a/src/common/hooks/useLocalizedRoutes.ts
+++ b/src/common/hooks/useLocalizedRoutes.ts
@@ -4,6 +4,9 @@ import { $enum } from 'ts-enum-util';
 import { ROUTES, RouteMap } from '../types/route';
 import { Language } from '../types/language';
 
+export const APPLICATION_ID_REGEXP = /(?<=\/)(\d+)/;
+export const HANKETUNNUS_REGEXP = /HAI\d{2}-(\d+)/;
+
 type GetLocalizationParams = {
   useTranslationResponse: UseTranslationResponse<''>;
   route: string;
@@ -28,7 +31,10 @@ export const getRouteLocalization = ({
 export const getMatchingRouteKey = (i18n: i18nInstance, language: Language, path: string) => {
   // eslint-disable-next-line
   const res: any = i18n.getDataByLanguage(language);
-  const pathWithoutLocale = path.length > 3 ? path.substring(3) : path;
+  let pathWithoutLocale = path.length > 3 ? path.substring(3) : path;
+  pathWithoutLocale = pathWithoutLocale
+    .replace(APPLICATION_ID_REGEXP, ':id')
+    .replace(HANKETUNNUS_REGEXP, ':hankeTunnus');
 
   // Find first matching routekey
   const routeKey = Object.keys(res.routes).find((key) =>


### PR DESCRIPTION
# Description

There was a problem when user was in a route containing dynamic path segment such as application id and changed UI language. In such case user was taken to front page instead of staying in the same page.

Problem was caused because for example key with value of 'hakemus/4' was not found in language files, so fixed this by replacing the id with ':id', so in this case 'hakemus/:id, and then placing the actual id back when navigating to changed language route.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2145

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Go to some hanke page or hanke form of some previously created hanke and change language. You should remain in the same page with the language updated. Try the same also with cable report application.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
