### PR TITLE
HAI-1976 Add user permissions info for each hanke in hanke list

### DIFF
--- a/src/domain/hanke/portfolio/HankePortfolio.test.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolio.test.tsx
@@ -191,6 +191,14 @@ describe('HankePortfolioComponent', () => {
       screen.getAllByText('Tämä hanke on muodostettu johtoselvityksen perusteella.'),
     ).toHaveLength(1);
   });
+
+  test('Should show user permission info for hankkeet', () => {
+    const userData = userDataByHanke(hankeList.map((hanke) => hanke.hankeTunnus));
+
+    render(<HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={userData} />);
+
+    expect(screen.getAllByText(/kaikki oikeudet/i)).toHaveLength(2);
+  });
 });
 
 describe('HankePortfolioContainer', () => {

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -218,6 +218,11 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke, signedInUser, 
                 <Text tag="h3" styleAs="h6" weight="bold" className={styles.infoHeader}>
                   {t('hankeForm:labels:rights')}
                 </Text>
+                {signedInUser !== undefined && (
+                  <Text tag="p" styleAs="body-m" className={styles.infoContent}>
+                    {t(`hankeUsers:accessRightLevels:${signedInUser.kayttooikeustaso}`)}
+                  </Text>
+                )}
               </div>
             </FeatureFlags>
           </div>


### PR DESCRIPTION
# Description

Information about user permissions for each hanke was missing in hanke list, so added that.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1976

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

1. Go to hanke list
2. Open any hanke by clicking its name
3. Check that in the section "Käyttöoikeutesi hankkeelle" has info about your permissions

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
