### PR TITLE
HAI-2160 Create new user in hanke form

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@faker-js/faker": "^8.3.1",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.1.2",

--- a/src/common/components/grid/ResponsiveGrid.module.scss
+++ b/src/common/components/grid/ResponsiveGrid.module.scss
@@ -5,7 +5,15 @@
   grid-template-columns: 1fr;
   grid-gap: var(--spacing-s);
   margin-bottom: var(--spacing-s);
+}
 
+.maxColumns--2 {
+  @include respond-above(m) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.maxColumns--3 {
   @include respond-above(m) {
     grid-template-columns: repeat(2, 1fr);
   }

--- a/src/common/components/grid/ResponsiveGrid.tsx
+++ b/src/common/components/grid/ResponsiveGrid.tsx
@@ -8,7 +8,7 @@ type Props = {
   maxColumns?: 2 | 3;
 };
 
-function ResponsiveGrid({ className, maxColumns = 3, children }: Props) {
+function ResponsiveGrid({ className, maxColumns = 3, children }: Readonly<Props>) {
   return (
     <div className={clsx([styles.container, className, styles[`maxColumns--${maxColumns}`]])}>
       {children}

--- a/src/common/components/grid/ResponsiveGrid.tsx
+++ b/src/common/components/grid/ResponsiveGrid.tsx
@@ -5,10 +5,15 @@ import styles from './ResponsiveGrid.module.scss';
 type Props = {
   children: React.ReactNode;
   className?: string;
+  maxColumns?: 2 | 3;
 };
 
-function ResponsiveGrid({ className, children }: Props) {
-  return <div className={clsx([styles.container, className])}>{children}</div>;
+function ResponsiveGrid({ className, maxColumns = 3, children }: Props) {
+  return (
+    <div className={clsx([styles.container, className, styles[`maxColumns--${maxColumns}`]])}>
+      {children}
+    </div>
+  );
 }
 
 export default ResponsiveGrid;

--- a/src/common/components/transition/Transition.tsx
+++ b/src/common/components/transition/Transition.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { Box } from '@chakra-ui/react';
+import clsx from 'clsx';
+
+function useDelayedUnmount(isMounted: boolean, delayTime: number) {
+  const [shouldRender, setShouldRender] = useState(false);
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout;
+    if (isMounted) {
+      setShouldRender(true);
+    } else {
+      timeoutId = setTimeout(() => setShouldRender(false), delayTime);
+    }
+    return function cleanup() {
+      clearTimeout(timeoutId);
+    };
+  }, [isMounted, delayTime]);
+
+  return shouldRender;
+}
+
+type Props = {
+  showChildren: boolean;
+  children: React.ReactNode;
+  animateInClass: string;
+  animateOutClass: string;
+  unmountDelay: number;
+};
+
+function Transition({
+  showChildren,
+  children,
+  animateInClass,
+  animateOutClass,
+  unmountDelay,
+}: Readonly<Props>) {
+  const shouldRender = useDelayedUnmount(showChildren, unmountDelay);
+
+  return !shouldRender ? null : (
+    <Box
+      overflow="hidden"
+      className={clsx({
+        [animateInClass]: showChildren,
+        [animateOutClass]: !showChildren,
+      })}
+    >
+      {children}
+    </Box>
+  );
+}
+
+export default Transition;

--- a/src/domain/forms/components/FormContact.module.scss
+++ b/src/domain/forms/components/FormContact.module.scss
@@ -1,0 +1,33 @@
+.newContactPersonForm {
+  &__in {
+    animation: 400ms transitionin linear;
+  }
+
+  &__out {
+    animation: 410ms transitionout linear;
+  }
+
+  @keyframes transitionin {
+    from {
+      max-height: 0;
+      opacity: 0;
+    }
+
+    to {
+      max-height: 600px;
+      opacity: 1;
+    }
+  }
+
+  @keyframes transitionout {
+    from {
+      max-height: 600px;
+      opacity: 1;
+    }
+
+    to {
+      max-height: 0;
+      opacity: 0;
+    }
+  }
+}

--- a/src/domain/forms/components/FormContact.tsx
+++ b/src/domain/forms/components/FormContact.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { Flex } from '@chakra-ui/react';
+import { Button, IconAngleDown, IconAngleUp, IconCross, Notification } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { UseFieldArrayRemove } from 'react-hook-form';
+import NewContactPersonForm, { ContactPersonAddedNotification } from './NewContactPersonForm';
+import { HankeUser } from '../../hanke/hankeUsers/hankeUser';
+import styles from './FormContact.module.scss';
+import Transition from '../../../common/components/transition/Transition';
+
+interface Props<T> {
+  contactType: T;
+  hankeTunnus: string;
+  index?: number;
+  canBeRemoved?: boolean;
+  onRemove?: UseFieldArrayRemove;
+  onContactPersonAdded?: (newHankeUser: HankeUser) => void;
+  children: React.ReactNode;
+}
+
+const FormContact = <T,>({
+  contactType,
+  hankeTunnus,
+  index,
+  canBeRemoved = true,
+  onRemove,
+  onContactPersonAdded,
+  children,
+}: Readonly<Props<T>>) => {
+  const { t } = useTranslation();
+  const [showNewContactPersonForm, setShowNewContactPersonForm] = useState(false);
+  const [showContactPersonAddedNotification, setShowContactPersonAddedNotification] =
+    useState<ContactPersonAddedNotification>(null);
+  const addContactPersonIcon = !showNewContactPersonForm ? <IconAngleDown /> : <IconAngleUp />;
+
+  function toggleNewContactForm() {
+    setShowNewContactPersonForm((formOpen) => !formOpen);
+  }
+
+  function closeNewContactForm(notification: ContactPersonAddedNotification) {
+    setShowNewContactPersonForm(false);
+    setShowContactPersonAddedNotification(notification);
+  }
+
+  function closeContactAddedNotification() {
+    setShowContactPersonAddedNotification(null);
+  }
+
+  return (
+    <>
+      <Flex justify="right" align="center" mb="var(--spacing-s)">
+        {canBeRemoved && onRemove && (
+          <Button
+            variant="supplementary"
+            iconLeft={<IconCross aria-hidden />}
+            onClick={() => onRemove(index)}
+          >
+            {t(`form:yhteystiedot:buttons:remove:${contactType}`)}
+          </Button>
+        )}
+      </Flex>
+
+      {children}
+
+      <Button
+        variant="supplementary"
+        iconLeft={addContactPersonIcon}
+        onClick={toggleNewContactForm}
+        style={{ marginBottom: 'var(--spacing-s)' }}
+      >
+        {t(`form:yhteystiedot:buttons:addNewContactPerson`)}
+      </Button>
+
+      <Transition
+        showChildren={showNewContactPersonForm}
+        animateInClass={styles.newContactPersonForm__in}
+        animateOutClass={styles.newContactPersonForm__out}
+        unmountDelay={400}
+      >
+        <NewContactPersonForm
+          hankeTunnus={hankeTunnus}
+          onContactPersonAdded={onContactPersonAdded}
+          onClose={closeNewContactForm}
+        />
+      </Transition>
+
+      {showContactPersonAddedNotification === 'success' && (
+        <Notification
+          position="top-right"
+          dismissible
+          autoClose
+          autoCloseDuration={4000}
+          type="success"
+          label={t('form:yhteystiedot:notifications:labels:contactPersonSaved')}
+          closeButtonLabelText={t('common:components:notification:closeButtonLabelText')}
+          onClose={closeContactAddedNotification}
+        >
+          {t('form:yhteystiedot:notifications:descriptions:contactPersonSaved')}
+        </Notification>
+      )}
+      {showContactPersonAddedNotification === 'error' && (
+        <Notification
+          position="top-right"
+          dismissible
+          type="error"
+          label={t('form:yhteystiedot:notifications:labels:contactPersonSaveError')}
+          closeButtonLabelText={t('common:components:notification:closeButtonLabelText')}
+          onClose={closeContactAddedNotification}
+        >
+          {t('form:yhteystiedot:notifications:descriptions:contactPersonSaveError')}
+        </Notification>
+      )}
+    </>
+  );
+};
+
+export default FormContact;

--- a/src/domain/forms/components/NewContactPersonForm.module.scss
+++ b/src/domain/forms/components/NewContactPersonForm.module.scss
@@ -1,0 +1,12 @@
+.fieldset {
+  max-width: 740px;
+  margin-bottom: var(--spacing-s);
+  padding-top: var(--spacing-xs);
+}
+
+.formButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-s);
+  margin-top: var(--spacing-m);
+}

--- a/src/domain/forms/components/NewContactPersonForm.tsx
+++ b/src/domain/forms/components/NewContactPersonForm.tsx
@@ -1,0 +1,101 @@
+import { useTranslation } from 'react-i18next';
+import { FormProvider, useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useMutation } from 'react-query';
+import { Button, Fieldset, IconCheck, IconCross } from 'hds-react';
+import ResponsiveGrid from '../../../common/components/grid/ResponsiveGrid';
+import TextInput from '../../../common/components/textInput/TextInput';
+import { createHankeUser } from '../../hanke/hankeUsers/hankeUsersApi';
+import { contactPersonSchema } from '../../hanke/edit/hankeSchema';
+import { ContactPerson, CONTACT_PERSON_FORMFIELD } from '../../hanke/edit/types';
+import styles from './NewContactPersonForm.module.scss';
+import { HankeUser } from '../../hanke/hankeUsers/hankeUser';
+
+export type ContactPersonAddedNotification = 'success' | 'error' | null;
+
+type Props = {
+  hankeTunnus: string;
+  onContactPersonAdded?: (newHankeUser: HankeUser) => void;
+  onClose: (notification: ContactPersonAddedNotification) => void;
+};
+
+function NewContactPersonForm({ hankeTunnus, onContactPersonAdded, onClose }: Readonly<Props>) {
+  const { t } = useTranslation();
+  const formContext = useForm<ContactPerson>({
+    mode: 'onTouched',
+    resolver: yupResolver(contactPersonSchema),
+  });
+  const { getValues, trigger } = formContext;
+  const { mutate } = useMutation(createHankeUser);
+
+  async function saveContact() {
+    const isFormValid = await trigger(undefined, { shouldFocus: true });
+    if (!isFormValid) {
+      return;
+    }
+
+    mutate(
+      { hankeTunnus, user: getValues() },
+      {
+        onSuccess(data) {
+          if (onContactPersonAdded) {
+            onContactPersonAdded(data);
+          }
+          onClose('success');
+        },
+        onError() {
+          onClose('error');
+        },
+      },
+    );
+  }
+
+  function cancelContactAdd() {
+    onClose(null);
+  }
+
+  return (
+    <FormProvider {...formContext}>
+      <Fieldset
+        heading={t('form:yhteystiedot:titles:subContactInformation')}
+        border
+        className={styles.fieldset}
+      >
+        <ResponsiveGrid maxColumns={2}>
+          <TextInput
+            name={CONTACT_PERSON_FORMFIELD.ETUNIMI}
+            label={t('hankeForm:labels:etunimi')}
+            required
+          />
+          <TextInput
+            name={CONTACT_PERSON_FORMFIELD.SUKUNIMI}
+            label={t('hankeForm:labels:sukunimi')}
+            required
+          />
+        </ResponsiveGrid>
+        <ResponsiveGrid maxColumns={2}>
+          <TextInput
+            name={CONTACT_PERSON_FORMFIELD.EMAIL}
+            label={t('hankeForm:labels:email')}
+            required
+          />
+          <TextInput
+            name={CONTACT_PERSON_FORMFIELD.PUHELINNUMERO}
+            label={t('hankeForm:labels:puhelinnumero')}
+            required
+          />
+        </ResponsiveGrid>
+        <div className={styles.formButtons}>
+          <Button iconLeft={<IconCheck />} onClick={saveContact}>
+            {t('form:yhteystiedot:buttons:saveAndAddContactPerson')}
+          </Button>
+          <Button iconLeft={<IconCross />} variant="secondary" onClick={cancelContactAdd}>
+            {t('common:confirmationDialog:cancelButton')}
+          </Button>
+        </div>
+      </Fieldset>
+    </FormProvider>
+  );
+}
+
+export default NewContactPersonForm;

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -1,16 +1,15 @@
 import React, { useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { $enum } from 'ts-enum-util';
-import { Accordion, Button, Fieldset, IconCross, IconPlusCircle } from 'hds-react';
+import { Accordion, Button, Fieldset, IconPlusCircle } from 'hds-react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { CONTACT_FORMFIELD, FORMFIELD, FormProps, SUBCONTACT_FORMFIELD } from './types';
+import { CONTACT_FORMFIELD, FORMFIELD, FormProps } from './types';
 import {
   HankeContact,
   CONTACT_TYYPPI,
   HANKE_CONTACT_TYPE,
   HankeContactTypeKey,
   HankeMuuTaho,
-  HankeSubContact,
 } from '../../types/hanke';
 import Text from '../../../common/components/text/Text';
 import { useFormPage } from './hooks/useFormPage';
@@ -18,8 +17,8 @@ import TextInput from '../../../common/components/textInput/TextInput';
 import useLocale from '../../../common/hooks/useLocale';
 import Dropdown from '../../../common/components/dropdown/Dropdown';
 import ResponsiveGrid from '../../../common/components/grid/ResponsiveGrid';
-import Contact from '../../forms/components/Contact';
 import './HankeForm.styles.scss';
+import FormContact from '../../forms/components/FormContact';
 
 const CONTACT_FIELDS: Array<keyof HankeContact> = [
   'tyyppi',
@@ -51,64 +50,6 @@ function getEmptyOtherContact(): HankeMuuTaho {
     alikontaktit: [],
   };
 }
-
-function getEmptySubContact(): HankeSubContact {
-  return {
-    etunimi: '',
-    sukunimi: '',
-    email: '',
-    puhelinnumero: '',
-  };
-}
-
-interface SubContactFieldProps {
-  fieldPath: string;
-  canBeRemoved?: boolean;
-  onRemove: () => void;
-}
-
-const SubContactFields = ({ fieldPath, canBeRemoved = true, onRemove }: SubContactFieldProps) => {
-  const { t } = useTranslation();
-
-  return (
-    <Fieldset
-      heading={t('form:yhteystiedot:titles:subContactInformation')}
-      border
-      className="fieldset"
-    >
-      <ResponsiveGrid>
-        <TextInput
-          name={`${fieldPath}.${SUBCONTACT_FORMFIELD.ETUNIMI}`}
-          label={t(`form:yhteystiedot:labels:${SUBCONTACT_FORMFIELD.ETUNIMI}`)}
-        />
-        <TextInput
-          name={`${fieldPath}.${SUBCONTACT_FORMFIELD.SUKUNIMI}`}
-          label={t(`form:yhteystiedot:labels:${SUBCONTACT_FORMFIELD.SUKUNIMI}`)}
-        />
-      </ResponsiveGrid>
-      <ResponsiveGrid>
-        <TextInput
-          name={`${fieldPath}.${SUBCONTACT_FORMFIELD.EMAIL}`}
-          label={t(`form:yhteystiedot:labels:${SUBCONTACT_FORMFIELD.EMAIL}`)}
-        />
-        <TextInput
-          name={`${fieldPath}.${SUBCONTACT_FORMFIELD.PUHELINNUMERO}`}
-          label={t(`form:yhteystiedot:labels:${SUBCONTACT_FORMFIELD.PUHELINNUMERO}`)}
-        />
-        {canBeRemoved && (
-          <Button
-            variant="supplementary"
-            iconLeft={<IconCross aria-hidden />}
-            onClick={onRemove}
-            style={{ alignSelf: 'end' }}
-          >
-            {t(`form:yhteystiedot:buttons:removeSubContact`)}
-          </Button>
-        )}
-      </ResponsiveGrid>
-    </Fieldset>
-  );
-};
 
 const ContactField: React.FC<{
   field: keyof HankeContact;
@@ -152,7 +93,7 @@ const ContactField: React.FC<{
   return <TextInput name={fieldName} label={label} disabled={inputDisabled} />;
 };
 
-const HankeFormYhteystiedot: React.FC<FormProps> = () => {
+const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
   useFormPage();
   const { t } = useTranslation();
   const locale = useLocale();
@@ -213,25 +154,13 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
       >
         {omistajat.map((item, index) => {
           return (
-            <Contact<HankeContactTypeKey>
+            <FormContact<HankeContactTypeKey>
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.OMISTAJAT}
+              hankeTunnus={formData.hankeTunnus!}
               index={index}
               canBeRemoved={omistajat.length > 1}
               onRemove={removeOmistaja}
-              subContactPath={`${HANKE_CONTACT_TYPE.OMISTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
-              subContactTemplate={true}
-              emptySubContact={getEmptySubContact()}
-              renderSubContact={(subContactIndex, subContactCount, removeSubContact) => {
-                const fieldPath = `${HANKE_CONTACT_TYPE.OMISTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
-                return (
-                  <SubContactFields
-                    fieldPath={fieldPath}
-                    canBeRemoved={subContactCount > 1}
-                    onRemove={() => removeSubContact(subContactIndex)}
-                  />
-                );
-              }}
             >
               <Fieldset
                 heading={t('form:yhteystiedot:titles:omistaja')}
@@ -252,7 +181,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
                   })}
                 </ResponsiveGrid>
               </Fieldset>
-            </Contact>
+            </FormContact>
           );
         })}
 
@@ -274,22 +203,12 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
       >
         {rakennuttajat.map((item, index) => {
           return (
-            <Contact<HankeContactTypeKey>
+            <FormContact<HankeContactTypeKey>
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.RAKENNUTTAJAT}
+              hankeTunnus={formData.hankeTunnus!}
               index={index}
               onRemove={removeRakennuttaja}
-              subContactPath={`${HANKE_CONTACT_TYPE.RAKENNUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
-              emptySubContact={getEmptySubContact()}
-              renderSubContact={(subContactIndex, _, removeSubContact) => {
-                const fieldPath = `${HANKE_CONTACT_TYPE.RAKENNUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
-                return (
-                  <SubContactFields
-                    fieldPath={fieldPath}
-                    onRemove={() => removeSubContact(subContactIndex)}
-                  />
-                );
-              }}
             >
               <Fieldset
                 heading={t('form:yhteystiedot:titles:rakennuttajat')}
@@ -310,7 +229,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
                   })}
                 </ResponsiveGrid>
               </Fieldset>
-            </Contact>
+            </FormContact>
           );
         })}
 
