### PR TITLE
HAI-2347 Send geometry id of hanke area when saving hanke form

### DIFF
--- a/src/common/hooks/useFieldArrayWithStateUpdate.ts
+++ b/src/common/hooks/useFieldArrayWithStateUpdate.ts
@@ -1,14 +1,23 @@
 import { useEffect } from 'react';
-import { useFieldArray, UseFieldArrayProps, useFormContext } from 'react-hook-form';
+import {
+  FieldValues,
+  FieldArrayPath,
+  UseFieldArrayProps,
+  useFieldArray,
+  useFormContext,
+} from 'react-hook-form';
 
 /**
  * Wrapper for React Hook Form useFieldArray that calls
  * setValue for each field in fieldArray when the fields
  * change, so that the fields are updated correctly
  */
-export default function useFieldArrayWithStateUpdate(props: UseFieldArrayProps) {
+export default function useFieldArrayWithStateUpdate<
+  TFieldValues extends FieldValues,
+  TFieldArrayName extends FieldArrayPath<TFieldValues>,
+>(props: UseFieldArrayProps<TFieldValues, TFieldArrayName>) {
   const { setValue, getValues } = useFormContext();
-  const fieldArrayReturn = useFieldArray(props);
+  const fieldArrayReturn = useFieldArray<TFieldValues, TFieldArrayName>(props);
 
   useEffect(() => {
     fieldArrayReturn.fields.forEach((_, index) => {

--- a/src/common/hooks/useSelectableTabs.ts
+++ b/src/common/hooks/useSelectableTabs.ts
@@ -11,10 +11,12 @@ type Options = {
  * to set active index to select a tab.
  */
 export default function useSelectableTabs(
-  numberOfTabs: number,
+  collection: unknown[],
   options: Options = { selectLastTabOnChange: false },
 ) {
+  const numberOfTabs = collection.length;
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const [stateUpdate, setStateUpdate] = useState(0);
 
   const tabRefs = useMemo(() => {
     return new Array(numberOfTabs).fill(0).map(() => React.createRef<HTMLDivElement>());
@@ -24,7 +26,13 @@ export default function useSelectableTabs(
     if (tabRefs.length > 0) {
       tabRefs[selectedTabIndex]?.current?.click();
     }
-  }, [tabRefs, selectedTabIndex]);
+  }, [tabRefs, selectedTabIndex, stateUpdate]);
+
+  useEffect(() => {
+    if (options.selectLastTabOnChange) {
+      setStateUpdate((current) => current + 1);
+    }
+  }, [collection, options.selectLastTabOnChange]);
 
   // When number of tabs changes,
   // select the last one

--- a/src/domain/forms/components/Contact.tsx
+++ b/src/domain/forms/components/Contact.tsx
@@ -56,7 +56,7 @@ const Contact = <T,>({
   }, [subContactFields, subContactTemplate, addSubContact]);
 
   const renderSubContacts = subContactFields.length > 0 && renderSubContact;
-  const { tabRefs } = useSelectableTabs(subContactFields.length, { selectLastTabOnChange: true });
+  const { tabRefs } = useSelectableTabs(subContactFields, { selectLastTabOnChange: true });
 
   return (
     <>

--- a/src/domain/hanke/edit/HankeForm.tsx
+++ b/src/domain/hanke/edit/HankeForm.tsx
@@ -23,6 +23,7 @@ import ApplicationAddDialog from '../../application/components/ApplicationAddDia
 import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
 import { changeFormStep } from '../../forms/utils';
 import { updateHanke } from './hankeApi';
+import { convertHankeAlueToFormState } from './utils';
 
 type Props = {
   formData: HankeDataFormState;
@@ -61,6 +62,7 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
     setValue,
     trigger,
     watch,
+    reset,
   } = formContext;
 
   const formValues = getValues();
@@ -80,6 +82,8 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
       setValue('status', data.status);
       setValue('alkuPvm', data.alkuPvm);
       setValue('loppuPvm', data.loppuPvm);
+      setValue('alueet', data.alueet?.map(convertHankeAlueToFormState));
+      reset(undefined, { keepDirtyValues: true });
       setShowNotification('success');
     },
   });
@@ -132,6 +136,12 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
     setAttachmentsUploading(uploading);
   }
 
+  function handleStepChange() {
+    if (isDirty) {
+      save();
+    }
+  }
+
   const formSteps = [
     {
       element: <HankeFormPerustiedot errors={errors} register={register} formData={formValues} />,
@@ -177,7 +187,7 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
         <MultipageForm
           heading={formHeading}
           formSteps={formSteps}
-          onStepChange={save}
+          onStepChange={handleStepChange}
           isLoading={attachmentsUploading}
           isLoadingText={attachmentsUploadingText}
         >

--- a/src/domain/hanke/edit/HankeForm.tsx
+++ b/src/domain/hanke/edit/HankeForm.tsx
@@ -62,7 +62,6 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
     setValue,
     trigger,
     watch,
-    reset,
   } = formContext;
 
   const formValues = getValues();
@@ -83,7 +82,6 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
       setValue('alkuPvm', data.alkuPvm);
       setValue('loppuPvm', data.loppuPvm);
       setValue('alueet', data.alueet?.map(convertHankeAlueToFormState));
-      reset(undefined, { keepDirtyValues: true });
       setShowNotification('success');
     },
   });

--- a/src/domain/hanke/edit/HankeFormAlueet.tsx
+++ b/src/domain/hanke/edit/HankeFormAlueet.tsx
@@ -8,7 +8,7 @@ import Geometry from 'ol/geom/Geometry';
 import { Box } from '@chakra-ui/react';
 import HankeDrawer from '../../map/components/HankeDrawer/HankeDrawer';
 import { useFormPage } from './hooks/useFormPage';
-import { FORMFIELD, FormProps, HankeAlueFormState } from './types';
+import { FORMFIELD, FormProps, HankeAlueFormState, HankeDataFormState } from './types';
 import { formatSurfaceArea } from '../../map/utils';
 import Haitat from './components/Haitat';
 import Text from '../../../common/components/text/Text';
@@ -19,7 +19,7 @@ import useFieldArrayWithStateUpdate from '../../../common/hooks/useFieldArrayWit
 import { HankeAlue } from '../../types/hanke';
 import { getAreaDefaultName } from './utils';
 
-function getEmptyArea(feature: Feature): Omit<HankeAlueFormState, 'id' | 'geometriat'> {
+function getEmptyArea(feature: Feature): Omit<HankeAlueFormState, 'geometriat'> {
   return {
     feature,
     haittaAlkuPvm: null,
@@ -29,24 +29,27 @@ function getEmptyArea(feature: Feature): Omit<HankeAlueFormState, 'id' | 'geomet
     tarinaHaitta: null,
     kaistaHaitta: null,
     kaistaPituusHaitta: null,
+    id: null,
   };
 }
 
 const HankeFormAlueet: React.FC<FormProps> = ({ formData }) => {
   const { t } = useTranslation();
-  const { setValue, trigger, watch, getValues } = useFormContext();
+  const { setValue, trigger, watch, getValues } = useFormContext<HankeDataFormState>();
   const {
     fields: hankeAlueet,
     append,
     remove,
-  } = useFieldArrayWithStateUpdate({
+  } = useFieldArrayWithStateUpdate<HankeDataFormState, 'alueet'>({
     name: FORMFIELD.HANKEALUEET,
   });
   const [drawSource] = useState<VectorSource>(new VectorSource());
   const addressCoordinate = useAddressCoordinate(formData.tyomaaKatuosoite);
   useFormPage();
 
-  const { tabRefs } = useSelectableTabs(hankeAlueet.length, { selectLastTabOnChange: true });
+  const { tabRefs } = useSelectableTabs(hankeAlueet, {
+    selectLastTabOnChange: true,
+  });
 
   const higlightArea = useHighlightArea();
 
@@ -79,7 +82,8 @@ const HankeFormAlueet: React.FC<FormProps> = ({ formData }) => {
     // geometriesChanged field in order to update
     // surface area calculation for the changed area
     trigger(FORMFIELD.GEOMETRIES_CHANGED);
-  }, [trigger]);
+    setValue(FORMFIELD.GEOMETRIES_CHANGED, true, { shouldDirty: true });
+  }, [trigger, setValue]);
 
   function removeArea(index: number) {
     remove(index);
@@ -89,7 +93,7 @@ const HankeFormAlueet: React.FC<FormProps> = ({ formData }) => {
     }
   }
 
-  const features = useMemo(() => formData.alueet?.map((alue) => alue.feature), [formData.alueet]);
+  const features = useMemo(() => hankeAlueet.map((alue) => alue.feature), [hankeAlueet]);
 
   return (
     <div>
@@ -118,13 +122,12 @@ const HankeFormAlueet: React.FC<FormProps> = ({ formData }) => {
       ) : (
         <Tabs>
           <TabList>
-            {hankeAlueet.map((item, index) => {
-              const hankeAlue = formData.alueet && formData.alueet[index];
-              const hankeGeometry = hankeAlue?.feature?.getGeometry();
+            {hankeAlueet.map((alue, index) => {
+              const hankeGeometry = alue.feature?.getGeometry();
               const surfaceArea = hankeGeometry && `(${formatSurfaceArea(hankeGeometry)})`;
               const name = watch(`${FORMFIELD.HANKEALUEET}.${index}.nimi`);
               return (
-                <Tab key={item.id} onClick={() => higlightArea(hankeAlue?.feature)}>
+                <Tab key={alue.id} onClick={() => higlightArea(alue.feature)}>
                   <div ref={tabRefs[index]}>
                     {name} {surfaceArea}
                   </div>

--- a/src/domain/johtoselvitys/Geometries.tsx
+++ b/src/domain/johtoselvitys/Geometries.tsx
@@ -123,7 +123,7 @@ export const Geometries: React.FC<React.PropsWithChildren<unknown>> = () => {
     };
   }, [drawSource, append, forceUpdate, setValue, featuresLoaded]);
 
-  const { tabRefs } = useSelectableTabs(applicationAreas.length, { selectLastTabOnChange: true });
+  const { tabRefs } = useSelectableTabs(applicationAreas, { selectLastTabOnChange: true });
 
   const higlightArea = useHighlightArea();
 

--- a/src/domain/johtoselvitys_new/Geometries.tsx
+++ b/src/domain/johtoselvitys_new/Geometries.tsx
@@ -123,7 +123,7 @@ export const Geometries: React.FC<React.PropsWithChildren<unknown>> = () => {
     };
   }, [drawSource, append, forceUpdate, setValue, featuresLoaded]);
 
-  const { tabRefs } = useSelectableTabs(applicationAreas.length, { selectLastTabOnChange: true });
+  const { tabRefs } = useSelectableTabs(applicationAreas, { selectLastTabOnChange: true });
 
   const higlightArea = useHighlightArea();
 

--- a/src/domain/map/components/HankeDrawer/HankeDrawer.tsx
+++ b/src/domain/map/components/HankeDrawer/HankeDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Vector as VectorSource } from 'ol/source';
 import { VectorSourceEvent } from 'ol/source/Vector';
 import { Feature } from 'ol';
@@ -47,11 +47,10 @@ const HankeDrawer: React.FC<React.PropsWithChildren<Props>> = ({
   const ortoLayerOpacity = mapTileLayers.kantakartta.visible ? 0.5 : 1;
   const [drawSource] = useState<VectorSource>(existingDrawSource || new VectorSource());
 
-  const featuresLoaded = useRef(false);
-
-  // Draw existing features once if any
+  // Draw existing features
   useEffect(() => {
-    if (features && features.length > 0 && !featuresLoaded.current) {
+    if (features && features.length > 0) {
+      drawSource.clear();
       features.forEach((feature) => {
         if (feature) {
           drawSource.addFeature(feature);
@@ -59,7 +58,6 @@ const HankeDrawer: React.FC<React.PropsWithChildren<Props>> = ({
       });
       drawSource.dispatchEvent('featuresAdded');
     }
-    featuresLoaded.current = true;
   }, [features, drawSource]);
 
   useEffect(() => {
@@ -115,7 +113,7 @@ const HankeDrawer: React.FC<React.PropsWithChildren<Props>> = ({
           {mapTileLayers.ortokartta.visible && <Ortokartta opacity={ortoLayerOpacity} />}
           <VectorLayer source={drawSource} zIndex={100} className="drawLayer" />
 
-          {featuresLoaded.current && <FitSource source={drawSource} />}
+          <FitSource source={drawSource} />
 
           <Controls>
             <DrawModule source={drawSource} />


### PR DESCRIPTION
# Description

Previously geometry ids of hanke areas were not send to backend, which lead to backend creating the geometries again each time.

Now ids are sent along with other data. Also when creating new areas and saving form, hanke area data from response is set to form state.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2347

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
