### PR TITLE
HAI-2224 Make it possible for user to edit their own information

### DIFF
--- a/src/domain/hanke/accessRights/AccessRightsView.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.tsx
@@ -39,6 +39,7 @@ import {
   InvitationErrorNotification,
   InvitationSuccessNotification,
 } from '../hankeUsers/InvitationNotification';
+import { userRoleSorter } from '../hankeUsers/utils';
 
 function UserIcon({
   user,
@@ -112,27 +113,6 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
   const [usersData, setUsersData] = useState<HankeUserWithWholeName[]>(() =>
     hankeUsers.map(addWholeName),
   );
-
-  const userRoleSortOrder = ['OMISTAJA', 'RAKENNUTTAJA', 'TOTEUTTAJA', 'MUU'];
-
-  const userRoleSorter = (a: string, b: string) => {
-    const indexA = userRoleSortOrder.indexOf(a);
-    const indexB = userRoleSortOrder.indexOf(b);
-
-    if (indexA === -1 && indexB === -1) {
-      // If both elements are not in sortOrder, maintain their original order
-      return 0;
-    } else if (indexA === -1) {
-      // If only 'a' is not in sortOrder, 'a' comes after 'b'
-      return 1;
-    } else if (indexB === -1) {
-      // If only 'b' is not in sortOrder, 'a' comes before 'b'
-      return -1;
-    } else {
-      // Compare based on their indices in sortOrder
-      return indexA - indexB;
-    }
-  };
 
   const columns: Column<HankeUserWithWholeName>[] = useMemo(() => {
     return [

--- a/src/domain/hanke/hankeUsers/EditUserView.test.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.test.tsx
@@ -1,10 +1,11 @@
 import { rest } from 'msw';
 import { server } from '../../mocks/test-server';
-import { render, screen } from '../../../testUtils/render';
+import { fireEvent, render, screen } from '../../../testUtils/render';
 import EditUserContainer from './EditUserContainer';
 import { waitForLoadingToFinish } from '../../../testUtils/helperFunctions';
 import { readAll } from '../../mocks/data/users';
 import { USER_EDIT_HANKE } from '../../mocks/signedInUser';
+import * as hankeUsersApi from './hankeUsersApi';
 
 test('Should show correct page title', async () => {
   render(<EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />);
@@ -68,4 +69,73 @@ test('Permissions dropdown should be disabled if user does not have enough right
   await waitForLoadingToFinish();
 
   expect(screen.getByRole('button', { name: 'Käyttöoikeudet' })).toBeDisabled();
+});
+
+test('Should be able to edit own information', async () => {
+  const updateSelf = jest.spyOn(hankeUsersApi, 'updateSelf');
+  const hankeTunnus = 'HAI22-2';
+  const { user } = render(
+    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus={hankeTunnus} />,
+  );
+  await waitForLoadingToFinish();
+  const sahkoposti = 'matti@test.com';
+  const puhelinnumero = '0000000000';
+  fireEvent.change(screen.getByLabelText(/sähköposti/i), {
+    target: { value: sahkoposti },
+  });
+  fireEvent.change(screen.getByLabelText(/puhelinnumero/i), {
+    target: { value: puhelinnumero },
+  });
+  await user.click(screen.getByRole('button', { name: /tallenna muutokset/i }));
+
+  expect(updateSelf).toHaveBeenCalledWith({
+    hankeTunnus,
+    user: { sahkoposti, puhelinnumero },
+  });
+  expect(screen.getByText('Käyttäjätiedot päivitetty')).toBeInTheDocument();
+  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2/kayttajat');
+});
+
+test('Should not be able to save changes if form is not valid', async () => {
+  const updateSelf = jest.spyOn(hankeUsersApi, 'updateSelf');
+  const { user } = render(
+    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />,
+  );
+  await waitForLoadingToFinish();
+  fireEvent.change(screen.getByLabelText(/sähköposti/i), {
+    target: { value: 'matti.com' },
+  });
+  fireEvent.change(screen.getByLabelText(/puhelinnumero/i), {
+    target: { value: '' },
+  });
+  await user.click(screen.getByRole('button', { name: /tallenna muutokset/i }));
+
+  expect(screen.getByText('Sähköposti on virheellinen')).toBeInTheDocument();
+  expect(screen.getByText('Kenttä on pakollinen')).toBeInTheDocument();
+  expect(updateSelf).not.toHaveBeenCalled();
+});
+
+test('Should be able to cancel and return to user management view', async () => {
+  const { user } = render(
+    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />,
+  );
+  await waitForLoadingToFinish();
+  await user.click(screen.getByRole('button', { name: /peruuta/i }));
+
+  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2/kayttajat');
+});
+
+test('Should show error notification if editing fails', async () => {
+  server.use(
+    rest.put('/api/hankkeet/:hankeTunnus/kayttajat/self', async (req, res, ctx) => {
+      return res(ctx.status(500));
+    }),
+  );
+  const { user } = render(
+    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />,
+  );
+  await waitForLoadingToFinish();
+  await user.click(screen.getByRole('button', { name: /tallenna muutokset/i }));
+
+  expect(screen.getByText('Virhe päivityksessä')).toBeInTheDocument();
 });

--- a/src/domain/hanke/hankeUsers/EditUserView.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.tsx
@@ -95,7 +95,7 @@ function EditUserView({
 
   const userFullName = `${etunimi} ${sukunimi}`;
   const userRoles = roolit
-    .sort(userRoleSorter)
+    .toSorted(userRoleSorter)
     .map((role) => t(`hankeUsers:roleLabels:${role}`))
     .join(', ');
 

--- a/src/domain/hanke/hankeUsers/EditUserView.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.tsx
@@ -126,7 +126,7 @@ function EditUserView({
     isOnlyWithAllRights || !canEditRights || !canEditAllRights || isSignedInUser;
 
   function navigateToHankeUsersView() {
-    navigate('..', { relative: 'path' });
+    navigate(getHankeUsersPath({ hankeTunnus }));
   }
 
   function handleSuccess(data: HankeUser) {

--- a/src/domain/hanke/hankeUsers/EditUserView.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.tsx
@@ -1,5 +1,18 @@
-import { useTranslation } from 'react-i18next';
-import { Breadcrumb, Button, IconCheckCircleFill, IconClock, IconEnvelope } from 'hds-react';
+import { Trans, useTranslation } from 'react-i18next';
+import {
+  Breadcrumb,
+  Button,
+  IconCheckCircleFill,
+  IconClock,
+  IconCross,
+  IconEnvelope,
+  IconSaveDisketteFill,
+  Link,
+  Notification,
+} from 'hds-react';
+import { useMutation, useQueryClient } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+import { yupResolver } from '@hookform/resolvers/yup';
 import Container from '../../../common/components/container/Container';
 import MainHeading from '../../../common/components/mainHeading/MainHeading';
 import { AccessRightLevel, HankeUser, SignedInUser } from './hankeUser';
@@ -19,6 +32,12 @@ import {
   InvitationErrorNotification,
   InvitationSuccessNotification,
 } from './InvitationNotification';
+import { updateSelf } from './hankeUsersApi';
+import yup from '../../../common/utils/yup';
+import { yhteyshenkiloSchema } from '../edit/hankeSchema';
+import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
+import Text from '../../../common/components/text/Text';
+import { userRoleSorter } from './utils';
 
 type Props = {
   user: HankeUser;
@@ -35,13 +54,23 @@ type AccessRightLevelOption = {
 
 function EditUserView({
   user,
-  user: { id, etunimi, sukunimi, sahkoposti, puhelinnumero, tunnistautunut, kayttooikeustaso },
+  user: {
+    id,
+    etunimi,
+    sukunimi,
+    sahkoposti,
+    puhelinnumero,
+    tunnistautunut,
+    kayttooikeustaso,
+    roolit,
+  },
   hankeUsers,
   signedInUser,
   hankeTunnus,
   hankeName,
 }: Readonly<Props>) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const hankeViewPath = useHankeViewPath(hankeTunnus);
   const getHankeUsersPath = useLinkPath(ROUTES.ACCESS_RIGHTS);
   const formContext = useForm({
@@ -53,11 +82,22 @@ function EditUserView({
       puhelinnumero,
       kayttooikeustaso,
     },
+    resolver: yupResolver(
+      yhteyshenkiloSchema.shape({ kayttooikeustaso: yup.mixed<keyof typeof AccessRightLevel>() }),
+    ),
   });
+  const { getValues, handleSubmit } = formContext;
 
+  const queryClient = useQueryClient();
+  const updateSelfMutation = useMutation(updateSelf);
   const { resendInvitationMutation, linksSentTo, sendInvitation } = useResendInvitation();
+  const { setNotification } = useGlobalNotification();
 
   const userFullName = `${etunimi} ${sukunimi}`;
+  const userRoles = roolit
+    .sort(userRoleSorter)
+    .map((role) => t(`hankeUsers:roleLabels:${role}`))
+    .join(', ');
 
   // Options for the dropdown
   const accessRightLevelOptions: AccessRightLevelOption[] = $enum(AccessRightLevel)
@@ -85,6 +125,45 @@ function EditUserView({
   const isDropdownDisabled =
     isOnlyWithAllRights || !canEditRights || !canEditAllRights || isSignedInUser;
 
+  function navigateToHankeUsersView() {
+    navigate('..', { relative: 'path' });
+  }
+
+  function handleSuccess(data: HankeUser) {
+    queryClient.setQueryData(['hankeUser', data.id], data);
+    queryClient.invalidateQueries(['hankeUsers', hankeTunnus]);
+    setNotification(true, {
+      label: t('hankeUsers:notifications:userUpdatedSuccessLabel'),
+      message: t('hankeUsers:notifications:userUpdatedSuccessText'),
+      type: 'success',
+      dismissible: true,
+      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+      autoClose: true,
+      autoCloseDuration: 7000,
+    });
+    navigateToHankeUsersView();
+  }
+
+  function editUser() {
+    if (isSignedInUser) {
+      updateSelfMutation.mutate(
+        {
+          hankeTunnus,
+          user: { sahkoposti: getValues('sahkoposti'), puhelinnumero: getValues('puhelinnumero') },
+        },
+        {
+          onSuccess: handleSuccess,
+        },
+      );
+    }
+  }
+
+  function closeUpdateUserErrorNotification() {
+    if (isSignedInUser) {
+      updateSelfMutation.reset();
+    }
+  }
+
   return (
     <div className={styles.container}>
       <header className={styles.header}>
@@ -105,9 +184,15 @@ function EditUserView({
               ]}
             />
           </div>
-          <MainHeading spacingBottom="l">
+          <MainHeading spacingBottom="m">
             {t('hankeUsers:userEditTitle')}: {userFullName}
           </MainHeading>
+          <Text tag="p" styleAs="body-s" spacingBottom="s">
+            <Box as="strong" marginRight="var(--spacing-s)">
+              {t('hankeUsers:role')}:
+            </Box>
+            {userRoles}
+          </Text>
           <Flex gap="var(--spacing-2-xs)" color="var(--color-black-60)">
             {tunnistautunut ? (
               <>
@@ -145,10 +230,20 @@ function EditUserView({
         </Box>
 
         <FormProvider {...formContext}>
-          <form className={styles.formContainer}>
+          <form onSubmit={handleSubmit(editUser)} className={styles.formContainer}>
             <ResponsiveGrid maxColumns={2}>
-              <TextInput name="etunimi" label={t('hankeForm:labels:etunimi')} required />
-              <TextInput name="sukunimi" label={t('hankeForm:labels:sukunimi')} required />
+              <TextInput
+                name="etunimi"
+                label={t('hankeForm:labels:etunimi')}
+                required
+                readOnly={isSignedInUser}
+              />
+              <TextInput
+                name="sukunimi"
+                label={t('hankeForm:labels:sukunimi')}
+                required
+                readOnly={isSignedInUser}
+              />
             </ResponsiveGrid>
             <ResponsiveGrid maxColumns={2}>
               <TextInput name="sahkoposti" label={t('hankeForm:labels:email')} required />
@@ -158,7 +253,7 @@ function EditUserView({
                 required
               />
             </ResponsiveGrid>
-            <ResponsiveGrid maxColumns={2} className={styles.accessRightSelect}>
+            <ResponsiveGrid maxColumns={2}>
               <Dropdown
                 id={id}
                 name="kayttooikeustaso"
@@ -171,9 +266,49 @@ function EditUserView({
                 }
               />
             </ResponsiveGrid>
+
+            <Flex
+              marginTop="var(--spacing-xl)"
+              marginBottom="var(--spacing-xl)"
+              gap="var(--spacing-s)"
+            >
+              <Button
+                iconLeft={<IconSaveDisketteFill />}
+                isLoading={updateSelfMutation.isLoading}
+                type="submit"
+              >
+                {t('form:buttons:saveChanges')}
+              </Button>
+              <Button
+                iconLeft={<IconCross />}
+                variant="secondary"
+                onClick={navigateToHankeUsersView}
+              >
+                {t('common:confirmationDialog:cancelButton')}
+              </Button>
+            </Flex>
           </form>
         </FormProvider>
       </Container>
+
+      {updateSelfMutation.isError && (
+        <Notification
+          position="top-right"
+          dismissible
+          type="error"
+          label={t('hankeUsers:notifications:userUpdatedErrorLabel')}
+          closeButtonLabelText={t('common:components:notification:closeButtonLabelText')}
+          onClose={closeUpdateUserErrorNotification}
+        >
+          <Trans i18nKey="hankeUsers:notifications:userUpdatedErrorText">
+            <p>
+              Käyttäjätietojen päivityksessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota
+              yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa
+              <Link href="mailto:haitatontuki@hel.fi">haitatontuki@hel.fi</Link>.
+            </p>
+          </Trans>
+        </Notification>
+      )}
 
       {resendInvitationMutation.isSuccess && (
         <InvitationSuccessNotification onClose={() => resendInvitationMutation.reset()}>

--- a/src/domain/hanke/hankeUsers/hankeUser.ts
+++ b/src/domain/hanke/hankeUsers/hankeUser.ts
@@ -17,6 +17,8 @@ export type HankeUser = {
   tunnistautunut: boolean;
 };
 
+export type HankeUserSelf = Pick<HankeUser, 'sahkoposti' | 'puhelinnumero'>;
+
 export enum Rights {
   VIEW = 'VIEW',
   MODIFY_VIEW_PERMISSIONS = 'MODIFY_VIEW_PERMISSIONS',

--- a/src/domain/hanke/hankeUsers/hankeUsersApi.ts
+++ b/src/domain/hanke/hankeUsers/hankeUsersApi.ts
@@ -1,5 +1,11 @@
 import api from '../../api/api';
-import { HankeUser, IdentificationResponse, SignedInUser, SignedInUserByHanke } from './hankeUser';
+import {
+  HankeUser,
+  HankeUserSelf,
+  IdentificationResponse,
+  SignedInUser,
+  SignedInUserByHanke,
+} from './hankeUser';
 import { Yhteyshenkilo } from '../edit/types';
 
 export async function createHankeUser({
@@ -39,7 +45,7 @@ export async function updateSelf({
   user,
 }: {
   hankeTunnus: string;
-  user: Pick<HankeUser, 'sahkoposti' | 'puhelinnumero'>;
+  user: HankeUserSelf;
 }) {
   const { data } = await api.put<HankeUser>(`hankkeet/${hankeTunnus}/kayttajat/self`, user);
   return data;

--- a/src/domain/hanke/hankeUsers/hankeUsersApi.ts
+++ b/src/domain/hanke/hankeUsers/hankeUsersApi.ts
@@ -34,6 +34,17 @@ export async function updateHankeUsers({
   return data;
 }
 
+export async function updateSelf({
+  hankeTunnus,
+  user,
+}: {
+  hankeTunnus: string;
+  user: Pick<HankeUser, 'sahkoposti' | 'puhelinnumero'>;
+}) {
+  const { data } = await api.put<HankeUser>(`hankkeet/${hankeTunnus}/kayttajat/self`, user);
+  return data;
+}
+
 // Get user id and rights of the signed in user for a hanke
 export async function getSignedInUserForHanke(hankeTunnus?: string): Promise<SignedInUser> {
   const { data } = await api.get<SignedInUser>(`hankkeet/${hankeTunnus}/whoami`);

--- a/src/domain/hanke/hankeUsers/hooks/useHankeUsers.ts
+++ b/src/domain/hanke/hankeUsers/hooks/useHankeUsers.ts
@@ -5,6 +5,5 @@ import { getHankeUsers } from '../hankeUsersApi';
 export function useHankeUsers(hankeTunnus?: string) {
   return useQuery<HankeUser[]>(['hankeUsers', hankeTunnus], () => getHankeUsers(hankeTunnus), {
     enabled: Boolean(hankeTunnus),
-    staleTime: 30000,
   });
 }

--- a/src/domain/hanke/hankeUsers/utils.ts
+++ b/src/domain/hanke/hankeUsers/utils.ts
@@ -16,3 +16,24 @@ export function mapHankeUserToHankeYhteyshenkilo({
     puhelinnumero,
   };
 }
+
+const userRoleSortOrder = ['OMISTAJA', 'RAKENNUTTAJA', 'TOTEUTTAJA', 'MUU'];
+
+export const userRoleSorter = (a: string, b: string) => {
+  const indexA = userRoleSortOrder.indexOf(a);
+  const indexB = userRoleSortOrder.indexOf(b);
+
+  if (indexA === -1 && indexB === -1) {
+    // If both elements are not in sortOrder, maintain their original order
+    return 0;
+  } else if (indexA === -1) {
+    // If only 'a' is not in sortOrder, 'a' comes after 'b'
+    return 1;
+  } else if (indexB === -1) {
+    // If only 'b' is not in sortOrder, 'a' comes before 'b'
+    return -1;
+  } else {
+    // Compare based on their indices in sortOrder
+    return indexA - indexB;
+  }
+};

--- a/src/domain/mocks/data/users.ts
+++ b/src/domain/mocks/data/users.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import usersData from './users-data.json';
-import { AccessRightLevel, HankeUser } from '../../hanke/hankeUsers/hankeUser';
+import { AccessRightLevel, HankeUser, HankeUserSelf } from '../../hanke/hankeUsers/hankeUser';
 import { Yhteyshenkilo } from '../../hanke/edit/types';
 
 let users = [...usersData];
@@ -55,4 +55,23 @@ export async function update(hankeTunnus: string, modifiedUsers: HankeUser[]) {
       }
       return user;
     });
+}
+
+export async function updateSelf(
+  hankeTunnus: string,
+  modifiedUser: HankeUserSelf & { id: string },
+) {
+  users = users
+    .filter((user) => user.hankeTunnus === hankeTunnus)
+    .map((user) => {
+      if (modifiedUser.id === user.id) {
+        return {
+          ...user,
+          sahkoposti: modifiedUser.sahkoposti,
+          puhelinnumero: modifiedUser.puhelinnumero,
+        };
+      }
+      return user;
+    });
+  return users.find((user) => user.id === modifiedUser.id);
 }

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -5,7 +5,7 @@ import * as hankkeetDB from './data/hankkeet';
 import * as hakemuksetDB from './data/hakemukset';
 import * as usersDB from './data/users';
 import ApiError from './apiError';
-import { IdentificationResponse, SignedInUser } from '../hanke/hankeUsers/hankeUser';
+import { HankeUserSelf, IdentificationResponse, SignedInUser } from '../hanke/hankeUsers/hankeUser';
 import { Yhteyshenkilo } from '../hanke/edit/types';
 
 const apiUrl = '/api';
@@ -191,6 +191,17 @@ export const handlers = [
     const { kayttajat } = await req.json();
     await usersDB.update(hankeTunnus as string, kayttajat);
     return res(ctx.status(200));
+  }),
+
+  rest.put(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat/self`, async (req, res, ctx) => {
+    const { hankeTunnus } = req.params;
+    const { sahkoposti, puhelinnumero }: HankeUserSelf = await req.json();
+    const user = await usersDB.updateSelf(hankeTunnus as string, {
+      sahkoposti,
+      puhelinnumero,
+      id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+    });
+    return res(ctx.status(200), ctx.json(user));
   }),
 
   rest.get(`${apiUrl}/hankkeet/:hankeTunnus/whoami`, async (req, res, ctx) => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -237,14 +237,14 @@
       }
     },
     "ACCESS_RIGHTS": {
-      "path": "/projectportfolio/:hankeTunnus/oikeudet",
-      "headerLabel": "Access rights",
+      "path": "/projectportfolio/:hankeTunnus/kayttajat",
+      "headerLabel": "Käyttäjähallinta",
       "meta": {
-        "title": "Haitaton - Access rights management"
+        "title": "Haitaton - Käyttäjähallinta"
       }
     },
     "EDIT_USER": {
-      "path": "/hankesalkku/:hankeTunnus/kayttajat/:id",
+      "path": "/projectportfolio/:hankeTunnus/kayttajat/:id",
       "headerLabel": "Käyttäjätietojen muokkaus",
       "meta": {
         "title": "Haitaton - Käyttäjätietojen muokkaus"
@@ -846,10 +846,10 @@
       "helperText": "Search by name"
     },
     "notifications": {
-      "rightsUpdatedSuccessLabel": "Access rights updated",
-      "rightsUpdatedSuccessText": "Access rights successfully updated",
-      "rightsUpdatedErrorLabel": "Error in the updating process",
-      "rightsUpdatedErrorText": "<0>An error occurred when updating access rights. Please try again later or contact the Haitaton technical support by email <1>haitatontuki@hel.fi</1>.</0>",
+      "userUpdatedSuccessLabel": "User information updated",
+      "userUpdatedSuccessText": "User information successfully updated",
+      "userUpdatedErrorLabel": "Error in the updating process",
+      "userUpdatedErrorText": "<0>An error occurred when updating user information. Please try again later or contact the Haitaton technical support by email <1>haitatontuki@hel.fi</1>.</0>",
       "userIdentifiedLabel": "Login successful",
       "userIdentifiedText": "Login successful. You have now been added to the project ({{hankeNimi}} {{hankeTunnus}}).",
       "userIdentifiedError": "Login failed",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -271,10 +271,10 @@
       }
     },
     "ACCESS_RIGHTS": {
-      "path": "/hankesalkku/:hankeTunnus/oikeudet",
-      "headerLabel": "Käyttöoikeudet",
+      "path": "/hankesalkku/:hankeTunnus/kayttajat",
+      "headerLabel": "Käyttäjähallinta",
       "meta": {
-        "title": "Haitaton - Käyttöoikeuksien hallinta"
+        "title": "Haitaton - Käyttäjähallinta"
       }
     },
     "EDIT_USER": {
@@ -908,10 +908,10 @@
       "helperText": "Hae nimellä"
     },
     "notifications": {
-      "rightsUpdatedSuccessLabel": "Käyttöoikeudet päivitetty",
-      "rightsUpdatedSuccessText": "Käyttöoikeudet on päivitetty onnistuneesti",
-      "rightsUpdatedErrorLabel": "Virhe päivityksessä",
-      "rightsUpdatedErrorText": "<0>Käyttöoikeuksien päivityksessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>",
+      "userUpdatedSuccessLabel": "Käyttäjätiedot päivitetty",
+      "userUpdatedSuccessText": "Käyttäjätiedot päivitetty onnistuneesti",
+      "userUpdatedErrorLabel": "Virhe päivityksessä",
+      "userUpdatedErrorText": "<0>Käyttäjätietojen päivityksessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>",
       "userIdentifiedLabel": "Tunnistautuminen onnistui",
       "userIdentifiedText": "Tunnistautuminen onnistui. Sinut on nyt lisätty hankkeelle ({{hankeNimi}} {{hankeTunnus}}).",
       "userIdentifiedError": "Tunnistautuminen epäonnistui",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -237,14 +237,14 @@
       }
     },
     "ACCESS_RIGHTS": {
-      "path": "/projektportfolj/:hankeTunnus/oikeudet",
-      "headerLabel": "Användningsrättigheter",
+      "path": "/projektportfolj/:hankeTunnus/kayttajat",
+      "headerLabel": "Käyttäjähallinta",
       "meta": {
-        "title": "Haitaton – Hantering av användningsrättigheter"
+        "title": "Haitaton – Käyttäjähallinta"
       }
     },
     "EDIT_USER": {
-      "path": "/hankesalkku/:hankeTunnus/kayttajat/:id",
+      "path": "/projektportfolj/:hankeTunnus/kayttajat/:id",
       "headerLabel": "Käyttäjätietojen muokkaus",
       "meta": {
         "title": "Haitaton - Käyttäjätietojen muokkaus"
@@ -846,10 +846,10 @@
       "helperText": "Sök enligt namn"
     },
     "notifications": {
-      "rightsUpdatedSuccessLabel": "Användningsrättigheterna har uppdaterats",
-      "rightsUpdatedSuccessText": "Användningsrättigheterna har uppdaterats",
-      "rightsUpdatedErrorLabel": "Ett fel uppstod vid uppdateringen",
-      "rightsUpdatedErrorText": "<0>Ett fel uppstod när användningsrättigheterna skulle uppdateras. Försök igen senare eller kontakta Haitatons tekniska support med e-post till <1>haitatontuki@hel.fi</1>.</0>",
+      "userUpdatedSuccessLabel": "Användarinformation har uppdaterats",
+      "userUpdatedSuccessText": "Användarinformation har uppdaterats",
+      "userUpdatedErrorLabel": "Ett fel uppstod vid uppdateringen",
+      "userUpdatedErrorText": "<0>Ett fel uppstod när användarinformation skulle uppdateras. Försök igen senare eller kontakta Haitatons tekniska support med e-post till <1>haitatontuki@hel.fi</1>.</0>",
       "userIdentifiedLabel": "Identifieringen lyckades",
       "userIdentifiedText": "Identifieringen lyckades. Du har nu lagts till i projektet ({{hankeNimi}} {{hankeTunnus}}).",
       "userIdentifiedError": "Identifieringen misslyckades",


### PR DESCRIPTION
# Description

Implemented editing users own contact information. Fields that can be edited are email and phone number. Success notification is shown if editing is successful and user is redirected to user management view. Error notification is shown if something goes wrong.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2224

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Go to edit your own information from the user management page
2. Edit both the email and the phone number and press "Tallenna muutokset" button
3. You should be taken back to user management page and there should be success notification
4. Check that the information in the table is updated

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
