### PR TITLE
HAI-2247 Retrieve verified name from backend

### DIFF
--- a/src/domain/auth/authService.test.ts
+++ b/src/domain/auth/authService.test.ts
@@ -17,12 +17,15 @@ describe('authService', () => {
 
   describe('getUser', () => {
     it('should resolve to the user value which has been resolved from getUser', async () => {
-      expect.assertions(1);
+      expect.assertions(4);
       jest.spyOn(userManager, 'getUser').mockResolvedValueOnce(mockUser);
 
       const user = await authService.getUser();
 
-      expect(user).toBe(mockUser);
+      expect(user?.id_token).toBe(mockUser.id_token);
+      expect(user?.session_state).toBe(mockUser.session_state);
+      expect(user?.access_token).toBe(mockUser.access_token);
+      expect(user?.profile.name).toBe('Testi Testinen');
     });
   });
 

--- a/src/domain/auth/profiiliApi.ts
+++ b/src/domain/auth/profiiliApi.ts
@@ -1,0 +1,7 @@
+import api from '../api/api';
+import { ProfiiliNimi } from './types';
+
+export async function getProfiiliNimi() {
+  const response = await api.get<ProfiiliNimi>('/profiili/verified-name');
+  return response.data;
+}

--- a/src/domain/auth/types.ts
+++ b/src/domain/auth/types.ts
@@ -1,0 +1,5 @@
+export type ProfiiliNimi = {
+  firstName: string;
+  lastName: string;
+  givenName: string;
+};

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -193,7 +193,7 @@ export const handlers = [
     return res(ctx.status(200));
   }),
 
-  rest.get('/api/hankkeet/:hankeTunnus/whoami', async (req, res, ctx) => {
+  rest.get(`${apiUrl}/hankkeet/:hankeTunnus/whoami`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
 
     if (hankeTunnus === 'SMTGEN2_1') {
@@ -263,5 +263,12 @@ export const handlers = [
 
   rest.get(`${apiUrl}/hankkeet/:hankeTunnus/liitteet`, async (_, res, ctx) => {
     return res(ctx.status(200), ctx.json([]));
+  }),
+
+  rest.get(`${apiUrl}/profiili/verified-name`, async (_, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({ firstName: 'Testi Tauno Tahvo', lastName: 'Testinen', givenName: 'Testi' }),
+    );
   }),
 ];


### PR DESCRIPTION
# Description

The name shown in the header is retrieved from backend from new `/profiili/verified-name` endpoint.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2247

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

The new endpoint is now in dev and could be used for testing. In UI tests and with `yarn start-msw` there is now always "Testi Testinen" as the name no matter what user is used in log-in.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