@@ -332,22 +251,12 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
       >
         {toteuttajat.map((item, index) => {
           return (
-            <Contact<HankeContactTypeKey>
+            <FormContact<HankeContactTypeKey>
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.TOTEUTTAJAT}
+              hankeTunnus={formData.hankeTunnus!}
               index={index}
               onRemove={removeToteuttaja}
-              subContactPath={`${HANKE_CONTACT_TYPE.TOTEUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
-              emptySubContact={getEmptySubContact()}
-              renderSubContact={(subContactIndex, _, removeSubContact) => {
-                const fieldPath = `${HANKE_CONTACT_TYPE.TOTEUTTAJAT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
-                return (
-                  <SubContactFields
-                    fieldPath={fieldPath}
-                    onRemove={() => removeSubContact(subContactIndex)}
-                  />
-                );
-              }}
             >
               <Fieldset
                 heading={t('form:yhteystiedot:titles:toteuttajat')}
@@ -368,7 +277,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
                   })}
                 </ResponsiveGrid>
               </Fieldset>
-            </Contact>
+            </FormContact>
           );
         })}
 
@@ -392,22 +301,12 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
           const fieldPath = `${FORMFIELD.MUUTTAHOT}.${index}`;
 
           return (
-            <Contact<HankeContactTypeKey>
+            <FormContact<HankeContactTypeKey>
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.MUUTTAHOT}
+              hankeTunnus={formData.hankeTunnus!}
               index={index}
               onRemove={removeMuuTaho}
