### PR TITLE
HAI-2230 Create new user in johtoselvitys form

### DIFF
--- a/src/domain/forms/components/testUtils.ts
+++ b/src/domain/forms/components/testUtils.ts
@@ -1,0 +1,29 @@
+import { fireEvent, screen } from '@testing-library/dom';
+
+export function fillNewContactPersonForm(
+  options: {
+    etunimi?: string;
+    sukunimi?: string;
+    sahkoposti?: string;
+    puhelinnumero?: string;
+  } = {},
+) {
+  const {
+    etunimi = 'Matti',
+    sukunimi = 'Meikäläinen',
+    sahkoposti = 'matti.meikalainen@test.com',
+    puhelinnumero = '0401234567',
+  } = options;
+  fireEvent.change(screen.getByLabelText(/etunimi/i), {
+    target: { value: etunimi },
+  });
+  fireEvent.change(screen.getByLabelText(/sukunimi/i), {
+    target: { value: sukunimi },
+  });
+  fireEvent.change(screen.getAllByRole('textbox', { name: /sähköposti/i })[1], {
+    target: { value: sahkoposti },
+  });
+  fireEvent.change(screen.getAllByRole('textbox', { name: /puhelin/i })[1], {
+    target: { value: puhelinnumero },
+  });
+}

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -19,6 +19,7 @@ import { HankeAttachmentMetadata } from '../hankeAttachments/types';
 import api from '../../api/api';
 import * as hankeAttachmentsApi from '../hankeAttachments/hankeAttachmentsApi';
 import { HankeUser } from '../hankeUsers/hankeUser';
+import { fillNewContactPersonForm } from '../../forms/components/testUtils';
 
 afterEach(cleanup);
 
