### PR TITLE
HAI-1957 Show error notification to user if loading hankkeet in hanke list fails

### DIFF
--- a/src/domain/hanke/portfolio/HankePortfolio.test.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolio.test.tsx
@@ -214,4 +214,17 @@ describe('HankePortfolioContainer', () => {
     await user.click(screen.getByRole('button', { name: 'Seuraava' }));
     expect(screen.getAllByTestId('hanke-card-header')[0]).toHaveFocus();
   });
+
+  test('Should show error notification if loading hankkeet fails', async () => {
+    server.use(
+      rest.get('/api/hankkeet', async (req, res, ctx) => {
+        return res(ctx.status(500), ctx.json({ errorMessage: 'Failed for testing purposes' }));
+      }),
+    );
+
+    render(<HankePortfolioContainer />);
+
+    await screen.findByText('Virhe tietojen lataamisessa.');
+    expect(screen.queryByText('Yritä hetken päästä uudelleen.')).toBeInTheDocument();
+  });
 });

--- a/src/domain/hanke/portfolio/HankePortfolioContainer.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioContainer.tsx
@@ -4,6 +4,7 @@ import api from '../../api/api';
 import { HankeData } from '../../types/hanke';
 import HankePortfolioComponent from './HankePortfolioComponent';
 import { usePermissionsByHanke } from '../hankeUsers/hooks/useUserRightsForHanke';
+import ErrorLoadingText from '../../../common/components/errorLoadingText/ErrorLoadingText';
 
 const getHankkeet = async () => {
   const { data } = await api.get<HankeData[]>(`/hankkeet`, {
@@ -17,9 +18,13 @@ const getHankkeet = async () => {
 const useHankeList = () => useQuery<HankeData[]>(['project'], getHankkeet);
 
 const HankePortfolioContainer: React.FC<React.PropsWithChildren<unknown>> = () => {
-  const { data: hankkeet } = useHankeList();
+  const { data: hankkeet, isError } = useHankeList();
   const { data: signedInUserByHanke } = usePermissionsByHanke();
   const userData = signedInUserByHanke ?? {};
+
+  if (isError) {
+    return <ErrorLoadingText />;
+  }
 
   // Add header to fix Axe "page-has-heading-one"-error
   return hankkeet ? (


### PR DESCRIPTION
# Description

If fetch of hankkeet in hanke list fails for some reason, for example backend is down, show error notification to user.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1957

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