-              subContactPath={`${HANKE_CONTACT_TYPE.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}`}
-              emptySubContact={getEmptySubContact()}
-              renderSubContact={(subContactIndex, _, removeSubContact) => {
-                const subContactFieldPath = `${HANKE_CONTACT_TYPE.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.ALIKONTAKTIT}.${subContactIndex}`;
-                return (
-                  <SubContactFields
-                    fieldPath={subContactFieldPath}
-                    onRemove={() => removeSubContact(subContactIndex)}
-                  />
-                );
-              }}
             >
               <Fieldset
                 heading={t('form:yhteystiedot:titles:muut')}
@@ -444,7 +343,7 @@ const HankeFormYhteystiedot: React.FC<FormProps> = () => {
                   />
                 </ResponsiveGrid>
               </Fieldset>
-            </Contact>
+            </FormContact>
           );
         })}
 

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -9,19 +9,15 @@ import {
   HANKE_KAISTAPITUUSHAITTA,
   CONTACT_TYYPPI,
 } from '../../types/hanke';
-import { FORMFIELD, CONTACT_FORMFIELD, SUBCONTACT_FORMFIELD } from './types';
+import { FORMFIELD, CONTACT_FORMFIELD, CONTACT_PERSON_FORMFIELD } from './types';
 import isValidBusinessId from '../../../common/utils/isValidBusinessId';
 