@@ -487,34 +488,6 @@ describe('HankeForm', () => {
 });
 
 describe('New contact person form and contact person dropdown', () => {
-  function fillNewContactPersonForm(
-    options: {
-      etunimi?: string;
-      sukunimi?: string;
-      sahkoposti?: string;
-      puhelinnumero?: string;
-    } = {},
-  ) {
-    const {
-      etunimi = 'Matti',
-      sukunimi = 'Meikäläinen',
-      sahkoposti = 'matti.meikalainen@test.com',
-      puhelinnumero = '0401234567',
-    } = options;
-    fireEvent.change(screen.getByLabelText(/etunimi/i), {
-      target: { value: etunimi },
-    });
-    fireEvent.change(screen.getByLabelText(/sukunimi/i), {
-      target: { value: sukunimi },
-    });
-    fireEvent.change(screen.getAllByRole('textbox', { name: /sähköposti/i })[1], {
-      target: { value: sahkoposti },
-    });
-    fireEvent.change(screen.getAllByRole('textbox', { name: /puhelin/i })[1], {
-      target: { value: puhelinnumero },
-    });
-  }
-
   test('Should be able to create new user and new user is added to dropdown', async () => {
     const newUser = {
       etunimi: 'Martti',

--- a/src/domain/johtoselvitys_new/Contacts.test.tsx
+++ b/src/domain/johtoselvitys_new/Contacts.test.tsx
@@ -93,26 +93,3 @@ test('Customer fields can be filled with orderer information', async () => {
     orderer.phone,
   );
 });
-
-test('Contact fields can be filled with orderer information', async () => {
-  const application = applications[0];
-  const orderer = application.applicationData.customerWithContacts.contacts[0];
-  const { user } = render(<Form application={application} />);
-
-  await user.click(
-    screen.getByTestId('applicationData.contractorWithContacts.contacts.0.fillOwnInfoButton'),
-  );
-
-  expect(
-    screen.getByTestId('applicationData.contractorWithContacts.contacts.0.firstName'),
-  ).toHaveValue(orderer.firstName);
-  expect(
-    screen.getByTestId('applicationData.contractorWithContacts.contacts.0.lastName'),
-  ).toHaveValue(orderer.lastName);
-  expect(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.email')).toHaveValue(
-    orderer.email,
-  );
-  expect(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.phone')).toHaveValue(
-    orderer.phone,
-  );
-});

--- a/src/domain/johtoselvitys_new/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys_new/JohtoselvitysContainer.tsx
@@ -255,15 +255,9 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
   const ordererKey = findOrdererKey(getValues('applicationData'));
 
   const customer = getValues('applicationData.customerWithContacts.customer');
-  const customersContacts = getValues('applicationData.customerWithContacts.contacts');
   const contractor = getValues('applicationData.contractorWithContacts.customer');
-  const contractorsContacts = getValues('applicationData.contractorWithContacts.contacts');
   const propertyDeveloper = getValues('applicationData.propertyDeveloperWithContacts.customer');
-  const propertyDevelopersContacts = getValues(
-    'applicationData.propertyDeveloperWithContacts.contacts',
-  );
   const representative = getValues('applicationData.representativeWithContacts.customer');
-  const representativesContacts = getValues('applicationData.representativeWithContacts.contacts');
 
   // Fields that are validated in each page when moving forward in form
   const pageFieldsToValidate: FieldPath<JohtoselvitysFormValues>[][] = useMemo(
@@ -291,46 +285,20 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
           'applicationData.customerWithContacts.customer',
         ),
         ...getFieldPaths<JohtoselvitysFormValues>(
-          customersContacts,
-          'applicationData.customerWithContacts.contacts',
-        ),
-        ...getFieldPaths<JohtoselvitysFormValues>(
           contractor,
           'applicationData.contractorWithContacts.customer',
-        ),
-        ...getFieldPaths<JohtoselvitysFormValues>(
-          contractorsContacts,
-          'applicationData.contractorWithContacts.contacts',
         ),
         ...getFieldPaths<JohtoselvitysFormValues>(
           propertyDeveloper,
           'applicationData.propertyDeveloperWithContacts.customer',
         ),
         ...getFieldPaths<JohtoselvitysFormValues>(
-          propertyDevelopersContacts,
-          'applicationData.propertyDeveloperWithContacts.contacts',
-        ),
-        ...getFieldPaths<JohtoselvitysFormValues>(
           representative,
           'applicationData.representativeWithContacts.customer',
         ),
-        ...getFieldPaths<JohtoselvitysFormValues>(
-          representativesContacts,
-          'applicationData.representativeWithContacts.contacts',
-        ),
       ],
     ],
-    [
-      ordererKey,
-      customer,
-      customersContacts,
-      contractor,
-      contractorsContacts,
-      propertyDeveloper,
-      propertyDevelopersContacts,
-      representative,
-      representativesContacts,
-    ],
+    [ordererKey, customer, contractor, propertyDeveloper, representative],
   );
 
   const formSteps = useMemo(() => {

--- a/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
@@ -187,26 +187,6 @@ function fillContactsInformation() {
   fireEvent.change(screen.getByTestId('applicationData.contractorWithContacts.customer.phone'), {
     target: { value: '0000000000' },
   });
-
-  // Fill contact of contractor
-  fireEvent.change(
-    screen.getByTestId('applicationData.contractorWithContacts.contacts.0.firstName'),
-    {
-      target: { value: 'Alli' },
-    },
-  );
-  fireEvent.change(
-    screen.getByTestId('applicationData.contractorWithContacts.contacts.0.lastName'),
-    {
-      target: { value: 'Asiakas' },
-    },
-  );
-  fireEvent.change(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.email'), {
-    target: { value: 'alli.asiakas@test.com' },
-  });
-  fireEvent.change(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.phone'), {
-    target: { value: '0000000000' },
-  });
 }
 
 test('Cable report application form can be filled and saved and sent to Allu', async () => {
@@ -393,7 +373,7 @@ test('Should save existing application between page changes when there are chang
 });
 
 test('Should change users own role and its fields correctly', async () => {
-  const { user } = render(<JohtoselvitysContainer application={application} />);
+  render(<JohtoselvitysContainer application={application} />);
 
   const firstName = 'Tauno';
   const lastName = 'Työmies';
@@ -422,40 +402,6 @@ test('Should change users own role and its fields correctly', async () => {
   fireEvent.change(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.phone'), {
     target: { value: phone },
   });
-
-  // Move to areas page
-  await user.click(screen.getByRole('button', { name: /seuraava/i }));
-
-  fillAreasInformation();
-
-  // Move to contacts page
-  await user.click(screen.getByRole('button', { name: /seuraava/i }));
-  await user.click(screen.getByTestId('contractorWithContacts-0'));
-
-  expect(
-    screen.getByTestId('applicationData.customerWithContacts.contacts.0.firstName'),
-  ).toHaveValue('');
-  expect(
-    screen.getByTestId('applicationData.customerWithContacts.contacts.0.lastName'),
-  ).toHaveValue('');
-  expect(screen.getByTestId('applicationData.customerWithContacts.contacts.0.email')).toHaveValue(
-    '',
-  );
-  expect(screen.getByTestId('applicationData.customerWithContacts.contacts.0.phone')).toHaveValue(
-    '',
-  );
-  expect(
-    screen.getByTestId('applicationData.contractorWithContacts.contacts.0.firstName'),
-  ).toHaveValue(firstName);
-  expect(
-    screen.getByTestId('applicationData.contractorWithContacts.contacts.0.lastName'),
-  ).toHaveValue(lastName);
-  expect(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.email')).toHaveValue(
-    email,
-  );
-  expect(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.phone')).toHaveValue(
-    phone,
-  );
 });
 
 test('Should not change anything if selecting the same role again', async () => {
@@ -617,13 +563,6 @@ test('Form is saved when contacts are filled with orderer information', async ()
   await testFormSaving(
     applications[0],
     'applicationData.customerWithContacts.customer.fillOwnInfoButton',
-  );
-});
-
-test('Form is saved when sub contacts are filled with orderer information', async () => {
-  await testFormSaving(
-    applications[0],
-    'applicationData.contractorWithContacts.contacts.0.fillOwnInfoButton',
   );
 });
 

--- a/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
@@ -17,6 +17,7 @@ import {
   AttachmentType,
 } from '../application/types/application';
 import * as applicationAttachmentsApi from '../application/attachments';
+import { fillNewContactPersonForm } from '../forms/components/testUtils';
 
 afterEach(cleanup);
 
@@ -719,4 +720,22 @@ test('Summary should show attachments and they are downloadable', async () => {
   await user.click(screen.getByText(ATTACHMENT_META.fileName));
 
   expect(fetchContentMock).toHaveBeenCalledWith(testApplication.id, ATTACHMENT_META.id);
+});
+
+test('Should be able to create new user', async () => {
+  const newUser = {
+    etunimi: 'Marja',
+    sukunimi: 'Meikäkäinen',
+    sahkoposti: 'marja@test.com',
+    puhelinnumero: '0000000000',
+  };
+  const testApplication = applications[0];
+  const { user } = render(<JohtoselvitysContainer application={testApplication} />);
+  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+  expect(screen.queryByText('Vaihe 3/5: Yhteystiedot')).toBeInTheDocument();
+  await user.click(screen.getAllByRole('button', { name: /lisää uusi yhteyshenkilö/i })[0]);
+  fillNewContactPersonForm(newUser);
+  await user.click(screen.getByRole('button', { name: /tallenna ja lisää yhteyshenkilö/i }));
+
+  expect(screen.getByText('Yhteyshenkilö tallennettu')).toBeInTheDocument();
 });


### PR DESCRIPTION
# Description

User can create new user for hanke in johtoselvitys form by clicking Add new contact button and filling the form that is opened.

User that is created is not yet added as a contact person for the contact that it's created, that will be done later.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2230

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new johtoselvitys
2. Fill first two pages so that you get to contacts page
3. Click "Lisää uusi yhteyshenkilö" button for example for applicant and fill the information for new user and click "Tallenna ja lisää yhteyshenkilö" button
4. Success notification should be shown
5. Navigate to user management page of the hanke and check that the new person is there

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
