### PR TITLE
HAI-2165 Make it possible to select hanke users as contacts persons in hanke form

### DIFF
--- a/src/common/components/dropdown/DropdownMultiselect.tsx
+++ b/src/common/components/dropdown/DropdownMultiselect.tsx
@@ -21,6 +21,7 @@ type PropTypes<T> = {
   errorMsg?: string;
   tooltip?: TooltipProps;
   icon?: ReactNode;
+  clearable?: boolean;
   mapValueToLabel: (value: T | null) => string;
 };
 
@@ -35,6 +36,7 @@ function DropdownMultiselect<T>({
   tooltip,
   helperText,
   icon,
+  clearable,
   mapValueToLabel,
 }: Readonly<PropTypes<T>>) {
   const { t } = useTranslation();
@@ -75,6 +77,7 @@ function DropdownMultiselect<T>({
               clearButtonAriaLabel={t('common:components:multiselect:clear')}
               multiselect
               icon={icon}
+              clearable={clearable}
             />
           );
         }}

--- a/src/common/components/dropdown/DropdownMultiselect.tsx
+++ b/src/common/components/dropdown/DropdownMultiselect.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { Combobox, Tooltip } from 'hds-react';
 import { useTranslation } from 'react-i18next';
@@ -19,6 +20,7 @@ type PropTypes<T> = {
   invalid?: boolean;
   errorMsg?: string;
   tooltip?: TooltipProps;
+  icon?: ReactNode;
   mapValueToLabel: (value: T | null) => string;
 };
 
@@ -32,6 +34,7 @@ function DropdownMultiselect<T>({
   errorMsg,
   tooltip,
   helperText,
+  icon,
   mapValueToLabel,
 }: Readonly<PropTypes<T>>) {
   const { t } = useTranslation();
@@ -71,6 +74,7 @@ function DropdownMultiselect<T>({
               selectedItemRemoveButtonAriaLabel={t('common:components:multiselect:removeSelected')}
               clearButtonAriaLabel={t('common:components:multiselect:clear')}
               multiselect
+              icon={icon}
             />
           );
         }}

--- a/src/common/components/dropdown/DropdownMultiselect.tsx
+++ b/src/common/components/dropdown/DropdownMultiselect.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { Combobox, Tooltip } from 'hds-react';
 import { useTranslation } from 'react-i18next';
@@ -7,21 +6,23 @@ import { TooltipProps } from '../../types/tooltip';
 
 import './dropDown.styles.scss';
 
-type Option = { value: string; label: string };
+type Option<T> = { value: T; label: string };
 
