### PR TITLE
HAI-2226 User can edit other users information

### DIFF
--- a/src/domain/hanke/edit/types.ts
+++ b/src/domain/hanke/edit/types.ts
@@ -93,3 +93,7 @@ export interface HankePostData
 export type NewHankeData = yup.InferType<typeof newHankeSchema>;
 
 export type Yhteyshenkilo = yup.InferType<typeof yhteyshenkiloSchema>;
+export type YhteyshenkiloWithoutName = Pick<
+  Yhteyshenkilo,
+  YHTEYSHENKILO_FORMFIELD.EMAIL | YHTEYSHENKILO_FORMFIELD.PUHELINNUMERO
+>;

--- a/src/domain/hanke/hankeUsers/EditUserView.test.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.test.tsx
@@ -7,6 +7,37 @@ import { readAll } from '../../mocks/data/users';
 import { USER_EDIT_HANKE } from '../../mocks/signedInUser';
 import * as hankeUsersApi from './hankeUsersApi';
 
+jest.setTimeout(10000);
+
+function fillUserInformation({
+  etunimi,
+  sukunimi,
+  sahkoposti,
+  puhelinnumero,
+}: {
+  etunimi?: string;
+  sukunimi?: string;
+  sahkoposti: string;
+  puhelinnumero: string;
+}) {
+  if (etunimi !== undefined) {
+    fireEvent.change(screen.getByLabelText(/etunimi/i), {
+      target: { value: etunimi },
+    });
+  }
+  if (sukunimi !== undefined) {
+    fireEvent.change(screen.getByLabelText(/sukunimi/i), {
+      target: { value: sukunimi },
+    });
+  }
+  fireEvent.change(screen.getByLabelText(/sähköposti/i), {
+    target: { value: sahkoposti },
+  });
+  fireEvent.change(screen.getByLabelText(/puhelinnumero/i), {
+    target: { value: puhelinnumero },
+  });
+}
+
 test('Should show correct page title', async () => {
   render(<EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />);
   await waitForLoadingToFinish();
@@ -16,7 +47,7 @@ test('Should show correct page title', async () => {
   ).toBeInTheDocument();
 });
 
-test('Should show status text of user identified if user is identified', async () => {
+test('For identified user should show status text of user identified and should not be able to edit name', async () => {
   render(<EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />);
   await waitForLoadingToFinish();
 
@@ -26,6 +57,8 @@ test('Should show status text of user identified if user is identified', async (
   expect(
     screen.queryByRole('button', { name: 'Lähetä kutsulinkki uudelleen' }),
   ).not.toBeInTheDocument();
+  expect(screen.getByRole('textbox', { name: /etunimi/i })).toHaveAttribute('readonly');
+  expect(screen.getByRole('textbox', { name: /sukunimi/i })).toHaveAttribute('readonly');
 });
 
 test('Should show status text of invitation send to user and Invitation send button if user is not identified', async () => {
@@ -48,14 +81,14 @@ test('Permissions dropdown should be disabled if only one user has all rights', 
   render(<EditUserContainer id={users[2].id} hankeTunnus={hankeTunnus} />);
   await waitForLoadingToFinish();
 
-  expect(screen.getByRole('button', { name: 'Käyttöoikeudet' })).toBeDisabled();
+  expect(screen.getByRole('button', { name: /käyttöoikeudet/i })).toBeDisabled();
 });
 
 test('Permissions dropdown should be disabled if editing own information', async () => {
   render(<EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />);
   await waitForLoadingToFinish();
 
-  expect(screen.getByRole('button', { name: 'Käyttöoikeudet' })).toBeDisabled();
+  expect(screen.getByRole('button', { name: /käyttöoikeudet/i })).toBeDisabled();
 });
 
 test('Permissions dropdown should be disabled if user does not have enough rights', async () => {
@@ -68,7 +101,7 @@ test('Permissions dropdown should be disabled if user does not have enough right
   render(<EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa8" hankeTunnus="HAI22-2" />);
   await waitForLoadingToFinish();
 
-  expect(screen.getByRole('button', { name: 'Käyttöoikeudet' })).toBeDisabled();
+  expect(screen.getByRole('button', { name: /käyttöoikeudet/i })).toBeDisabled();
 });
 
 test('Should be able to edit own information', async () => {
@@ -80,12 +113,7 @@ test('Should be able to edit own information', async () => {
   await waitForLoadingToFinish();
   const sahkoposti = 'matti@test.com';
   const puhelinnumero = '0000000000';
-  fireEvent.change(screen.getByLabelText(/sähköposti/i), {
-    target: { value: sahkoposti },
-  });
-  fireEvent.change(screen.getByLabelText(/puhelinnumero/i), {
-    target: { value: puhelinnumero },
-  });
+  fillUserInformation({ sahkoposti, puhelinnumero });
   await user.click(screen.getByRole('button', { name: /tallenna muutokset/i }));
 
   expect(updateSelf).toHaveBeenCalledWith({
@@ -94,6 +122,8 @@ test('Should be able to edit own information', async () => {
   });
   expect(screen.getByText('Käyttäjätiedot päivitetty')).toBeInTheDocument();
   expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2/kayttajat');
+
+  updateSelf.mockRestore();
 });
 
 test('Should not be able to save changes if form is not valid', async () => {
@@ -102,17 +132,14 @@ test('Should not be able to save changes if form is not valid', async () => {
     <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />,
   );
   await waitForLoadingToFinish();
-  fireEvent.change(screen.getByLabelText(/sähköposti/i), {
-    target: { value: 'matti.com' },
-  });
-  fireEvent.change(screen.getByLabelText(/puhelinnumero/i), {
-    target: { value: '' },
-  });
+  fillUserInformation({ sahkoposti: 'matti.com', puhelinnumero: '' });
   await user.click(screen.getByRole('button', { name: /tallenna muutokset/i }));
 
   expect(screen.getByText('Sähköposti on virheellinen')).toBeInTheDocument();
   expect(screen.getByText('Kenttä on pakollinen')).toBeInTheDocument();
   expect(updateSelf).not.toHaveBeenCalled();
+
+  updateSelf.mockRestore();
 });
 
 test('Should be able to cancel and return to user management view', async () => {
@@ -125,7 +152,7 @@ test('Should be able to cancel and return to user management view', async () => 
   expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2/kayttajat');
 });
 
-test('Should show error notification if editing fails', async () => {
+test('Should show error notification if editing own information fails', async () => {
   server.use(
     rest.put('/api/hankkeet/:hankeTunnus/kayttajat/self', async (req, res, ctx) => {
       return res(ctx.status(500));
@@ -135,6 +162,75 @@ test('Should show error notification if editing fails', async () => {
     <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />,
   );
   await waitForLoadingToFinish();
+  await user.click(screen.getByRole('button', { name: /tallenna muutokset/i }));
+
+  expect(screen.getByText('Virhe päivityksessä')).toBeInTheDocument();
+});
+
+test('Should be able to edit users information', async () => {
+  const updateUser = jest.spyOn(hankeUsersApi, 'updateHankeUser');
+  const updatePermission = jest.spyOn(hankeUsersApi, 'updateHankeUsersPermissions');
+  const hankeTunnus = 'HAI22-2';
+  const userId = '3fa85f64-5717-4562-b3fc-2c963f66afa7';
+  const { user } = render(<EditUserContainer id={userId} hankeTunnus={hankeTunnus} />);
+  await waitForLoadingToFinish();
+  const etunimi = 'Teppo Tauno';
+  const sukunimi = 'Testaaja';
+  const sahkoposti = 'teppo.testaaja@test.com';
+  const puhelinnumero = '1234567';
+  fillUserInformation({ etunimi, sukunimi, sahkoposti, puhelinnumero });
+  fireEvent.click(screen.getByRole('button', { name: /käyttöoikeudet/i }));
+  fireEvent.click(screen.getAllByText('Kaikki oikeudet')[1]);
+  await user.click(screen.getByRole('button', { name: /tallenna muutokset/i }));
+
+  expect(updateUser).toHaveBeenCalledWith({
+    hankeTunnus,
+    userId,
+    user: { etunimi, sukunimi, sahkoposti, puhelinnumero },
+  });
+  expect(updatePermission).toHaveBeenCalledWith({
+    hankeTunnus,
+    users: [
+      {
+        id: userId,
+        kayttooikeustaso: 'KAIKKI_OIKEUDET',
+      },
+    ],
+  });
+  expect(screen.getByText('Käyttäjätiedot päivitetty')).toBeInTheDocument();
+  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2/kayttajat');
+
+  updateUser.mockRestore();
+  updatePermission.mockRestore();
+});
+
+test('Should show error notification if editing users information fails', async () => {
+  server.use(
+    rest.put('/api/hankkeet/:hankeTunnus/kayttajat/:userId', async (req, res, ctx) => {
+      return res(ctx.status(500));
+    }),
+  );
+  const { user } = render(
+    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa7" hankeTunnus="HAI22-2" />,
+  );
+  await waitForLoadingToFinish();
+  await user.click(screen.getByRole('button', { name: /tallenna muutokset/i }));
+
+  expect(screen.getByText('Virhe päivityksessä')).toBeInTheDocument();
+});
+
+test('Should show error notification if editing users permission fails', async () => {
+  server.use(
+    rest.put('/api/hankkeet/:hankeTunnus/kayttajat', async (req, res, ctx) => {
+      return res(ctx.status(500));
+    }),
+  );
+  const { user } = render(
+    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa7" hankeTunnus="HAI22-2" />,
+  );
+  await waitForLoadingToFinish();
+  fireEvent.click(screen.getByRole('button', { name: /käyttöoikeudet/i }));
+  fireEvent.click(screen.getByText('Katseluoikeus'));
   await user.click(screen.getByRole('button', { name: /tallenna muutokset/i }));
 
   expect(screen.getByText('Virhe päivityksessä')).toBeInTheDocument();

--- a/src/domain/hanke/hankeUsers/EditUserView.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.tsx
@@ -32,7 +32,7 @@ import {
   InvitationErrorNotification,
   InvitationSuccessNotification,
 } from './InvitationNotification';
-import { updateSelf } from './hankeUsersApi';
+import { updateHankeUser, updateHankeUsersPermissions, updateSelf } from './hankeUsersApi';
 import yup from '../../../common/utils/yup';
 import { yhteyshenkiloSchema } from '../edit/hankeSchema';
 import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
@@ -51,6 +51,10 @@ type AccessRightLevelOption = {
   label: string;
   value: keyof typeof AccessRightLevel;
 };
+
+const editUserSchema = yhteyshenkiloSchema.shape({
+  kayttooikeustaso: yup.mixed<keyof typeof AccessRightLevel>().defined().required(),
+});
 
 function EditUserView({
   user,
@@ -82,14 +86,14 @@ function EditUserView({
       puhelinnumero,
       kayttooikeustaso,
     },
-    resolver: yupResolver(
-      yhteyshenkiloSchema.shape({ kayttooikeustaso: yup.mixed<keyof typeof AccessRightLevel>() }),
-    ),
+    resolver: yupResolver(editUserSchema),
   });
-  const { getValues, handleSubmit } = formContext;
+  const { handleSubmit } = formContext;
 
   const queryClient = useQueryClient();
   const updateSelfMutation = useMutation(updateSelf);
+  const updateUserMutation = useMutation(updateHankeUser);
+  const updatePermissionMutation = useMutation(updateHankeUsersPermissions);
   const { resendInvitationMutation, linksSentTo, sendInvitation } = useResendInvitation();
   const { setNotification } = useGlobalNotification();
 
@@ -125,13 +129,19 @@ function EditUserView({
   const isDropdownDisabled =
     isOnlyWithAllRights || !canEditRights || !canEditAllRights || isSignedInUser;
 
+  const saveButtonIsLoading =
+    updateSelfMutation.isLoading ||
+    updateUserMutation.isLoading ||
+    updatePermissionMutation.isLoading;
+  const showUpdatedUserErrorNotification =
+    updateSelfMutation.isError || updateUserMutation.isError || updatePermissionMutation.isError;
+
   function navigateToHankeUsersView() {
     navigate(getHankeUsersPath({ hankeTunnus }));
   }
 
   function handleSuccess(data: HankeUser) {
     queryClient.setQueryData(['hankeUser', data.id], data);
-    queryClient.invalidateQueries(['hankeUsers', hankeTunnus]);
     setNotification(true, {
       label: t('hankeUsers:notifications:userUpdatedSuccessLabel'),
       message: t('hankeUsers:notifications:userUpdatedSuccessText'),
@@ -144,23 +154,48 @@ function EditUserView({
     navigateToHankeUsersView();
   }
 
-  function editUser() {
+  async function editUser(data: yup.InferType<typeof editUserSchema>) {
     if (isSignedInUser) {
       updateSelfMutation.mutate(
         {
           hankeTunnus,
-          user: { sahkoposti: getValues('sahkoposti'), puhelinnumero: getValues('puhelinnumero') },
+          user: { sahkoposti: data.sahkoposti, puhelinnumero: data.puhelinnumero },
         },
         {
           onSuccess: handleSuccess,
         },
       );
+    } else {
+      try {
+        const updatedUser = await updateUserMutation.mutateAsync({
+          hankeTunnus,
+          userId: id,
+          user: {
+            etunimi: data.etunimi,
+            sukunimi: data.sukunimi,
+            sahkoposti: data.sahkoposti,
+            puhelinnumero: data.puhelinnumero,
+          },
+        });
+        if (data.kayttooikeustaso !== kayttooikeustaso) {
+          await updatePermissionMutation.mutateAsync({
+            hankeTunnus,
+            users: [{ id, kayttooikeustaso: data.kayttooikeustaso }],
+          });
+          updatedUser.kayttooikeustaso = data.kayttooikeustaso;
+        }
+        handleSuccess(updatedUser);
+        // eslint-disable-next-line no-empty
+      } catch (e) {}
     }
   }
 
   function closeUpdateUserErrorNotification() {
     if (isSignedInUser) {
       updateSelfMutation.reset();
+    } else {
+      updateUserMutation.reset();
+      updatePermissionMutation.reset();
     }
   }
 
@@ -236,13 +271,13 @@ function EditUserView({
                 name="etunimi"
                 label={t('hankeForm:labels:etunimi')}
                 required
-                readOnly={isSignedInUser}
+                readOnly={tunnistautunut}
               />
               <TextInput
                 name="sukunimi"
                 label={t('hankeForm:labels:sukunimi')}
                 required
-                readOnly={isSignedInUser}
+                readOnly={tunnistautunut}
               />
             </ResponsiveGrid>
             <ResponsiveGrid maxColumns={2}>
@@ -259,6 +294,7 @@ function EditUserView({
                 name="kayttooikeustaso"
                 label={t('hankeUsers:accessRights')}
                 options={accessRightLevelOptions}
+                required
                 disabled={isDropdownDisabled}
                 isOptionDisabled={(option) =>
                   option.value === 'KAIKKI_OIKEUDET' &&
@@ -274,7 +310,7 @@ function EditUserView({
             >
               <Button
                 iconLeft={<IconSaveDisketteFill />}
-                isLoading={updateSelfMutation.isLoading}
+                isLoading={saveButtonIsLoading}
                 type="submit"
               >
                 {t('form:buttons:saveChanges')}
@@ -291,7 +327,7 @@ function EditUserView({
         </FormProvider>
       </Container>
 
-      {updateSelfMutation.isError && (
+      {showUpdatedUserErrorNotification && (
         <Notification
           position="top-right"
           dismissible

--- a/src/domain/hanke/hankeUsers/EditUserView.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.tsx
@@ -167,15 +167,18 @@ function EditUserView({
       );
     } else {
       try {
+        const updates = tunnistautunut
+          ? { sahkoposti: data.sahkoposti, puhelinnumero: data.puhelinnumero }
+          : {
+              etunimi: data.etunimi,
+              sukunimi: data.sukunimi,
+              sahkoposti: data.sahkoposti,
+              puhelinnumero: data.puhelinnumero,
+            };
         const updatedUser = await updateUserMutation.mutateAsync({
           hankeTunnus,
           userId: id,
-          user: {
-            etunimi: data.etunimi,
-            sukunimi: data.sukunimi,
-            sahkoposti: data.sahkoposti,
-            puhelinnumero: data.puhelinnumero,
-          },
+          user: updates,
         });
         if (data.kayttooikeustaso !== kayttooikeustaso) {
           await updatePermissionMutation.mutateAsync({

--- a/src/domain/hanke/hankeUsers/hankeUser.ts
+++ b/src/domain/hanke/hankeUsers/hankeUser.ts
@@ -17,8 +17,6 @@ export type HankeUser = {
   tunnistautunut: boolean;
 };
 
-export type HankeUserSelf = Pick<HankeUser, 'sahkoposti' | 'puhelinnumero'>;
-
 export enum Rights {
   VIEW = 'VIEW',
   MODIFY_VIEW_PERMISSIONS = 'MODIFY_VIEW_PERMISSIONS',

--- a/src/domain/hanke/hankeUsers/hankeUsersApi.ts
+++ b/src/domain/hanke/hankeUsers/hankeUsersApi.ts
@@ -1,12 +1,6 @@
 import api from '../../api/api';
-import {
-  HankeUser,
-  HankeUserSelf,
-  IdentificationResponse,
-  SignedInUser,
-  SignedInUserByHanke,
-} from './hankeUser';
-import { Yhteyshenkilo } from '../edit/types';
+import { HankeUser, IdentificationResponse, SignedInUser, SignedInUserByHanke } from './hankeUser';
+import { Yhteyshenkilo, YhteyshenkiloWithoutName } from '../edit/types';
 
 export async function createHankeUser({
   hankeTunnus,
@@ -48,7 +42,7 @@ export async function updateHankeUser({
 }: {
   hankeTunnus: string;
   userId: string;
-  user: Yhteyshenkilo;
+  user: Yhteyshenkilo | YhteyshenkiloWithoutName;
 }) {
   const { data } = await api.put<HankeUser>(`hankkeet/${hankeTunnus}/kayttajat/${userId}`, user);
   return data;
@@ -59,7 +53,7 @@ export async function updateSelf({
   user,
 }: {
   hankeTunnus: string;
-  user: HankeUserSelf;
+  user: YhteyshenkiloWithoutName;
 }) {
   const { data } = await api.put<HankeUser>(`hankkeet/${hankeTunnus}/kayttajat/self`, user);
   return data;

--- a/src/domain/hanke/hankeUsers/hankeUsersApi.ts
+++ b/src/domain/hanke/hankeUsers/hankeUsersApi.ts
@@ -29,14 +29,28 @@ export async function getHankeUsers(hankeTunnus?: string) {
   return data.kayttajat;
 }
 
-export async function updateHankeUsers({
+// Update permissions of the listed users
+export async function updateHankeUsersPermissions({
   hankeTunnus,
   users,
 }: {
   hankeTunnus: string;
   users: Pick<HankeUser, 'id' | 'kayttooikeustaso'>[];
 }) {
-  const { data } = await api.put(`hankkeet/${hankeTunnus}/kayttajat`, { kayttajat: users });
+  await api.put(`hankkeet/${hankeTunnus}/kayttajat`, { kayttajat: users });
+}
+
+// Update the contact information of a user
+export async function updateHankeUser({
+  hankeTunnus,
+  userId,
+  user,
+}: {
+  hankeTunnus: string;
+  userId: string;
+  user: Yhteyshenkilo;
+}) {
+  const { data } = await api.put<HankeUser>(`hankkeet/${hankeTunnus}/kayttajat/${userId}`, user);
   return data;
 }
 

--- a/src/domain/mocks/data/users.ts
+++ b/src/domain/mocks/data/users.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker';
 import usersData from './users-data.json';
 import { AccessRightLevel, HankeUser, HankeUserSelf } from '../../hanke/hankeUsers/hankeUser';
 import { Yhteyshenkilo } from '../../hanke/edit/types';
+import ApiError from '../apiError';
 
 let users = [...usersData];
 
@@ -26,6 +27,10 @@ export async function readAll(hankeTunnus: string): Promise<HankeUser[]> {
   return users.filter((user) => user.hankeTunnus === hankeTunnus).map(mapToHankeUser);
 }
 
+async function readFromHanke(hankeTunnus: string, id: string): Promise<HankeUser | undefined> {
+  return (await readAll(hankeTunnus)).find((user) => user.id === id);
+}
+
 export async function create(hankeTunnus: string, user: Yhteyshenkilo) {
   const newUser: HankeUser = {
     id: faker.string.uuid(),
@@ -41,7 +46,10 @@ export async function create(hankeTunnus: string, user: Yhteyshenkilo) {
   return newUser;
 }
 
-export async function update(hankeTunnus: string, modifiedUsers: HankeUser[]) {
+export async function updatePermissions(
+  hankeTunnus: string,
+  modifiedUsers: Pick<HankeUser, 'id' | 'kayttooikeustaso'>[],
+) {
   users = users
     .filter((user) => user.hankeTunnus === hankeTunnus)
     .map((user) => {
@@ -50,28 +58,24 @@ export async function update(hankeTunnus: string, modifiedUsers: HankeUser[]) {
         return {
           ...user,
           kayttooikeustaso: modifiedUser.kayttooikeustaso as AccessRightLevel,
-          roolit: modifiedUser.roolit,
         };
       }
       return user;
     });
 }
 
-export async function updateSelf(
+export async function update(
   hankeTunnus: string,
-  modifiedUser: HankeUserSelf & { id: string },
+  userId: string,
+  updates: Yhteyshenkilo | HankeUserSelf,
 ) {
-  users = users
-    .filter((user) => user.hankeTunnus === hankeTunnus)
-    .map((user) => {
-      if (modifiedUser.id === user.id) {
-        return {
-          ...user,
-          sahkoposti: modifiedUser.sahkoposti,
-          puhelinnumero: modifiedUser.puhelinnumero,
-        };
-      }
-      return user;
-    });
-  return users.find((user) => user.id === modifiedUser.id);
+  const userToUpdate = await readFromHanke(hankeTunnus, userId);
+  if (!userToUpdate) {
+    throw new ApiError('User not found', 404);
+  }
+  const updatedUser = Object.assign(userToUpdate, updates);
+  users = users.map((user) => {
+    return user.id === updatedUser?.id ? { ...updatedUser, hankeTunnus } : user;
+  });
+  return updatedUser;
 }

--- a/src/domain/mocks/data/users.ts
+++ b/src/domain/mocks/data/users.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import usersData from './users-data.json';
-import { AccessRightLevel, HankeUser, HankeUserSelf } from '../../hanke/hankeUsers/hankeUser';
-import { Yhteyshenkilo } from '../../hanke/edit/types';
+import { AccessRightLevel, HankeUser } from '../../hanke/hankeUsers/hankeUser';
+import { Yhteyshenkilo, YhteyshenkiloWithoutName } from '../../hanke/edit/types';
 import ApiError from '../apiError';
 
 let users = [...usersData];
@@ -67,7 +67,7 @@ export async function updatePermissions(
 export async function update(
   hankeTunnus: string,
   userId: string,
-  updates: Yhteyshenkilo | HankeUserSelf,
+  updates: Yhteyshenkilo | YhteyshenkiloWithoutName,
 ) {
   const userToUpdate = await readFromHanke(hankeTunnus, userId);
   if (!userToUpdate) {

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -5,8 +5,8 @@ import * as hankkeetDB from './data/hankkeet';
 import * as hakemuksetDB from './data/hakemukset';
 import * as usersDB from './data/users';
 import ApiError from './apiError';
-import { HankeUserSelf, IdentificationResponse, SignedInUser } from '../hanke/hankeUsers/hankeUser';
-import { Yhteyshenkilo } from '../hanke/edit/types';
+import { IdentificationResponse, SignedInUser } from '../hanke/hankeUsers/hankeUser';
+import { Yhteyshenkilo, YhteyshenkiloWithoutName } from '../hanke/edit/types';
 
 const apiUrl = '/api';
 
@@ -195,7 +195,7 @@ export const handlers = [
 
   rest.put(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat/self`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
-    const reqBody: HankeUserSelf = await req.json();
+    const reqBody: YhteyshenkiloWithoutName = await req.json();
     const user = await usersDB.update(
       hankeTunnus as string,
       '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -206,7 +206,7 @@ export const handlers = [
 
   rest.put(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat/:userId`, async (req, res, ctx) => {
     const { hankeTunnus, userId } = req.params;
-    const reqBody: Yhteyshenkilo = await req.json();
+    const reqBody: Yhteyshenkilo | YhteyshenkiloWithoutName = await req.json();
     try {
       const updatedUser = await usersDB.update(hankeTunnus as string, userId as string, reqBody);
       return res(ctx.status(200), ctx.json(updatedUser));

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -189,19 +189,37 @@ export const handlers = [
   rest.put(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
     const { kayttajat } = await req.json();
-    await usersDB.update(hankeTunnus as string, kayttajat);
-    return res(ctx.status(200));
+    await usersDB.updatePermissions(hankeTunnus as string, kayttajat);
+    return res(ctx.status(204));
   }),
 
   rest.put(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat/self`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
-    const { sahkoposti, puhelinnumero }: HankeUserSelf = await req.json();
-    const user = await usersDB.updateSelf(hankeTunnus as string, {
-      sahkoposti,
-      puhelinnumero,
-      id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-    });
+    const reqBody: HankeUserSelf = await req.json();
+    const user = await usersDB.update(
+      hankeTunnus as string,
+      '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+      reqBody,
+    );
     return res(ctx.status(200), ctx.json(user));
+  }),
+
+  rest.put(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat/:userId`, async (req, res, ctx) => {
+    const { hankeTunnus, userId } = req.params;
+    const reqBody: Yhteyshenkilo = await req.json();
+    try {
+      const updatedUser = await usersDB.update(hankeTunnus as string, userId as string, reqBody);
+      return res(ctx.status(200), ctx.json(updatedUser));
+    } catch (error) {
+      const { status, message } = error as ApiError;
+      return res(
+        ctx.status(status),
+        ctx.json({
+          errorMessage: message,
+          errorCode: 'HAI1001',
+        }),
+      );
+    }
   }),
 
   rest.get(`${apiUrl}/hankkeet/:hankeTunnus/whoami`, async (req, res, ctx) => {


### PR DESCRIPTION
# Description

Implemented editing users contact information. For user who is not identified, all fields can be edited, including changing permission. For identified user first name and last name cannot be edited.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2226

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Go to edit unidentified users information
2. Make changes to all fields including changing permission and save
3. Check that success notification is shown and that updated information is shown in the list
4. Go to edit identified user and check that first name and last name are readonly fields

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
