### PR TITLE
HAI-1975 Update hanke draft state notification to match new design in hanke list

### DIFF
--- a/src/domain/hanke/portfolio/HankePortfolio.test.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolio.test.tsx
@@ -169,11 +169,7 @@ describe('HankePortfolioComponent', () => {
   test('Should show draft state notification for hankkeet that are in draft state', async () => {
     render(<HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />);
 
-    expect(
-      screen.getAllByText(
-        'Hanke on luonnostilassa. Alueiden haittatiedot ja muut pakolliset tiedot on täytettävä hankkeen julkaisemiseksi ja lupien lisäämiseksi.',
-      ),
-    ).toHaveLength(1);
+    expect(screen.getAllByText('Luonnos')).toHaveLength(1);
   });
 
   test('Should show generated state notification for hankkeet that are generated', async () => {

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -9,8 +9,9 @@ import {
   useAsyncDebounce,
   useSortBy,
 } from 'react-table';
-import { useAccordion, Card, Select, Button, Pagination, SearchInput } from 'hds-react';
+import { useAccordion, Card, Select, Button, Pagination, SearchInput, Tag } from 'hds-react';
 import {
+  IconAlertCircle,
   IconAngleDown,
   IconAngleUp,
   IconEye,
@@ -20,6 +21,7 @@ import {
 } from 'hds-react/icons';
 import { Link, useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
+import { Flex } from '@chakra-ui/react';
 import Text from '../../../common/components/text/Text';
 import { HankeData, HANKE_TYOMAATYYPPI, HANKE_VAIHE } from '../../types/hanke';
 import styles from './HankePortfolio.module.scss';
@@ -33,7 +35,6 @@ import HankeVaiheTag from '../vaiheTag/HankeVaiheTag';
 import { Language } from '../../../common/types/language';
 import OwnHankeMap from '../../map/components/OwnHankeMap/OwnHankeMap';
 import OwnHankeMapHeader from '../../map/components/OwnHankeMap/OwnHankeMapHeader';
-import HankeDraftStateNotification from '../edit/components/HankeDraftStateNotification';
 import HankeGeneratedStateNotification from '../edit/components/HankeGeneratedStateNotification';
 import Container from '../../../common/components/container/Container';
 import useHankeViewPath from '../hooks/useHankeViewPath';
@@ -96,6 +97,14 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke, signedInUser, 
                 {hanke.nimi}
               </Text>
               <FeatureFlags flags={['hanke']}>
+                {hanke.status === 'DRAFT' && (
+                  <Tag>
+                    <Flex alignItems="center">
+                      <IconAlertCircle style={{ marginRight: 'var(--spacing-2-xs)' }} />
+                      {t('hakemus:status:null')}
+                    </Flex>
+                  </Tag>
+                )}
                 <HankeVaiheTag tagName={hanke.vaihe} />
               </FeatureFlags>
             </div>
@@ -151,7 +160,6 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke, signedInUser, 
             generated={hanke.generated}
             className={styles.stateNotification}
           />
-          <HankeDraftStateNotification hanke={hanke} className={styles.stateNotification} />
         </FeatureFlags>
       </>
       <div className={styles.hankeCardContent} {...contentProps}>


### PR DESCRIPTION
# Description

Design for hanke draft state notification in hanke list changed from longer notification text to a tag, so updated UI to match that.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1975

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

1. Create a new hanke but don't fill all the information
2. Go to hanke list and check that hanke draft state matches Figma design: https://www.figma.com/file/dRtEnlMJUwz0KUPqAaTzq3/Haitaton-2.0?type=design&node-id=4724-24509&mode=design

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