-type PropTypes = {
+type PropTypes<T> = {
   name: string;
   id: string;
   rules?: { required: boolean };
-  defaultValue: string[];
+  defaultValue?: Option<T>[];
   label: string;
-  options: Array<Option>;
+  helperText?: string;
+  options: Array<Option<T>>;
   invalid?: boolean;
   errorMsg?: string;
   tooltip?: TooltipProps;
+  mapValueToLabel: (value: T | null) => string;
 };
 
-const DropdownMultiselect: React.FC<React.PropsWithChildren<PropTypes>> = ({
+function DropdownMultiselect<T>({
   name,
   rules,
   options,
@@ -30,7 +31,9 @@ const DropdownMultiselect: React.FC<React.PropsWithChildren<PropTypes>> = ({
   invalid,
   errorMsg,
   tooltip,
-}) => {
+  helperText,
+  mapValueToLabel,
+}: Readonly<PropTypes<T>>) {
   const { t } = useTranslation();
   const { control } = useFormContext();
 
@@ -53,12 +56,17 @@ const DropdownMultiselect: React.FC<React.PropsWithChildren<PropTypes>> = ({
         rules={rules}
         render={({ field: { onChange, value } }) => {
           return (
-            <Combobox<Option>
+            <Combobox<Option<T>>
               options={options}
               label={label}
+              helper={helperText}
               invalid={invalid}
-              defaultValue={value && options.filter((o) => value.includes(o.value))}
-              onChange={(option: Option[]) => onChange(option.map((o) => o.value))}
+              defaultValue={defaultValue}
+              value={value?.map((v: T) => ({
+                value: v,
+                label: mapValueToLabel(v),
+              }))}
+              onChange={(option: Option<T>[]) => onChange(option.map((o) => o.value))}
               toggleButtonAriaLabel={t('common:components:multiselect:toggle')}
               selectedItemRemoveButtonAriaLabel={t('common:components:multiselect:removeSelected')}
               clearButtonAriaLabel={t('common:components:multiselect:clear')}
@@ -70,6 +78,6 @@ const DropdownMultiselect: React.FC<React.PropsWithChildren<PropTypes>> = ({
       {invalid && <span className="error-text">{errorMsg}</span>}
     </div>
   );
-};
+}
 
 export default DropdownMultiselect;

--- a/src/domain/hanke/edit/HankeFormPerustiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormPerustiedot.tsx
@@ -106,8 +106,16 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
             value,
             label: t(`hanke:${FORMFIELD.TYOMAATYYPPI}:${value}`),
           }))}
-          defaultValue={formData ? (formData[FORMFIELD.TYOMAATYYPPI] as string[]) : []}
+          defaultValue={
+            formData
+              ? formData[FORMFIELD.TYOMAATYYPPI]?.map((value) => ({
+                  value,
+                  label: t(`hanke:${FORMFIELD.TYOMAATYYPPI}:${value}`),
+                }))
+              : []
+          }
           label={t(`hankeForm:labels:${FORMFIELD.TYOMAATYYPPI}`)}
+          mapValueToLabel={(value) => t(`hanke:${FORMFIELD.TYOMAATYYPPI}:${value}`)}
           invalid={!!errors[FORMFIELD.TYOMAATYYPPI]}
           errorMsg={t('hankeForm:insertFieldError')}
         />

--- a/src/domain/hanke/edit/components/ContactsSummary.tsx
+++ b/src/domain/hanke/edit/components/ContactsSummary.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid } from '@chakra-ui/react';
+import { Box, Grid } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { SectionItemContent, SectionItemTitle } from '../../../forms/components/FormSummarySection';
 import { HankeYhteystieto, HankeMuuTaho, HankeYhteyshenkilo } from '../../../types/hanke';
@@ -57,7 +57,7 @@ const ContactsSummary: React.FC<{
       <SectionItemContent>
         {contacts.map((contact) => {
           return (
-            <React.Fragment key={contact.email}>
+            <Box key={contact.email} marginBottom="var(--spacing-m)">
               <ContactSummary contact={contact} />
               {contact.yhteyshenkilot && contact.yhteyshenkilot?.length > 0 && (
                 <>
@@ -72,13 +72,18 @@ const ContactsSummary: React.FC<{
                   >
                     {contact.yhteyshenkilot?.map((yhteyshenkilo) => {
                       return (
-                        <SubContactSummary key={yhteyshenkilo.sahkoposti} contact={yhteyshenkilo} />
+                        yhteyshenkilo && (
+                          <SubContactSummary
+                            key={yhteyshenkilo.sahkoposti}
+                            contact={yhteyshenkilo}
+                          />
+                        )
                       );
                     })}
                   </Grid>
                 </>
               )}
-            </React.Fragment>
+            </Box>
           );
         })}
       </SectionItemContent>

--- a/src/domain/hanke/edit/types.ts
+++ b/src/domain/hanke/edit/types.ts
@@ -2,7 +2,13 @@ import { FieldErrors } from 'react-hook-form';
 import { Feature } from 'ol';
 import Geometry from 'ol/geom/Geometry';
 import { PartialExcept } from '../../../common/types/utils';
-import { HankeData, HankeContactTypeKey, HankeAlue } from '../../types/hanke';
+import {
+  HankeData,
+  HankeContactTypeKey,
+  HankeAlue,
+  HankeYhteystieto,
+  HankeMuuTaho,
+} from '../../types/hanke';
 import yup from '../../../common/utils/yup';
 import { contactPersonSchema, newHankeSchema } from './hankeSchema';
 
@@ -68,16 +74,21 @@ export interface FormProps {
   register: any;
 }
 
-export type SaveFormArguments = {
-  data: HankeDataFormState;
-  currentFormPage: number;
-};
+export interface HankePostYhteystieto extends Omit<HankeYhteystieto, 'yhteyshenkilot'> {
+  yhteyshenkilot: string[];
+}
 
-export type Organization = {
-  id: number;
-  nimi: string;
-  tunnus: string;
-};
+export interface HankePostMuuTaho extends Omit<HankeMuuTaho, 'yhteyshenkilot'> {
+  yhteyshenkilot: string[];
+}
+
+export interface HankePostData
+  extends Omit<HankeDataFormState, 'omistajat' | 'rakennuttajat' | 'toteuttajat' | 'muut'> {
+  omistajat: HankePostYhteystieto[];
+  rakennuttajat: HankePostYhteystieto[];
+  toteuttajat: HankePostYhteystieto[];
+  muut: HankePostMuuTaho[];
+}
 
 export type NewHankeData = yup.InferType<typeof newHankeSchema>;
 

--- a/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
+++ b/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from 'react-i18next';
+import { HankeUser } from './hankeUser';
+import { HankeYhteyshenkilo } from '../../types/hanke';
+import { mapHankeUserToHankeYhteyshenkilo } from './utils';
+import DropdownMultiselect from '../../../common/components/dropdown/DropdownMultiselect';
+
+/**
+ * Combobox component for selecting hanke user as contact person (yhteyshenkilö) for a contact (yhteystieto)
+ */
+function ContactPersonSelect({
+  name,
+  defaultValue,
+  hankeUsers,
+}: Readonly<{
+  name: string;
+  defaultValue?: HankeYhteyshenkilo[];
+  hankeUsers?: HankeUser[];
+}>) {
+  const { t } = useTranslation();
+
+  function mapUserToLabel(user: HankeUser | HankeYhteyshenkilo | null) {
+    return user !== null ? `${user.etunimi} ${user.sukunimi} (${user.sahkoposti})` : '';
+  }
+
+  return (
+    <DropdownMultiselect<HankeYhteyshenkilo>
+      id={name}
+      name={name}
+      label={t('form:yhteystiedot:titles:subContacts')}
+      helperText={t('form:yhteystiedot:helperTexts:yhteyshenkilo')}
+      mapValueToLabel={mapUserToLabel}
+      defaultValue={defaultValue?.map((value: HankeYhteyshenkilo) => ({
+        value,
+        label: mapUserToLabel(value),
+      }))}
+      options={
+        hankeUsers?.map((hankeUser) => ({
+          value: mapHankeUserToHankeYhteyshenkilo(hankeUser),
+          label: mapUserToLabel(hankeUser),
+        })) ?? []
+      }
+    />
+  );
+}
+
+export default ContactPersonSelect;

--- a/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
+++ b/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { IconUser } from 'hds-react';
 import { HankeUser } from './hankeUser';
 import { HankeYhteyshenkilo } from '../../types/hanke';
 import { mapHankeUserToHankeYhteyshenkilo } from './utils';
@@ -28,6 +29,7 @@ function ContactPersonSelect({
       name={name}
       label={t('form:yhteystiedot:titles:subContacts')}
       helperText={t('form:yhteystiedot:helperTexts:yhteyshenkilo')}
+      icon={<IconUser />}
       mapValueToLabel={mapUserToLabel}
       defaultValue={defaultValue?.map((value: HankeYhteyshenkilo) => ({
         value,

--- a/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
+++ b/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
@@ -30,6 +30,7 @@ function ContactPersonSelect({
       label={t('form:yhteystiedot:titles:subContacts')}
       helperText={t('form:yhteystiedot:helperTexts:yhteyshenkilo')}
       icon={<IconUser />}
+      clearable={false}
       mapValueToLabel={mapUserToLabel}
       defaultValue={defaultValue?.map((value: HankeYhteyshenkilo) => ({
         value,

--- a/src/domain/hanke/hankeUsers/utils.ts
+++ b/src/domain/hanke/hankeUsers/utils.ts
@@ -1,0 +1,18 @@
+import { HankeUser } from './hankeUser';
+import { HankeYhteyshenkilo } from '../../types/hanke';
+
+export function mapHankeUserToHankeYhteyshenkilo({
+  id,
+  etunimi,
+  sukunimi,
+  sahkoposti,
+  puhelinnumero,
+}: HankeUser): HankeYhteyshenkilo {
+  return {
+    id,
+    etunimi,
+    sukunimi,
+    sahkoposti,
+    puhelinnumero,
+  };
+}

--- a/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.module.scss
@@ -2,7 +2,6 @@
   &__content {
     border-top: 1px solid var(--color-black-20);
     max-width: 320px;
-    top: 72px !important;
 
     hr {
       margin-top: 36px;

--- a/src/domain/types/hanke.ts
+++ b/src/domain/types/hanke.ts
@@ -95,7 +95,7 @@ export type HankeContactTypeKey =
   | HANKE_CONTACT_TYPE.MUUTTAHOT;
 
 export interface HankeYhteyshenkilo {
-  id?: string | null;
+  id: string;
   etunimi: string;
   sukunimi: string;
   sahkoposti: string;

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -210,7 +210,8 @@
         "otherPartyRole": "Isännöitsijä, konsultti..."
       },
       "helperTexts": {
-        "otherPartyRole": "Tahon rooli hankkeessa"
+        "otherPartyRole": "Tahon rooli hankkeessa",
+        "yhteyshenkilo": "Valitsemillesi yhteyshenkilöille lähetetään kutsu hankkeelle sähköpostilla. Yhteyshenkilöt näkyvät kaikille hanketta katseleville tahoille."
       },
       "contactType": {
         "YKSITYISHENKILO": "Yksityishenkilö",


### PR DESCRIPTION
# Description

Added comboboxes to contacts page in hanke form to select existing hanke users as contact persons (yhteyshenkilöt) for hanke contacts. Creating new hanke user also adds that user as a contact person.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2165

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new hanke or edit existing hanke
2. Go to contacts page
3. Add yhteyshenkilö to hanke owner from dropdown
4. Create new yhteyshenkilö for hanke owner and check that it is added as yhteyshenkilö
5. Go to summary page
6. Check that hanke is saved successfully and that yhteyshenkilöt are shown in summary page

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