-const subContactSchema = yup
-  .object()
-  .nullable()
-  .default(null)
-  .shape({
-    [SUBCONTACT_FORMFIELD.SUKUNIMI]: yup.string().max(50),
-    [SUBCONTACT_FORMFIELD.ETUNIMI]: yup.string().max(50),
-    [SUBCONTACT_FORMFIELD.EMAIL]: yup.string().email().max(100),
-    [SUBCONTACT_FORMFIELD.PUHELINNUMERO]: yup.string().nullable().default(null).max(20),
-  });
+export const contactPersonSchema = yup.object({
+  [CONTACT_PERSON_FORMFIELD.ETUNIMI]: yup.string().max(50).required(),
+  [CONTACT_PERSON_FORMFIELD.SUKUNIMI]: yup.string().max(50).required(),
+  [CONTACT_PERSON_FORMFIELD.EMAIL]: yup.string().email().max(100).required(),
+  [CONTACT_PERSON_FORMFIELD.PUHELINNUMERO]: yup.string().max(20).required(),
+});
 
 const contactSchema = yup
   .object()
@@ -45,7 +41,6 @@ const contactSchema = yup
       }),
     [CONTACT_FORMFIELD.EMAIL]: yup.string().email().max(100),
     [CONTACT_FORMFIELD.PUHELINNUMERO]: yup.string().nullable().default(null).max(20),
