### PR TITLE
HAI-2234 bug fix for "Hindrance affecting lane length"

### DIFF
--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -3,14 +3,14 @@ import { rest } from 'msw';
 import { FORMFIELD, HankeDataFormState } from './types';
 import HankeForm from './HankeForm';
 import HankeFormContainer from './HankeFormContainer';
-import { HANKE_VAIHE, HANKE_TYOMAATYYPPI } from '../../types/hanke';
+import { HANKE_TYOMAATYYPPI, HANKE_VAIHE } from '../../types/hanke';
 import {
-  render,
+  act,
   cleanup,
   fireEvent,
-  waitFor,
+  render,
   screen,
-  act,
+  waitFor,
   within,
 } from '../../../testUtils/render';
 import hankkeet from '../../mocks/data/hankkeet-data';
@@ -109,7 +109,74 @@ const formData: HankeDataFormState = {
   tyomaaTyyppi: [HANKE_TYOMAATYYPPI.AKILLINEN_VIKAKORJAUS],
   nimi: 'testi kuoppa',
   kuvaus: 'testi kuvaus',
+  alueet: [
+    {
+      id: 414,
+      hankeId: 277,
+      haittaAlkuPvm: '2023-12-19T00:00:00Z',
+      haittaLoppuPvm: '2023-12-31T00:00:00Z',
+      geometriat: {
+        id: 508,
+        featureCollection: {
+          type: 'FeatureCollection',
+          crs: {
+            type: 'name',
+            properties: {
+              name: 'urn:ogc:def:crs:EPSG::3879',
+            },
+          },
+          features: [
+            {
+              type: 'Feature',
+              properties: {
+                hankeTunnus: 'HAI23-152',
+              },
+              geometry: {
+                type: 'Polygon',
+                crs: {
+                  type: 'name',
+                  properties: {
+                    name: 'EPSG:3879',
+                  },
+                },
+                coordinates: [
+                  [
+                    [2.549981931e7, 6674214.72],
+                    [2.549981932e7, 6674233.32],
+                    [2.549980072e7, 6674233.32],
+                    [2.549980071e7, 6674214.72],
+                    [2.549981931e7, 6674214.72],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+        version: 0,
+        createdByUserId: '5f893af3-f7c0-433b-bf50-08f88fbc43a7',
+        createdAt: '2023-12-19T13:34:15.068Z',
+        modifiedByUserId: null,
+        modifiedAt: null,
+      },
+      kaistaHaitta: 'EI_VAIKUTA',
+      kaistaPituusHaitta: 'EI_VAIKUTA_KAISTAJARJESTELYIHIN',
+      meluHaitta: 'SATUNNAINEN_HAITTA',
+      polyHaitta: 'SATUNNAINEN_HAITTA',
+      tarinaHaitta: 'SATUNNAINEN_HAITTA',
+      nimi: 'Hankealue 1',
+    },
+  ],
 };
+
+async function setupAlueetPage(jsx: JSX.Element) {
+  const renderResult = render(jsx);
+
+  await waitFor(() => expect(screen.queryByText('Perustiedot')).toBeInTheDocument());
+  await renderResult.user.click(screen.getByRole('button', { name: /alueet/i }));
+  await waitFor(() => expect(screen.queryByText(/Piirrä alue kartalle/i)).toBeInTheDocument());
+
+  return renderResult;
+}
 
 async function setupYhteystiedotPage(jsx: JSX.Element) {
   const renderResult = render(jsx);
@@ -192,6 +259,12 @@ describe('HankeForm', () => {
 
     const result = screen.getByRole('textbox', { name: /hankkeen nimi/i });
     expect(result).toHaveValue(initialName.concat('additional'));
+  });
+
+  test('Hindrance affecting lane lenght dropdown should show correct values', async () => {
+    await setupAlueetPage(<HankeFormContainer hankeTunnus="HAI22-1" />);
+
+    expect(screen.getByTestId('alueet.0.kaistaPituusHaitta')).toHaveValue('PITUUS_10_99_METRIA');
   });
 
   test('Yhteystiedot can be filled', async () => {

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -117,10 +117,12 @@ test('Correct information about hanke should be displayed', async () => {
   expect(screen.getByTestId('test-autoliikenneindeksi')).toHaveTextContent('1.5');
   expect(screen.queryByText('11974 m²')).toBeInTheDocument();
   expect(screen.queryByText('Meluhaitta: Satunnainen haitta')).toBeInTheDocument();
-  expect(screen.queryByText('Pölyhaitta: Satunnainen haitta')).toBeInTheDocument();
-  expect(screen.queryByText('Tärinähaitta: Lyhytaikainen toistuva haitta')).toBeInTheDocument();
-  expect(screen.queryByText('Autoliikenteen kaistahaitta: Ei vaikuta')).toBeInTheDocument();
-  expect(screen.queryByText('Kaistahaittojen pituus: Ei vaikuta')).toBeInTheDocument();
+  expect(screen.queryByText('Pölyhaitta: Lyhytaikainen toistuva haitta')).toBeInTheDocument();
+  expect(screen.queryByText('Tärinähaitta: Pitkäkestoinen jatkuva haitta')).toBeInTheDocument();
+  expect(
+    screen.queryByText('Autoliikenteen kaistahaitta: Vähentää kaistan yhdellä ajosuunnalla'),
+  ).toBeInTheDocument();
+  expect(screen.queryByText('Kaistahaittojen pituus: Alle 10 m')).toBeInTheDocument();
 
   // Change to contacts tab
   await user.click(screen.getByRole('tab', { name: /yhteystiedot/i }));

--- a/src/domain/mocks/data/hankkeet-data.ts
+++ b/src/domain/mocks/data/hankkeet-data.ts
@@ -1,4 +1,11 @@
-import { HankeDataDraft, HANKE_POLYHAITTA } from '../../types/hanke';
+import {
+  HankeDataDraft,
+  HANKE_POLYHAITTA,
+  HANKE_KAISTAHAITTA,
+  HANKE_KAISTAPITUUSHAITTA,
+  HANKE_MELUHAITTA,
+  HANKE_TARINAHAITTA,
+} from '../../types/hanke';
 
 const hankkeet: HankeDataDraft[] = [
   {
@@ -123,11 +130,11 @@ const hankkeet: HankeDataDraft[] = [
         hankeId: 2,
         haittaAlkuPvm: '2023-01-12T00:00:00Z',
         haittaLoppuPvm: '2024-11-27T00:00:00Z',
-        kaistaHaitta: 'VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA',
-        kaistaPituusHaitta: 'PITUUS_100_499_METRIA',
-        meluHaitta: 'PITKAKESTOINEN_TOISTUVA_HAITTA',
+        kaistaHaitta: HANKE_KAISTAHAITTA.VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA,
+        kaistaPituusHaitta: HANKE_KAISTAPITUUSHAITTA.PITUUS_100_499_METRIA,
+        meluHaitta: HANKE_MELUHAITTA.PITKAKESTOINEN_TOISTUVA_HAITTA,
         polyHaitta: HANKE_POLYHAITTA.PITKAKESTOINEN_TOISTUVA_HAITTA,
-        tarinaHaitta: 'SATUNNAINEN_HAITTA',
+        tarinaHaitta: HANKE_TARINAHAITTA.SATUNNAINEN_HAITTA,
         geometriat: {
           id: 37,
           version: 0,
@@ -177,11 +184,11 @@ const hankkeet: HankeDataDraft[] = [
         hankeId: 2,
         haittaAlkuPvm: '2023-05-15T20:59:59.999Z',
         haittaLoppuPvm: '2023-09-30T20:59:59.999Z',
-        meluHaitta: 'LYHYTAIKAINEN_TOISTUVA_HAITTA',
+        meluHaitta: HANKE_MELUHAITTA.LYHYTAIKAINEN_TOISTUVA_HAITTA,
         polyHaitta: HANKE_POLYHAITTA.PITKAKESTOINEN_TOISTUVA_HAITTA,
-        tarinaHaitta: 'SATUNNAINEN_HAITTA',
-        kaistaHaitta: 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA',
-        kaistaPituusHaitta: 'PITUUS_10_99_METRIA',
+        tarinaHaitta: HANKE_TARINAHAITTA.SATUNNAINEN_HAITTA,
+        kaistaHaitta: HANKE_KAISTAHAITTA.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+        kaistaPituusHaitta: HANKE_KAISTAPITUUSHAITTA.PITUUS_10_99_METRIA,
         geometriat: {
           featureCollection: {
             type: 'FeatureCollection',
@@ -275,11 +282,11 @@ const hankkeet: HankeDataDraft[] = [
         id: 1,
         haittaAlkuPvm: '2023-01-02T21:59:59.999Z',
         haittaLoppuPvm: '2023-02-24T21:59:59.999Z',
-        meluHaitta: 'SATUNNAINEN_HAITTA',
-        polyHaitta: HANKE_POLYHAITTA.SATUNNAINEN_HAITTA,
-        tarinaHaitta: 'LYHYTAIKAINEN_TOISTUVA_HAITTA',
-        kaistaHaitta: 'EI_VAIKUTA',
-        kaistaPituusHaitta: 'EI_VAIKUTA_KAISTAJARJESTELYIHIN',
+        meluHaitta: HANKE_MELUHAITTA.SATUNNAINEN_HAITTA,
+        polyHaitta: HANKE_POLYHAITTA.LYHYTAIKAINEN_TOISTUVA_HAITTA,
+        tarinaHaitta: HANKE_TARINAHAITTA.PITKAKESTOINEN_TOISTUVA_HAITTA,
+        kaistaHaitta: HANKE_KAISTAHAITTA.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
+        kaistaPituusHaitta: HANKE_KAISTAPITUUSHAITTA.PITUUS_ALLE_10_METRIA,
         geometriat: {
           featureCollection: {
             type: 'FeatureCollection',

--- a/src/domain/types/hanke.ts
+++ b/src/domain/types/hanke.ts
@@ -152,7 +152,7 @@ export type HankeAlue = {
   kaistaHaitta: HANKE_KAISTAHAITTA_KEY | null;
   kaistaPituusHaitta: HANKE_KAISTAPITUUSHAITTA_KEY | null;
   meluHaitta: HANKE_MELUHAITTA_KEY | null;
-  polyHaitta: HANKE_POLYHAITTA | null;
+  polyHaitta: HANKE_POLYHAITTA_KEY | null;
   tarinaHaitta: HANKE_TARINAHAITTA_KEY | null;
   nimi?: string | null;
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -405,10 +405,10 @@
     },
     "kaistaPituusHaitta": {
       "EI_VAIKUTA_KAISTAJARJESTELYIHIN": "Does not affect",
-      "KAISTAVAIKUTUSTEN_PITUUS_ALLE_10_METRIA": "Less than 10 m",
-      "KAISTAVAIKUTUSTEN_PITUUS_10_99_METRIA": "10–99 m",
-      "KAISTAVAIKUTUSTEN_PITUUS_100_499_METRIA": "100–499 m",
-      "VIKAISTAVAIKUTUSTEN_PITUUS_500_METRIA_TAI_ENEMMAN": "500 m or more"
+      "PITUUS_ALLE_10_METRIA": "Less than 10 m",
+      "PITUUS_10_99_METRIA": "10–99 m",
+      "PITUUS_100_499_METRIA": "100–499 m",
+      "PITUUS_500_METRIA_TAI_ENEMMAN": "500 m or more"
     },
     "meluHaitta": {
       "SATUNNAINEN_HAITTA": "Occasional nuisance",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -421,10 +421,10 @@
     },
     "kaistaPituusHaitta": {
       "EI_VAIKUTA_KAISTAJARJESTELYIHIN": "Ei vaikuta",
-      "KAISTAVAIKUTUSTEN_PITUUS_ALLE_10_METRIA": "Alle 10 m",
-      "KAISTAVAIKUTUSTEN_PITUUS_10_99_METRIA": "10-99 m",
-      "KAISTAVAIKUTUSTEN_PITUUS_100_499_METRIA": "100-499 m",
-      "VIKAISTAVAIKUTUSTEN_PITUUS_500_METRIA_TAI_ENEMMAN": "500 m tai enemmän"
+      "PITUUS_ALLE_10_METRIA": "Alle 10 m",
+      "PITUUS_10_99_METRIA": "10-99 m",
+      "PITUUS_100_499_METRIA": "100-499 m",
+      "PITUUS_500_METRIA_TAI_ENEMMAN": "500 m tai enemmän"
     },
     "meluHaitta": {
       "SATUNNAINEN_HAITTA": "Satunnainen haitta",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -405,10 +405,10 @@
     },
     "kaistaPituusHaitta": {
       "EI_VAIKUTA_KAISTAJARJESTELYIHIN": "Påverkar inte",
-      "KAISTAVAIKUTUSTEN_PITUUS_ALLE_10_METRIA": "Mindre än 10 m",
-      "KAISTAVAIKUTUSTEN_PITUUS_10_99_METRIA": "10–99 m",
-      "KAISTAVAIKUTUSTEN_PITUUS_100_499_METRIA": "100–499 m",
-      "VIKAISTAVAIKUTUSTEN_PITUUS_500_METRIA_TAI_ENEMMAN": "500 m eller mer"
+      "PITUUS_ALLE_10_METRIA": "Mindre än 10 m",
+      "PITUUS_10_99_METRIA": "10–99 m",
+      "PITUUS_100_499_METRIA": "100–499 m",
+      "PITUUS_500_METRIA_TAI_ENEMMAN": "500 m eller mer"
     },
     "meluHaitta": {
       "SATUNNAINEN_HAITTA": "Tillfällig olägenhet",


### PR DESCRIPTION
# Description

Fixed naming of "Hindrance affecting lane length" choices.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2234

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Create a new Hanke or open an existing one, go to section 2 ("Alueet") and add a new area or check an existing area. The choices in "Kaistahaittojen pituus" should have correct values instead of value keys:
```
Ei vaikuta
Alle 10 m
10-99 m
100-499 m
500 m tai enemmän
```

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
