### PR TITLE
HAI-2158 Rework user management page

### DIFF
--- a/src/assets/styles/reset.css
+++ b/src/assets/styles/reset.css
@@ -84,5 +84,4 @@ video {
   padding: 0;
   border: 0;
   font-size: 100%;
-  vertical-align: baseline;
 }

--- a/src/domain/hanke/accessRights/AccessRightsView.module.scss
+++ b/src/domain/hanke/accessRights/AccessRightsView.module.scss
@@ -16,19 +16,12 @@
   padding-bottom: var(--spacing-m);
 }
 
-.hankeLink {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-2-xs);
-  margin-bottom: var(--spacing-m);
-
-  &:hover {
-    text-decoration: underline;
-  }
+.breadcrumb > nav {
+  margin: 0 !important;
 }
 
 .infoAccordion {
-  margin-bottom: var(--spacing-xl);
+  margin-bottom: var(--spacing-m);
 
   .infoList {
     padding-left: var(--spacing-m);
@@ -49,30 +42,22 @@
 }
 
 .table > div {
-  overflow-x: initial;
   display: none;
 
-  @include respond-above(l) {
+  @include respond-above(m) {
     display: block;
   }
 }
 
 .userCards {
-  @include respond-above(l) {
+  @include respond-above(m) {
     display: none;
   }
 }
 
-.accessRightSelect {
-  min-width: auto;
-
-  @include respond-above(m) {
-    min-width: 250px;
-  }
-
-  @include respond-above(l) {
-    min-width: 345px;
-  }
+.userIcon {
+  align-self: center;
+  margin-right: var(--spacing-xs);
 }
 
 .invitationSendButtonContainer {

--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { rest } from 'msw';
 import { render, cleanup, screen, waitFor, fireEvent } from '../../../testUtils/render';
 import { waitForLoadingToFinish } from '../../../testUtils/helperFunctions';
@@ -6,7 +5,6 @@ import AccessRightsViewContainer from './AccessRightsViewContainer';
 import { server } from '../../mocks/test-server';
 import usersData from '../../mocks/data/users-data.json';
 import { SignedInUser } from '../hankeUsers/hankeUser';
-import * as hankeUsersApi from '../../hanke/hankeUsers/hankeUsersApi';
 
 jest.setTimeout(50000);
 
@@ -39,40 +37,30 @@ test('Renders correct information', async () => {
   await waitForLoadingToFinish();
 
   expect(
-    screen.queryByText('Aidasmäentien vesihuollon rakentaminen (HAI22-2)'),
+    screen.getByRole('link', { name: 'Aidasmäentien vesihuollon rakentaminen (HAI22-2)' }),
   ).toBeInTheDocument();
   expect((screen.getByRole('table') as HTMLTableElement).tBodies[0].rows).toHaveLength(10);
-  expect(screen.getAllByText(users[0].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[0].etunimi} ${users[0].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[0].sahkoposti)).toHaveLength(2);
-  expect(screen.getAllByText(users[1].nimi)).toHaveLength(2);
+  expect(screen.getByTestId('puhelinnumero-0')).toHaveTextContent('0401234567');
+  expect(screen.getAllByText(`${users[1].etunimi} ${users[1].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[1].sahkoposti)).toHaveLength(2);
-  expect(screen.getAllByText(users[2].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[2].etunimi} ${users[2].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[2].sahkoposti)).toHaveLength(2);
-  expect(screen.getAllByText(users[3].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[3].etunimi} ${users[3].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[3].sahkoposti)).toHaveLength(2);
-  expect(screen.getAllByText(users[4].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[4].etunimi} ${users[4].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[4].sahkoposti)).toHaveLength(2);
-  expect(screen.getAllByText(users[5].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[5].etunimi} ${users[5].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[5].sahkoposti)).toHaveLength(2);
-  expect(screen.getAllByText(users[6].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[6].etunimi} ${users[6].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[6].sahkoposti)).toHaveLength(2);
-  expect(screen.getAllByText(users[7].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[7].etunimi} ${users[7].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[7].sahkoposti)).toHaveLength(2);
-  expect(screen.getAllByText(users[8].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[8].etunimi} ${users[8].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[8].sahkoposti)).toHaveLength(2);
-  expect(screen.getAllByText(users[9].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[9].etunimi} ${users[9].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[9].sahkoposti)).toHaveLength(2);
-});
-
-test('Link back to related hanke should work', async () => {
-  const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
-
-  await waitForLoadingToFinish();
-  await user.click(
-    screen.getByRole('link', { name: 'Aidasmäentien vesihuollon rakentaminen (HAI22-2)' }),
-  );
-
-  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2');
 });
 
 test('Pagination works', async () => {
@@ -82,7 +70,7 @@ test('Pagination works', async () => {
   fireEvent.click(screen.getByTestId('hds-pagination-next-button'));
 
   expect((screen.getByRole('table') as HTMLTableElement).tBodies[0].rows).toHaveLength(2);
-  expect(screen.getAllByText(users[10].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[10].etunimi} ${users[10].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[10].sahkoposti)).toHaveLength(2);
 });
 
@@ -92,29 +80,29 @@ test('Sorting by users name works', async () => {
   await waitForLoadingToFinish();
   fireEvent.click(screen.getByTestId('hds-table-sorting-header-nimi'));
 
-  expect(screen.getByTestId('nimi-0')).toHaveTextContent(users[2].nimi);
-  expect(screen.getByTestId('nimi-1')).toHaveTextContent(users[9].nimi);
-  expect(screen.getByTestId('nimi-2')).toHaveTextContent(users[8].nimi);
-  expect(screen.getByTestId('nimi-3')).toHaveTextContent(users[5].nimi);
-  expect(screen.getByTestId('nimi-4')).toHaveTextContent(users[0].nimi);
-  expect(screen.getByTestId('nimi-5')).toHaveTextContent(users[11].nimi);
-  expect(screen.getByTestId('nimi-6')).toHaveTextContent(users[6].nimi);
-  expect(screen.getByTestId('nimi-7')).toHaveTextContent(users[7].nimi);
-  expect(screen.getByTestId('nimi-8')).toHaveTextContent(users[10].nimi);
-  expect(screen.getByTestId('nimi-9')).toHaveTextContent(users[4].nimi);
+  expect(screen.getByTestId('nimi-0')).toHaveTextContent(users[2].etunimi);
+  expect(screen.getByTestId('nimi-1')).toHaveTextContent(users[9].etunimi);
+  expect(screen.getByTestId('nimi-2')).toHaveTextContent(users[8].etunimi);
+  expect(screen.getByTestId('nimi-3')).toHaveTextContent(users[5].etunimi);
+  expect(screen.getByTestId('nimi-4')).toHaveTextContent(users[0].etunimi);
+  expect(screen.getByTestId('nimi-5')).toHaveTextContent(users[11].etunimi);
+  expect(screen.getByTestId('nimi-6')).toHaveTextContent(users[6].etunimi);
+  expect(screen.getByTestId('nimi-7')).toHaveTextContent(users[7].etunimi);
+  expect(screen.getByTestId('nimi-8')).toHaveTextContent(users[10].etunimi);
+  expect(screen.getByTestId('nimi-9')).toHaveTextContent(users[4].etunimi);
 
   fireEvent.click(screen.getByTestId('hds-table-sorting-header-nimi'));
 
-  expect(screen.getByTestId('nimi-0')).toHaveTextContent(users[3].nimi);
-  expect(screen.getByTestId('nimi-1')).toHaveTextContent(users[1].nimi);
-  expect(screen.getByTestId('nimi-2')).toHaveTextContent(users[4].nimi);
-  expect(screen.getByTestId('nimi-3')).toHaveTextContent(users[10].nimi);
-  expect(screen.getByTestId('nimi-4')).toHaveTextContent(users[7].nimi);
-  expect(screen.getByTestId('nimi-5')).toHaveTextContent(users[6].nimi);
-  expect(screen.getByTestId('nimi-6')).toHaveTextContent(users[0].nimi);
-  expect(screen.getByTestId('nimi-7')).toHaveTextContent(users[11].nimi);
-  expect(screen.getByTestId('nimi-8')).toHaveTextContent(users[5].nimi);
-  expect(screen.getByTestId('nimi-9')).toHaveTextContent(users[8].nimi);
+  expect(screen.getByTestId('nimi-0')).toHaveTextContent(users[3].etunimi);
+  expect(screen.getByTestId('nimi-1')).toHaveTextContent(users[1].etunimi);
+  expect(screen.getByTestId('nimi-2')).toHaveTextContent(users[4].etunimi);
+  expect(screen.getByTestId('nimi-3')).toHaveTextContent(users[10].etunimi);
+  expect(screen.getByTestId('nimi-4')).toHaveTextContent(users[7].etunimi);
+  expect(screen.getByTestId('nimi-5')).toHaveTextContent(users[6].etunimi);
+  expect(screen.getByTestId('nimi-6')).toHaveTextContent(users[0].etunimi);
+  expect(screen.getByTestId('nimi-7')).toHaveTextContent(users[11].etunimi);
+  expect(screen.getByTestId('nimi-8')).toHaveTextContent(users[5].etunimi);
+  expect(screen.getByTestId('nimi-9')).toHaveTextContent(users[8].etunimi);
 });
 
 test('Sorting by users email works', async () => {
@@ -159,7 +147,7 @@ test('Filtering works', async () => {
   await waitFor(() =>
     expect((screen.getByRole('table') as HTMLTableElement).tBodies[0].rows).toHaveLength(1),
   );
-  expect(screen.getAllByText(users[1].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[1].etunimi} ${users[1].sukunimi}`)).toHaveLength(2);
 
   // Clear the search
   await user.click(screen.getByRole('button', { name: 'Clear' }));
@@ -170,8 +158,8 @@ test('Filtering works', async () => {
   await waitFor(() =>
     expect((screen.getByRole('table') as HTMLTableElement).tBodies[0].rows).toHaveLength(2),
   );
-  expect(screen.getAllByText(users[2].nimi)).toHaveLength(2);
-  expect(screen.getAllByText(users[7].nimi)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[2].etunimi} ${users[2].sukunimi}`)).toHaveLength(2);
+  expect(screen.getAllByText(`${users[7].etunimi} ${users[7].sukunimi}`)).toHaveLength(2);
 });
 
 test('Should show error notification if information is not found', async () => {
@@ -203,118 +191,26 @@ test('Should show error notification if there is technical error', async () => {
   expect(screen.queryByText('Yritä hetken päästä uudelleen.')).toBeInTheDocument();
 });
 
-test('All rights dropdown should be disabled if only one user has all rights', async () => {
-  server.use(
-    rest.get('/api/hankkeet/:hankeTunnus/whoami', async (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json<SignedInUser>(getSignedInUser()));
-    }),
-  );
-
+test('Should show correct icons for users', async () => {
   render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
 
   await waitForLoadingToFinish();
 
-  expect(screen.getByTestId('kayttooikeustaso-0').querySelector('button')).toBeDisabled();
-});
-
-test('Should be able to edit rights if user has all rights', async () => {
-  server.use(
-    rest.get('/api/hankkeet/:hankeTunnus/whoami', async (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json<SignedInUser>(getSignedInUser()));
+  expect(
+    screen.getByRole('cell', {
+      name: 'Omat käyttäjätietosi Matti Meikäläinen',
     }),
-  );
-
-  const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
-
-  await waitForLoadingToFinish();
-
-  // Save button should be disabled when there are no changes
-  expect(screen.getByRole('button', { name: 'Tallenna muutokset' })).toBeDisabled();
-
-  fireEvent.click(screen.getAllByRole('button', { name: 'Hankkeen ja hakemusten muokkaus' })[0]);
-  fireEvent.click(screen.getAllByText('Kaikki oikeudet')[2]);
-
-  await user.click(screen.getByRole('button', { name: 'Tallenna muutokset' }));
-
-  expect(screen.queryByText('Käyttöoikeudet päivitetty')).toBeInTheDocument();
-  expect(screen.getByTestId('kayttooikeustaso-1')).toHaveTextContent('Kaikki oikeudet');
-});
-
-test('Should not be able to edit rights if user does not have enough rights', async () => {
-  server.use(
-    rest.get('/api/hankkeet/:hankeTunnus/whoami', async (req, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json<SignedInUser>(
-          getSignedInUser({ kayttooikeustaso: 'HANKEMUOKKAUS', kayttooikeudet: ['EDIT', 'VIEW'] }),
-        ),
-      );
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('cell', {
+      name: 'Kirjautunut hankkeelle tunnistautuneena Aku Asiakas',
     }),
-  );
-
-  render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
-
-  await waitForLoadingToFinish();
-
-  expect(screen.getByTestId('kayttooikeustaso-0').querySelector('button')).toBeDisabled();
-  expect(screen.getByTestId('kayttooikeustaso-1').querySelector('button')).toBeDisabled();
-  expect(screen.getByTestId('kayttooikeustaso-2').querySelector('button')).toBeDisabled();
-  expect(screen.getByTestId('kayttooikeustaso-3').querySelector('button')).toBeDisabled();
-  expect(screen.getByTestId('kayttooikeustaso-4').querySelector('button')).toBeDisabled();
-  expect(screen.getByTestId('kayttooikeustaso-5').querySelector('button')).toBeDisabled();
-  expect(screen.getByTestId('kayttooikeustaso-6').querySelector('button')).toBeDisabled();
-  expect(screen.getByTestId('kayttooikeustaso-7').querySelector('button')).toBeDisabled();
-  expect(screen.getByTestId('kayttooikeustaso-8').querySelector('button')).toBeDisabled();
-  expect(screen.getByTestId('kayttooikeustaso-9').querySelector('button')).toBeDisabled();
-});
-
-test('Should not be able to assign all rights if user does not have all rights', async () => {
-  server.use(
-    rest.get('/api/hankkeet/:hankeTunnus/whoami', async (req, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json<SignedInUser>(getSignedInUser({ kayttooikeustaso: 'KAIKKIEN_MUOKKAUS' })),
-      );
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('cell', {
+      name: 'Kutsulinkki lähetetty Teppo Työmies',
     }),
-  );
-
-  const { container } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
-
-  await waitForLoadingToFinish();
-
-  fireEvent.click(screen.getAllByRole('button', { name: 'Hankemuokkaus' })[0]);
-
-  expect(container.querySelectorAll('li')[5]).toHaveAttribute('disabled');
-});
-
-test('Should not be able to remove all rights if user does not have all rights', async () => {
-  server.use(
-    rest.get('/api/hankkeet/:hankeTunnus/whoami', async (req, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json<SignedInUser>(getSignedInUser({ kayttooikeustaso: 'KAIKKIEN_MUOKKAUS' })),
-      );
-    }),
-  );
-
-  render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
-
-  await waitForLoadingToFinish();
-
-  expect(screen.getByTestId('kayttooikeustaso-3').querySelector('button')).toBeDisabled();
-});
-
-test('Should show Käyttäjä tunnistautunut text for correct users', async () => {
-  render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
-
-  await waitForLoadingToFinish();
-
-  expect(screen.getByTestId('tunnistautunut-0')).toHaveTextContent('Käyttäjä tunnistautunut');
-  expect(screen.getByTestId('tunnistautunut-1')).not.toHaveTextContent('Käyttäjä tunnistautunut');
-  expect(screen.getByTestId('tunnistautunut-2')).toHaveTextContent('Käyttäjä tunnistautunut');
-  expect(screen.getByTestId('tunnistautunut-6')).toHaveTextContent('Käyttäjä tunnistautunut');
-  expect(screen.getByTestId('tunnistautunut-7')).toHaveTextContent('Käyttäjä tunnistautunut');
-  expect(screen.getByTestId('tunnistautunut-8')).toHaveTextContent('Käyttäjä tunnistautunut');
+  ).toBeInTheDocument();
 });
 
 test('Should send invitation to user when cliking the Lähetä kutsulinkki uudelleen button', async () => {
@@ -322,9 +218,13 @@ test('Should send invitation to user when cliking the Lähetä kutsulinkki uudel
 
   await waitForLoadingToFinish();
 
-  const invitationButton = screen.getAllByRole('button', {
-    name: 'Lähetä kutsulinkki uudelleen',
+  const invitationMenu = screen.getAllByRole('button', {
+    name: 'Käyttäjävalikko',
   })[0];
+  await user.click(invitationMenu);
+  const invitationButton = screen.getByRole('menuitem', {
+    name: 'Lähetä kutsulinkki uudelleen',
+  });
   await user.click(invitationButton);
 
   await waitFor(() => {
@@ -332,26 +232,8 @@ test('Should send invitation to user when cliking the Lähetä kutsulinkki uudel
       screen.queryByText('Kutsulinkki lähetetty osoitteeseen teppo@test.com.'),
     ).toBeInTheDocument();
   });
-  expect(invitationButton).toHaveTextContent('Kutsulinkki lähetetty');
+  await user.click(invitationMenu);
   expect(invitationButton).toBeDisabled();
-});
-
-test('Should not send multiple requests when clicking the Lähetä kutsulinkki uudelleen button many times', async () => {
-  const sendInvitation = jest.spyOn(hankeUsersApi, 'resendInvitation');
-  const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
-
-  await waitForLoadingToFinish();
-
-  const invitationButton = screen.getAllByRole('button', {
-    name: 'Lähetä kutsulinkki uudelleen',
-  })[0];
-  await user.click(invitationButton);
-  await user.click(invitationButton);
-  await user.click(invitationButton);
-
-  expect(sendInvitation).toHaveBeenCalledTimes(1);
-
-  sendInvitation.mockRestore();
 });
 
 test('Should show error notification if sending invitation fails', async () => {
@@ -365,15 +247,20 @@ test('Should show error notification if sending invitation fails', async () => {
 
   await waitForLoadingToFinish();
 
-  const invitationButton = screen.getAllByRole('button', {
-    name: 'Lähetä kutsulinkki uudelleen',
-  })[1];
-  await user.click(invitationButton);
+  const invitationMenu = screen.getAllByRole('button', {
+    name: 'Käyttäjävalikko',
+  })[0];
+  await user.click(invitationMenu);
+  await user.click(
+    screen.getByRole('menuitem', {
+      name: 'Lähetä kutsulinkki uudelleen',
+    }),
+  );
 
   expect(screen.queryByText('Virhe linkin lähettämisessä')).toBeInTheDocument();
 });
 
-test('Should not show invitation buttons if user does not have permission to send invitation', async () => {
+test('Should not show invitation menus if user does not have permission to send invitation', async () => {
   server.use(
     rest.get('/api/hankkeet/:hankeTunnus/whoami', async (req, res, ctx) => {
       return res(
@@ -390,8 +277,8 @@ test('Should not show invitation buttons if user does not have permission to sen
   await waitForLoadingToFinish();
 
   expect(
-    screen.queryAllByRole('button', {
-      name: 'Lähetä kutsulinkki uudelleen',
+    screen.queryAllByRole('cell', {
+      name: 'Käyttäjävalikko',
     }),
   ).toHaveLength(0);
 });

--- a/src/domain/hanke/accessRights/AccessRightsView.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.tsx
@@ -1,21 +1,21 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Accordion,
-  Button,
-  IconAngleLeft,
-  IconSaveDisketteFill,
   Notification,
   Pagination,
   SearchInput,
-  Select,
   Table,
   Link as HDSLink,
   IconEnvelope,
   IconCheckCircleFill,
+  Breadcrumb,
+  IconUser,
+  IconClock,
+  IconMenuDots,
+  LoadingSpinner,
 } from 'hds-react';
-import { cloneDeep } from 'lodash';
-import { Box, Flex } from '@chakra-ui/react';
-import { useMutation, useQueryClient } from 'react-query';
+import { Box, Flex, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
+import { useMutation } from 'react-query';
 import {
   Column,
   useAsyncDebounce,
@@ -25,17 +25,40 @@ import {
   useTable,
 } from 'react-table';
 import { Trans, useTranslation } from 'react-i18next';
-import { $enum } from 'ts-enum-util';
-import { Link } from 'react-router-dom';
-import Text from '../../../common/components/text/Text';
 import styles from './AccessRightsView.module.scss';
 import { Language } from '../../../common/types/language';
-import { HankeUser, AccessRightLevel, SignedInUser } from '../hankeUsers/hankeUser';
+import { HankeUser, SignedInUser } from '../hankeUsers/hankeUser';
 import useHankeViewPath from '../hooks/useHankeViewPath';
-import { resendInvitation, updateHankeUsers } from '../hankeUsers/hankeUsersApi';
+import { resendInvitation } from '../hankeUsers/hankeUsersApi';
 import Container from '../../../common/components/container/Container';
 import UserCard from './UserCard';
 import MainHeading from '../../../common/components/mainHeading/MainHeading';
+
+function UserIcon({
+  user,
+  signedInUser,
+}: Readonly<{ user: HankeUser; signedInUser?: SignedInUser }>) {
+  const { t } = useTranslation();
+
+  if (user.id === signedInUser?.hankeKayttajaId) {
+    return (
+      <IconUser className={styles.userIcon} aria-label={t('hankeUsers:labels:ownInformation')} />
+    );
+  } else {
+    return user.tunnistautunut ? (
+      <IconCheckCircleFill
+        color="var(--color-success)"
+        className={styles.userIcon}
+        aria-label={t('hankeUsers:labels:userIdentified')}
+      />
+    ) : (
+      <IconClock
+        className={styles.userIcon}
+        aria-label={t('hankeUsers:notifications:invitationSentSuccessLabel')}
+      />
+    );
+  }
+}
 
 function sortCaseInsensitive(rowOneColumn: string, rowTwoColumn: string) {
   const rowOneColUpperCase = rowOneColumn.toUpperCase();
@@ -46,6 +69,17 @@ function sortCaseInsensitive(rowOneColumn: string, rowTwoColumn: string) {
   return rowOneColUpperCase > rowTwoColUpperCase ? 1 : -1;
 }
 
+type HankeUserWithWholeName = HankeUser & { nimi: string };
+
+function addWholeName(user: HankeUser): HankeUserWithWholeName {
+  return { ...user, nimi: `${user.etunimi} ${user.sukunimi}` };
+}
+
+const NAME_KEY = 'nimi';
+const EMAIL_KEY = 'sahkoposti';
+const PHONE_KEY = 'puhelinnumero';
+const ACCESS_RIGHT_LEVEL_KEY = 'kayttooikeustaso';
+
 type Props = {
   hankeUsers: HankeUser[];
   hankeTunnus: string;
@@ -53,30 +87,19 @@ type Props = {
   signedInUser?: SignedInUser;
 };
 
-type AccessRightLevelOption = {
-  label: string;
-  value: keyof typeof AccessRightLevel;
-};
-
-const NAME_KEY = 'nimi';
-const EMAIL_KEY = 'sahkoposti';
-const ACCESS_RIGHT_LEVEL_KEY = 'kayttooikeustaso';
-const USER_IDENTIFIED_KEY = 'tunnistautunut';
-
-function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: Props) {
-  const queryClient = useQueryClient();
+function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: Readonly<Props>) {
   const { t, i18n } = useTranslation();
   const hankeViewPath = useHankeViewPath(hankeTunnus);
-  const [usersData, setUsersData] = useState<(HankeUser & { modified?: boolean })[]>(hankeUsers);
-  const modifiedUsers = usersData.filter((user) => user.modified);
-  const saveButtonDisabled = modifiedUsers.length === 0;
+  const [usersData, setUsersData] = useState<(HankeUserWithWholeName & { modified?: boolean })[]>(
+    () => hankeUsers.map(addWholeName),
+  );
 
-  const columns: Column<HankeUser>[] = useMemo(() => {
+  const columns: Column<HankeUserWithWholeName>[] = useMemo(() => {
     return [
       { accessor: NAME_KEY },
       { accessor: EMAIL_KEY },
+      { accessor: PHONE_KEY },
       { accessor: ACCESS_RIGHT_LEVEL_KEY },
-      { accessor: USER_IDENTIFIED_KEY },
     ];
   }, []);
 
@@ -87,7 +110,7 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
     toggleSortBy,
     gotoPage,
     setFilter,
-  } = useTable<HankeUser>(
+  } = useTable<HankeUserWithWholeName>(
     {
       columns,
       data: usersData,
@@ -106,21 +129,14 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
   );
 
   useEffect(() => {
-    setUsersData(hankeUsers);
+    setUsersData(hankeUsers.map(addWholeName));
   }, [hankeUsers]);
 
-  const updateUsersMutation = useMutation(updateHankeUsers);
   const resendInvitationMutation = useMutation(resendInvitation);
   // List of user ids for tracking which users have been sent the invitation link
   const linksSentTo = useRef<string[]>([]);
 
   const [usersSearchValue, setUsersSearchValue] = useState('');
-
-  const accessRightLevelOptions: AccessRightLevelOption[] = $enum(AccessRightLevel)
-    .getValues()
-    .map((rightLevel) => {
-      return { label: t(`hankeUsers:accessRightLevels:${rightLevel}`), value: rightLevel };
-    });
 
   function handleUserSearch(searchTerm: string) {
     setUsersSearchValue(searchTerm);
@@ -144,74 +160,26 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
     handleSort();
   }
 
-  function getAccessRightSelect(args: HankeUser) {
-    const isOnlyWithAllRights: boolean =
-      args.kayttooikeustaso === 'KAIKKI_OIKEUDET' &&
-      usersData.filter((user) => user.kayttooikeustaso === 'KAIKKI_OIKEUDET').length === 1;
-
-    const canEditRights = signedInUser?.kayttooikeudet?.includes('MODIFY_EDIT_PERMISSIONS');
-
-    const canEditAllRights =
-      args.kayttooikeustaso === 'KAIKKI_OIKEUDET'
-        ? signedInUser?.kayttooikeustaso === 'KAIKKI_OIKEUDET'
-        : true;
-
-    // Check if this user is the same as the signed in user,
-    // so that user is not able to edit their own rights
-    const isSignedInUser = args.id === signedInUser?.hankeKayttajaId;
-
-    const isDisabled = isOnlyWithAllRights || !canEditRights || !canEditAllRights || isSignedInUser;
-
-    function handleRightsChange(e: AccessRightLevelOption) {
-      setUsersData((prevData) => {
-        const newData = prevData.map((user) => {
-          if (user.id === args.id) {
-            const modifiedUser = cloneDeep(user);
-            modifiedUser.kayttooikeustaso = e.value;
-            modifiedUser.modified = true;
-            return modifiedUser;
-          }
-          return user;
-        });
-        return newData;
-      });
-    }
-
+  function getUserName(args: HankeUserWithWholeName) {
     return (
-      <Select<AccessRightLevelOption>
-        id={args.id}
-        aria-labelledby={t('hankeUsers:accessRights')}
-        options={accessRightLevelOptions}
-        value={accessRightLevelOptions.find((option) => option.value === args.kayttooikeustaso)}
-        onChange={handleRightsChange}
-        isOptionDisabled={(option) =>
-          option.value === 'KAIKKI_OIKEUDET' && signedInUser?.kayttooikeustaso !== 'KAIKKI_OIKEUDET'
-        }
-        disabled={isDisabled}
-        className={styles.accessRightSelect}
-      />
+      <Flex>
+        <UserIcon user={args} signedInUser={signedInUser} />
+        <p>{args.nimi}</p>
+      </Flex>
     );
   }
 
-  function getInvitationResendButton(args: HankeUser) {
+  function getAccessRightLabel(args: HankeUser) {
+    return t(`hankeUsers:accessRightLevels:${args.kayttooikeustaso}`);
+  }
+
+  function getInvitationMenu(args: HankeUser) {
     if (args.tunnistautunut) {
-      return (
-        <Flex alignItems="baseline">
-          <IconCheckCircleFill
-            color="var(--color-success)"
-            style={{ marginRight: 'var(--spacing-3-xs)', alignSelf: 'center' }}
-            aria-hidden
-          />
-          <p>{t('hankeUsers:userIdentified')}</p>
-        </Flex>
-      );
+      return <></>;
     }
 
     const linkSent = linksSentTo.current.includes(args.id);
-    const buttonText = linkSent
-      ? t('hankeUsers:buttons:invitationSent')
-      : t('hankeUsers:buttons:resendInvitation');
-    const isButtonLoading =
+    const isSending =
       resendInvitationMutation.isLoading && resendInvitationMutation.variables === args.id;
 
     function sendInvitation() {
@@ -223,35 +191,29 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
     }
 
     return (
-      <div className={styles.invitationSendButtonContainer}>
-        <Button
-          variant="secondary"
-          className={styles.invitationSendButton}
-          iconLeft={<IconEnvelope aria-hidden />}
-          onClick={sendInvitation}
-          disabled={linkSent}
-          isLoading={isButtonLoading}
-        >
-          {buttonText}
-        </Button>
-      </div>
-    );
-  }
-
-  function updateUsers() {
-    const users: Pick<HankeUser, 'id' | 'kayttooikeustaso'>[] = modifiedUsers.map((user) => {
-      return {
-        id: user.id,
-        kayttooikeustaso: user.kayttooikeustaso,
-      };
-    });
-    updateUsersMutation.mutate(
-      { hankeTunnus, users },
-      {
-        onSuccess() {
-          queryClient.invalidateQueries(['hankeUsers', hankeTunnus]);
-        },
-      },
+      <Menu>
+        <MenuButton>
+          <Box height="16px">
+            {isSending ? (
+              <LoadingSpinner small />
+            ) : (
+              <IconMenuDots
+                style={{ display: 'block' }}
+                color="var(--color-bus)"
+                aria-label={t('hankeUsers:labels:userMenu')}
+              />
+            )}
+          </Box>
+        </MenuButton>
+        <MenuList>
+          <MenuItem onClick={sendInvitation} isDisabled={linkSent}>
+            <Flex alignItems="center" gap="var(--spacing-2-xs)" color="var(--color-bus)">
+              <IconEnvelope size="xs" />
+              {t('hankeUsers:buttons:resendInvitation')}
+            </Flex>
+          </MenuItem>
+        </MenuList>
+      </Menu>
     );
   }
 
@@ -261,6 +223,7 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
       key: NAME_KEY,
       isSortable: true,
       customSortCompareFunction: sortCaseInsensitive,
+      transform: getUserName,
     },
     {
       headerName: t('form:yhteystiedot:labels:email'),
@@ -269,17 +232,24 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
       customSortCompareFunction: sortCaseInsensitive,
     },
     {
+      headerName: t('form:yhteystiedot:labels:puhelinnumero'),
+      key: PHONE_KEY,
+      isSortable: false,
+    },
+    {
       headerName: t('hankeUsers:accessRights'),
       key: ACCESS_RIGHT_LEVEL_KEY,
-      transform: getAccessRightSelect,
+      isSortable: true,
+      transform: getAccessRightLabel,
     },
   ];
 
   if (signedInUser?.kayttooikeudet.includes('RESEND_INVITATION')) {
     tableCols.push({
-      headerName: '',
-      key: USER_IDENTIFIED_KEY,
-      transform: getInvitationResendButton,
+      headerName: null,
+      key: 'invitationMenu',
+      isSortable: false,
+      transform: getInvitationMenu,
     });
   }
 
@@ -287,13 +257,19 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
     <article className={styles.container}>
       <header className={styles.header}>
         <Container>
-          <Link to={hankeViewPath} className={styles.hankeLink}>
-            <IconAngleLeft aria-hidden="true" />
-            <Text tag="h2" styleAs="h3" weight="bold">
-              {hankeName} ({hankeTunnus})
-            </Text>
-          </Link>
-          <MainHeading spacingBottom="l">{t('hankeUsers:manageRights')}</MainHeading>
+          <div className={styles.breadcrumb}>
+            <Breadcrumb
+              ariaLabel={t('hankeList:breadcrumb:ariaLabel')}
+              list={[
+                { path: hankeViewPath, title: `${hankeName} (${hankeTunnus})` },
+                {
+                  path: null,
+                  title: t('hankeUsers:userManagementTitle'),
+                },
+              ]}
+            />
+          </div>
+          <MainHeading spacingBottom="l">{t('hankeUsers:userManagementTitle')}</MainHeading>
         </Container>
       </header>
 
@@ -341,6 +317,10 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
           <p>{t('hankeUsers:accessRightsInfo:modifyInfo')}</p>
         </Accordion>
 
+        <Box marginBottom="var(--spacing-l)">
+          <h2 className="heading-l">{t('hankeUsers:users')}</h2>
+        </Box>
+
         <SearchInput
           className={styles.searchInput}
           label={t('hankePortfolio:search')}
@@ -364,11 +344,15 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
         <div className={styles.userCards}>
           {page.map((row) => {
             return (
-              <UserCard key={row.original.id} user={row.original}>
-                <Box marginBottom="var(--spacing-s)">{getAccessRightSelect(row.original)}</Box>
-                {signedInUser?.kayttooikeudet.includes('RESEND_INVITATION')
-                  ? getInvitationResendButton(row.original)
-                  : null}
+              <UserCard
+                key={row.original.id}
+                user={row.original}
+                headingIcon={<UserIcon user={row.original} signedInUser={signedInUser} />}
+              >
+                <Box marginBottom="var(--spacing-s)">
+                  <strong>{t('hankeUsers:accessRight')}:</strong>{' '}
+                  {getAccessRightLabel(row.original)}
+                </Box>
               </UserCard>
             );
           })}
@@ -384,49 +368,6 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
             paginationAriaLabel={t('hankeList:paginatioAriaLabel')}
           />
         </div>
-
-        <Flex justifyContent="flex-end" mb="var(--spacing-l)">
-          <Button
-            onClick={updateUsers}
-            iconLeft={<IconSaveDisketteFill />}
-            disabled={saveButtonDisabled}
-          >
-            {t('form:buttons:saveChanges')}
-          </Button>
-        </Flex>
-
-        {updateUsersMutation.isSuccess && (
-          <Notification
-            position="top-right"
-            dismissible
-            autoClose
-            autoCloseDuration={4000}
-            type="success"
-            label={t('hankeUsers:notifications:rightsUpdatedSuccessLabel')}
-            closeButtonLabelText={t('common:components:notification:closeButtonLabelText')}
-            onClose={() => updateUsersMutation.reset()}
-          >
-            {t('hankeUsers:notifications:rightsUpdatedSuccessText')}
-          </Notification>
-        )}
-        {updateUsersMutation.isError && (
-          <Notification
-            position="top-right"
-            dismissible
-            type="error"
-            label={t('hankeUsers:notifications:rightsUpdatedErrorLabel')}
-            closeButtonLabelText={t('common:components:notification:closeButtonLabelText')}
-            onClose={() => updateUsersMutation.reset()}
-          >
-            <Trans i18nKey="hankeUsers:notifications:rightsUpdatedErrorText">
-              <p>
-                Käyttöoikeuksien päivityksessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota
-                yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa
-                <HDSLink href="mailto:haitatontuki@hel.fi">haitatontuki@hel.fi</HDSLink>.
-              </p>
-            </Trans>
-          </Notification>
-        )}
 
         {resendInvitationMutation.isSuccess && (
           <Notification

--- a/src/domain/hanke/accessRights/UserCard.tsx
+++ b/src/domain/hanke/accessRights/UserCard.tsx
@@ -2,20 +2,26 @@ import React from 'react';
 import { Card } from 'hds-react';
 import { HankeUser } from '../hankeUsers/hankeUser';
 import Text from '../../../common/components/text/Text';
+import { Flex } from '@chakra-ui/react';
 
 type Props = {
   user: HankeUser;
   children?: React.ReactNode;
+  headingIcon?: React.ReactNode;
 };
 
-function UserCard({ user, children }: Props) {
+function UserCard({ user, children, headingIcon }: Props) {
   return (
     <Card border style={{ marginBottom: 'var(--spacing-m)' }}>
-      <Text tag="h2" styleAs="h2" weight="bold" spacingBottom="s">
-        {user.nimi}
-      </Text>
+      <Flex marginBottom="var(--spacing-s)">
+        {headingIcon}
+        <h3 className="heading-m">
+          {user.etunimi} {user.sukunimi}
+        </h3>
+      </Flex>
+      <Text tag="p">{user.sahkoposti}</Text>
       <Text tag="p" spacingBottom="s">
-        {user.sahkoposti}
+        {user.puhelinnumero}
       </Text>
       {children}
     </Card>

--- a/src/domain/hanke/accessRights/UserCard.tsx
+++ b/src/domain/hanke/accessRights/UserCard.tsx
@@ -10,7 +10,7 @@ type Props = {
   headingIcon?: React.ReactNode;
 };
 
-function UserCard({ user, children, headingIcon }: Props) {
+function UserCard({ user, children, headingIcon }: Readonly<Props>) {
   return (
     <Card border style={{ marginBottom: 'var(--spacing-m)' }}>
       <Flex marginBottom="var(--spacing-s)">

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -498,7 +498,7 @@ describe('New contact person form', () => {
     fireEvent.change(screen.getAllByLabelText(/sähköposti/i)[1], {
       target: { value: sahkoposti },
     });
-    fireEvent.change(screen.getAllByLabelText(/Puhelinnumero/i)[1], {
+    fireEvent.change(screen.getAllByLabelText(/puhelin/i)[1], {
       target: { value: puhelinnumero },
     });
   }

--- a/src/domain/hanke/hankeUsers/hankeUser.ts
+++ b/src/domain/hanke/hankeUsers/hankeUser.ts
@@ -9,9 +9,9 @@ export enum AccessRightLevel {
 export type HankeUser = {
   id: string;
   sahkoposti: string;
-  nimi: string;
   etunimi: string;
   sukunimi: string;
+  puhelinnumero: string;
   kayttooikeustaso: keyof typeof AccessRightLevel;
   tunnistautunut: boolean;
 };

--- a/src/domain/johtoselvitys/Contacts.test.tsx
+++ b/src/domain/johtoselvitys/Contacts.test.tsx
@@ -41,7 +41,7 @@ test('Contacts can be filled with hanke contact info', async () => {
   expect(screen.getAllByRole('textbox', { name: /nimi/i })[0]).toHaveValue(hankeOwner.nimi);
   expect(screen.getAllByRole('textbox', { name: /Y-tunnus/i })[0]).toHaveValue(hankeOwner.ytunnus);
   expect(screen.getAllByRole('textbox', { name: /sähköposti/i })[0]).toHaveValue(hankeOwner.email);
-  expect(screen.getAllByRole('textbox', { name: /puhelinnumero/i })[0]).toHaveValue(
+  expect(screen.getAllByRole('textbox', { name: /puhelin/i })[0]).toHaveValue(
     hankeOwner.puhelinnumero,
   );
 });

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -136,7 +136,7 @@ function fillBasicInformation() {
   fireEvent.change(screen.getByLabelText(/sähköposti/i), {
     target: { value: 'matti.meikalainen@test.com' },
   });
-  fireEvent.change(screen.getByLabelText(/puhelinnumero/i), {
+  fireEvent.change(screen.getByLabelText(/puhelin/i), {
     target: { value: '0000000000' },
   });
 }

--- a/src/domain/mocks/data/users-data.json
+++ b/src/domain/mocks/data/users-data.json
@@ -2,9 +2,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
     "sahkoposti": "matti.meikalainen@test.com",
-    "nimi": "Matti Meikäläinen",
     "etunimi": "Matti",
     "sukunimi": "Meikäläinen",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KAIKKI_OIKEUDET",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"
@@ -12,9 +12,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa7",
     "sahkoposti": "teppo@test.com",
-    "nimi": "Teppo Työmies",
     "etunimi": "Teppo",
     "sukunimi": "Työmies",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KAIKKIEN_MUOKKAUS",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -22,9 +22,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa8",
     "sahkoposti": "aku@asiakas.com",
-    "nimi": "Aku Asiakas",
     "etunimi": "Aku",
     "sukunimi": "Asiakas",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "HANKEMUOKKAUS",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"
@@ -32,9 +32,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa9",
     "sahkoposti": "vilja@test.com",
-    "nimi": "Vilja Viljanen",
     "etunimi": "Vilja",
     "sukunimi": "Viljanen",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KAIKKI_OIKEUDET",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -42,9 +42,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb1",
     "sahkoposti": "tauno@test.com",
-    "nimi": "Tauno Testinen",
     "etunimi": "Tauno",
     "sukunimi": "Testinen",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -52,9 +52,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb2",
     "sahkoposti": "marja@test.com",
-    "nimi": "Marja Marjanen",
     "etunimi": "Marja",
     "sukunimi": "Marjanen",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -62,9 +62,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb3",
     "sahkoposti": "milka@test.com",
-    "nimi": "Milka Marjanen",
     "etunimi": "Milka",
     "sukunimi": "Marjanen",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"
@@ -72,9 +72,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb4",
     "sahkoposti": "sakari@test.com",
-    "nimi": "Sakari Selkonen",
     "etunimi": "Sakari",
     "sukunimi": "Selkonen",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "HAKEMUSASIOINTI",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"
@@ -82,9 +82,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb5",
     "sahkoposti": "keijo@test.com",
-    "nimi": "Keijo Keijonen",
     "etunimi": "Keijo",
     "sukunimi": "Keijonen",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"
@@ -92,9 +92,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb6",
     "sahkoposti": "alma@test.com",
-    "nimi": "Alma Testinen",
     "etunimi": "Alma",
     "sukunimi": "Testinen",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -102,9 +102,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb7",
     "sahkoposti": "taneli@test.com",
-    "nimi": "Taneli Taunonen",
     "etunimi": "Taneli",
     "sukunimi": "Taunonen",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2"
@@ -112,9 +112,9 @@
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66af5",
     "sahkoposti": "matti@test.com",
-    "nimi": "matti Meikäläinen",
     "etunimi": "matti",
     "sukunimi": "Meikäläinen",
+    "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2"

--- a/src/domain/mocks/data/users.ts
+++ b/src/domain/mocks/data/users.ts
@@ -11,9 +11,9 @@ export async function readAll(hankeTunnus: string): Promise<HankeUser[]> {
     .map((user) => ({
       id: user.id,
       sahkoposti: user.sahkoposti,
-      nimi: user.nimi,
       etunimi: user.etunimi,
       sukunimi: user.sukunimi,
+      puhelinnumero: user.puhelinnumero,
       kayttooikeustaso: user.kayttooikeustaso as AccessRightLevel,
       tunnistautunut: user.tunnistautunut,
     }));
@@ -25,7 +25,7 @@ export async function create(hankeTunnus: string, user: ContactPerson) {
     etunimi: user.etunimi,
     sukunimi: user.sukunimi,
     sahkoposti: user.sahkoposti,
-    nimi: `${user.etunimi} ${user.sukunimi}`,
+    puhelinnumero: user.puhelinnumero,
     kayttooikeustaso: AccessRightLevel.KATSELUOIKEUS,
     tunnistautunut: false,
   };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -811,7 +811,6 @@
   },
   "hankeUsers": {
     "accessRights": "Access rights",
-    "manageRights": "Access rights management",
     "accessRightLevels": {
       "KAIKKI_OIKEUDET": "All rights",
       "KAIKKIEN_MUOKKAUS": "Project and application editing",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -194,7 +194,7 @@
         "postinumero": "Postinumero",
         "postitoimipaikka": "Postitoimipaikka",
         "email": "Sähköposti",
-        "puhelinnumero": "Puhelinnumero",
+        "puhelinnumero": "Puhelin",
         "rooli": "Rooli",
         "osasto": "Osasto",
         "organisaatioNimi": "Organisaatio",
@@ -855,11 +855,16 @@
       "toPreviousPage": "Listan edelliselle sivulle",
       "toNextPage": "Listan seuraavalle sivulle",
       "toLastPage": "Listan viimeiselle sivulle"
+    },
+    "breadcrumb": {
+      "ariaLabel": "Hankkeen navigaatio"
     }
   },
   "hankeUsers": {
     "accessRights": "Käyttöoikeudet",
-    "manageRights": "Käyttöoikeuksien hallinta",
+    "users": "Käyttäjät",
+    "accessRight": "Käyttöoikeus",
+    "userManagementTitle": "Käyttäjähallinta",
     "accessRightLevels": {
       "KAIKKI_OIKEUDET": "Kaikki oikeudet",
       "KAIKKIEN_MUOKKAUS": "Hankkeen ja hakemusten muokkaus",
@@ -896,6 +901,11 @@
     "buttons": {
       "resendInvitation": "Lähetä kutsulinkki uudelleen",
       "invitationSent": "Kutsulinkki lähetetty"
+    },
+    "labels": {
+      "ownInformation": "Omat käyttäjätietosi",
+      "userIdentified": "Kirjautunut hankkeelle tunnistautuneena",
+      "userMenu": "Käyttäjävalikko"
     },
     "userIdentified": "Käyttäjä tunnistautunut"
   },

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -811,7 +811,6 @@
   },
   "hankeUsers": {
     "accessRights": "Användningsrättigheter",
-    "manageRights": "Hantering av användningsrättigheter",
     "accessRightLevels": {
       "KAIKKI_OIKEUDET": "Alla rättigheter",
       "KAIKKIEN_MUOKKAUS": "Ändringar i projekt och ansökningar",


### PR DESCRIPTION
# Description

Changed page heading.

Changed navigation back to hanke page to use HDS Breadcrumb component.

Added icons before users name based on their status.

Added phone number column to table.

Changed permission dropdown to plain text.

Moved invitation send button behind menu that is opened by clicking three dots icon button.

Removed Save button that would save changes to user permission as all modifications to user info are going to be in user edit page.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2158

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