-    [CONTACT_FORMFIELD.ALIKONTAKTIT]: yup.array().ensure().of(subContactSchema),
   });
 
 const otherPartySchema = contactSchema

--- a/src/domain/hanke/edit/types.ts
+++ b/src/domain/hanke/edit/types.ts
@@ -4,7 +4,7 @@ import Geometry from 'ol/geom/Geometry';
 import { PartialExcept } from '../../../common/types/utils';
 import { HankeData, HankeContactTypeKey, HankeAlue } from '../../types/hanke';
 import yup from '../../../common/utils/yup';
-import { newHankeSchema } from './hankeSchema';
+import { contactPersonSchema, newHankeSchema } from './hankeSchema';
 
 export type FormNotification = 'ok' | 'success' | 'error' | null;
 
@@ -45,11 +45,10 @@ export enum CONTACT_FORMFIELD {
   ALIKONTAKTIT = 'alikontaktit',
 }
 
-export enum SUBCONTACT_FORMFIELD {
-  ID = 'id',
+export enum CONTACT_PERSON_FORMFIELD {
   ETUNIMI = 'etunimi',
   SUKUNIMI = 'sukunimi',
-  EMAIL = 'email',
+  EMAIL = 'sahkoposti',
   PUHELINNUMERO = 'puhelinnumero',
 }
 
@@ -81,3 +80,5 @@ export type Organization = {
 };
 
 export type NewHankeData = yup.InferType<typeof newHankeSchema>;
+
+export type ContactPerson = yup.InferType<typeof contactPersonSchema>;

--- a/src/domain/hanke/hankeUsers/hankeUser.ts
+++ b/src/domain/hanke/hankeUsers/hankeUser.ts
@@ -10,6 +10,8 @@ export type HankeUser = {
   id: string;
   sahkoposti: string;
   nimi: string;
+  etunimi: string;
+  sukunimi: string;
   kayttooikeustaso: keyof typeof AccessRightLevel;
   tunnistautunut: boolean;
 };

--- a/src/domain/hanke/hankeUsers/hankeUsersApi.ts
+++ b/src/domain/hanke/hankeUsers/hankeUsersApi.ts
@@ -1,5 +1,17 @@
 import api from '../../api/api';
 import { HankeUser, IdentificationResponse, SignedInUser, SignedInUserByHanke } from './hankeUser';
+import { ContactPerson } from '../edit/types';
+
+export async function createHankeUser({
+  hankeTunnus,
+  user,
+}: {
+  hankeTunnus: string;
+  user: ContactPerson;
+}) {
+  const { data } = await api.post<HankeUser>(`hankkeet/${hankeTunnus}/kayttajat`, user);
+  return data;
+}
 
 export async function getHankeUsers(hankeTunnus: string) {
   const { data } = await api.get<{ kayttajat: HankeUser[] }>(`hankkeet/${hankeTunnus}/kayttajat`);

--- a/src/domain/map/HankeMap.test.tsx
+++ b/src/domain/map/HankeMap.test.tsx
@@ -26,7 +26,6 @@ describe('HankeMap', () => {
     await screen.findByPlaceholderText('Etsi osoitteella');
     await screen.findByText('Ajanjakson alku');
 
-    expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('2');
     changeFilterDate(startDateLabel, renderedComponent, '1.1.2022');
     expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('2');
     changeFilterDate(endDateLabel, renderedComponent, '1.1.2022');

--- a/src/domain/mocks/data/hankkeet.ts
+++ b/src/domain/mocks/data/hankkeet.ts
@@ -36,7 +36,6 @@ export async function create(data: HankeDataDraft) {
 
 export async function update(hankeTunnus: string, updates: HankeDataDraft) {
   let hanke = await read(hankeTunnus);
-  console.log(hankeTunnus, hanke);
   if (!hanke) {
     throw new Error(`No hanke with hankeTunnus ${hankeTunnus}`);
   }

--- a/src/domain/mocks/data/users-data.json
+++ b/src/domain/mocks/data/users-data.json
@@ -3,6 +3,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "sahkoposti": "matti.meikalainen@test.com",
     "nimi": "Matti Meikäläinen",
+    "etunimi": "Matti",
+    "sukunimi": "Meikäläinen",
     "kayttooikeustaso": "KAIKKI_OIKEUDET",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"
@@ -11,6 +13,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa7",
     "sahkoposti": "teppo@test.com",
     "nimi": "Teppo Työmies",
+    "etunimi": "Teppo",
+    "sukunimi": "Työmies",
     "kayttooikeustaso": "KAIKKIEN_MUOKKAUS",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -19,6 +23,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa8",
     "sahkoposti": "aku@asiakas.com",
     "nimi": "Aku Asiakas",
+    "etunimi": "Aku",
+    "sukunimi": "Asiakas",
     "kayttooikeustaso": "HANKEMUOKKAUS",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"
@@ -27,6 +33,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa9",
     "sahkoposti": "vilja@test.com",
     "nimi": "Vilja Viljanen",
+    "etunimi": "Vilja",
+    "sukunimi": "Viljanen",
     "kayttooikeustaso": "KAIKKI_OIKEUDET",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -35,6 +43,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb1",
     "sahkoposti": "tauno@test.com",
     "nimi": "Tauno Testinen",
+    "etunimi": "Tauno",
+    "sukunimi": "Testinen",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -43,6 +53,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb2",
     "sahkoposti": "marja@test.com",
     "nimi": "Marja Marjanen",
+    "etunimi": "Marja",
+    "sukunimi": "Marjanen",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -51,6 +63,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb3",
     "sahkoposti": "milka@test.com",
     "nimi": "Milka Marjanen",
+    "etunimi": "Milka",
+    "sukunimi": "Marjanen",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"
@@ -59,6 +73,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb4",
     "sahkoposti": "sakari@test.com",
     "nimi": "Sakari Selkonen",
+    "etunimi": "Sakari",
+    "sukunimi": "Selkonen",
     "kayttooikeustaso": "HAKEMUSASIOINTI",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"
@@ -67,6 +83,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb5",
     "sahkoposti": "keijo@test.com",
     "nimi": "Keijo Keijonen",
+    "etunimi": "Keijo",
+    "sukunimi": "Keijonen",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"
@@ -75,6 +93,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb6",
     "sahkoposti": "alma@test.com",
     "nimi": "Alma Testinen",
+    "etunimi": "Alma",
+    "sukunimi": "Testinen",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -83,6 +103,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb7",
     "sahkoposti": "taneli@test.com",
     "nimi": "Taneli Taunonen",
+    "etunimi": "Taneli",
+    "sukunimi": "Taunonen",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -91,6 +113,8 @@
     "id": "3fa85f64-5717-4562-b3fc-2c963f66af5",
     "sahkoposti": "matti@test.com",
     "nimi": "matti Meikäläinen",
+    "etunimi": "matti",
+    "sukunimi": "Meikäläinen",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"

--- a/src/domain/mocks/data/users.ts
+++ b/src/domain/mocks/data/users.ts
@@ -1,5 +1,7 @@
+import { faker } from '@faker-js/faker';
 import usersData from './users-data.json';
 import { AccessRightLevel, HankeUser } from '../../hanke/hankeUsers/hankeUser';
+import { ContactPerson } from '../../hanke/edit/types';
 
 let users = [...usersData];
 
@@ -10,9 +12,25 @@ export async function readAll(hankeTunnus: string): Promise<HankeUser[]> {
       id: user.id,
       sahkoposti: user.sahkoposti,
       nimi: user.nimi,
+      etunimi: user.etunimi,
+      sukunimi: user.sukunimi,
       kayttooikeustaso: user.kayttooikeustaso as AccessRightLevel,
       tunnistautunut: user.tunnistautunut,
     }));
+}
+
+export async function create(hankeTunnus: string, user: ContactPerson) {
+  const newUser: HankeUser = {
+    id: faker.string.uuid(),
+    etunimi: user.etunimi,
+    sukunimi: user.sukunimi,
+    sahkoposti: user.sahkoposti,
+    nimi: `${user.etunimi} ${user.sukunimi}`,
+    kayttooikeustaso: AccessRightLevel.KATSELUOIKEUS,
+    tunnistautunut: false,
+  };
+  users.push({ ...newUser, hankeTunnus });
+  return newUser;
 }
 
 export async function update(hankeTunnus: string, modifiedUsers: HankeUser[]) {

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -6,6 +6,7 @@ import * as hakemuksetDB from './data/hakemukset';
 import * as usersDB from './data/users';
 import ApiError from './apiError';
 import { IdentificationResponse, SignedInUser } from '../hanke/hankeUsers/hankeUser';
+import { ContactPerson } from '../hanke/edit/types';
 
 const apiUrl = '/api';
 
@@ -176,6 +177,13 @@ export const handlers = [
     const { hankeTunnus } = req.params;
     const users = await usersDB.readAll(hankeTunnus as string);
     return res(ctx.status(200), ctx.json({ kayttajat: users }));
+  }),
+
+  rest.post(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat`, async (req, res, ctx) => {
+    const { hankeTunnus } = req.params;
+    const user: ContactPerson = await req.json();
+    const createdUser = await usersDB.create(hankeTunnus as string, user);
+    return res(ctx.status(200), ctx.json(createdUser));
   }),
 
   rest.put(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat`, async (req, res, ctx) => {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -218,7 +218,9 @@
       },
       "buttons": {
         "addSubContact": "Lisää yhteyshenkilö",
+        "addNewContactPerson": "Lisää uusi yhteyshenkilö",
         "removeSubContact": "Poista yhteyshenkilö",
+        "saveAndAddContactPerson": "Tallenna ja lisää yhteyshenkilö",
         "remove": {
           "omistajat": "Poista omistaja",
           "rakennuttajat": "Poista rakennuttaja",
@@ -226,6 +228,16 @@
           "muut": "Poista muu taho",
           "propertyDeveloperWithContacts": "Poista rakennuttaja",
           "representativeWithContacts": "Poista asianhoitaja"
+        }
+      },
+      "notifications": {
+        "labels": {
+          "contactPersonSaved": "Yhteyshenkilö tallennettu",
+          "contactPersonSaveError": "Yhteyshenkilön tallennus epäonnistui"
+        },
+        "descriptions": {
+          "contactPersonSaved": "Yhteyshenkilön tiedot tallennettu ja lisätty hankkelle onnistuneesti.",
+          "contactPersonSaveError": "Yhteyshenkilön tietojen tallennus epäonnistui. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman teknisen tukeen."
         }
       }
     }
@@ -493,7 +505,7 @@
       "sukunimi": "Sukunimi",
       "etunimi": "Etunimi",
       "email": "Sähköposti",
-      "puhelinnumero": "Puhelin",
+      "puhelinnumero": "Puhelinnumero",
       "osasto": "Osasto",
       "organisaatio": "Organisaatio",
       "omaOrganisaatio": "Lisää oma organisaatio",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3321,6 +3321,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.46.0.tgz#3f7802972e8b6fe3f88ed1aabc74ec596c456db6"
   integrity sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==
 
+"@faker-js/faker@^8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.3.1.tgz#7753df0cb88d7649becf984a96dd1bd0a26f43e3"
+  integrity sha512-FdgpFxY6V6rLZE9mmIBb9hM0xpfvQOSNOLnzolzKwsE1DH+gC7lEKV1p1IbR0lAYyvYd5a4u3qWJzowUkw1bIw==
+
 "@hapi/hoek@^9.0.0":
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.0.tgz#6c9eafc78c1529248f8f4d92b0799a712b6052c6"


### PR DESCRIPTION
# Description

User can create new user for hanke in hanke form by clicking Add new contact button and filling the form that is opened.

User that is created is not yet added as a contact person for the contact that it's created, that will be done later.

### Jira Issue:

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new hanke or edit existing hanke
2. Go to contacts page of hanke form
3. Click "Lisää uusi yhteyshenkilö" button for example for hanke owner
4. Form for new contact person should open below
5. Leave some of the fields empty and click "Tallenna ja lisää yhteyshenkilö" button
6. Validation errors should be shown for empty fields and new contact person should not be saved
7. Fill rest of the fields and click "Tallenna ja lisää yhteyshenkilö" button
8. Contact person form should be closed and notification "Yhteyshenkilö tallennettu" should be shown

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
