### PR TITLE
Remove redux-thunk from dependencies as it is included in redux toolkit 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "react-router-dom": "^6.13.0",
     "react-scripts": "^5.0.1",
     "react-table": "^7.8.0",
-    "redux-thunk": "^2.3.0",
     "sass": "^1.69.7",
     "stream": "npm:stream-browserify",
     "stream-browserify": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14553,11 +14553,6 @@ reduce-flatten@^2.0.0:
   resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-2.0.0.tgz#734fd84e65f375d7ca4465c69798c25c9d10ae27"
   integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
 
-redux-thunk@^2.3.0:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.2.tgz#b9d05d11994b99f7a91ea223e8b04cf0afa5ef3b"
-  integrity sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==
-
 redux-thunk@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-3.1.0.tgz#94aa6e04977c30e14e892eae84978c1af6058ff3"


### PR DESCRIPTION
# Description

Redux Thunk is included as part of Redux Toolkit from version 2.0, so removed Redux Thunk from dependencies.