### PR TITLE
HAI-1808 Add aria attributes for hanke list button, which expands the hanke card

### DIFF
--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -151,7 +151,13 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke, signedInUser, 
               </CheckRightsByUser>
             </FeatureFlags>
           </div>
-          <button type="button" className={styles.iconWrapper}>
+          <button
+            type="button"
+            className={styles.iconWrapper}
+            aria-label={t('hankePortfolio:ariaLabels:expandHankeCard')}
+            aria-controls="hanke-card-content"
+            aria-expanded={buttonProps['aria-expanded']}
+          >
             {icon}
           </button>
         </div>
@@ -162,7 +168,7 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke, signedInUser, 
           />
         </FeatureFlags>
       </>
-      <div className={styles.hankeCardContent} {...contentProps}>
+      <div className={styles.hankeCardContent} {...contentProps} id="hanke-card-content">
         <FeatureFlags flags={['hanke']}>
           <div>
             <div className={styles.gridBasicInfo}>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -831,6 +831,9 @@
       "sposti": "Sähköposti",
       "puhelin": "Puhelin",
       "oikeudet": "Käyttöoikeutesi hankkeelle"
+    },
+    "ariaLabels": {
+      "expandHankeCard": "Laajenna hankkeen tiedot"
     }
   },
   "publicHankkeet": {


### PR DESCRIPTION
# Description

For better accessibility, added aria-label, aria-controls and aria-expanded attributes for hanke card expand button.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1808

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
