### PR TITLE
HAI-1880 Fix new hanke link font size being too small in empty hanke list text

### DIFF
--- a/src/domain/hanke/portfolio/HankePortfolio.module.scss
+++ b/src/domain/hanke/portfolio/HankePortfolio.module.scss
@@ -12,6 +12,10 @@
       flex-direction: column;
       align-items: center;
       margin: var(--spacing-3-xl) auto;
+
+      .newHankeLink {
+        font-size: var(--fontsize-heading-m) !important;
+      }
     }
 
     .hankeCard {

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -605,7 +605,7 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
                     </Text>
                     <Text tag="p" className="heading-m">
                       Tarkista hakuehdot tai{' '}
-                      <HDSLink href={NEW_HANKE.path} className="heading-m">
+                      <HDSLink href={NEW_HANKE.path} className={styles.newHankeLink}>
                         luo uusi hanke
                       </HDSLink>
                       .


### PR DESCRIPTION
# Description

In manual testing it was found that font size of new hanke link is too small in empty hanke list text so fixed that.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1880

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
