### PR TITLE
HAI-2341 Show hanke areas in johtoselvitys form

### DIFF
--- a/src/common/components/map/layers/VectorLayer.tsx
+++ b/src/common/components/map/layers/VectorLayer.tsx
@@ -3,6 +3,7 @@ import { Vector as VectorSource } from 'ol/source';
 import { StyleLike } from 'ol/style/Style';
 import OLVectorLayer from 'ol/layer/Vector';
 import MapContext from '../MapContext';
+import { STYLES } from '../../../../domain/map/utils/geometryStyle';
 
 type Props = {
   source: VectorSource;
@@ -11,12 +12,7 @@ type Props = {
   style?: StyleLike;
 };
 
-const VectorLayer: React.FC<React.PropsWithChildren<Props>> = ({
-  source,
-  className,
-  zIndex = 0,
-  style = undefined,
-}) => {
+function VectorLayer({ source, className, zIndex = 0, style = STYLES.BLUE }: Readonly<Props>) {
   const { map, layers } = useContext(MapContext);
 
   useEffect(() => {
@@ -42,6 +38,6 @@ const VectorLayer: React.FC<React.PropsWithChildren<Props>> = ({
   }, [map, className, style, layers, source, zIndex]);
 
   return null;
-};
+}
 
 export default VectorLayer;

--- a/src/common/components/map/modules/draw/DrawInteraction.tsx
+++ b/src/common/components/map/modules/draw/DrawInteraction.tsx
@@ -11,6 +11,7 @@ import { DRAWTOOLTYPE } from './types';
 import MapContext from '../../MapContext';
 import useDrawContext from './useDrawContext';
 import { getSurfaceArea, isPolygonSelfIntersecting } from '../../utils';
+import { styleFunction } from '../../../../../domain/map/utils/geometryStyle';
 
 type Props = {
   features?: Collection<Feature>;
@@ -80,12 +81,15 @@ const DrawInteraction: React.FC<React.PropsWithChildren<Props>> = ({
       });
 
       drawInstance.on('drawstart', (event) => {
+        selection.current?.setActive(false);
         event.feature.on('change', (changeEvent) => {
           drawnFeature.current = changeEvent.target;
         });
       });
 
       drawInstance.on('drawend', (event) => {
+        selection.current?.setActive(true);
+
         const isSelfIntersecting = isPolygonSelfIntersecting(
           event.feature.getGeometry() as Polygon,
         );
@@ -145,10 +149,11 @@ const DrawInteraction: React.FC<React.PropsWithChildren<Props>> = ({
 
     selection.current.on('select', (e) => {
       const features = e.target.getFeatures();
-      const feature = features.getArray()[0];
+      const feature: Feature<Geometry> = features.getArray()[0];
 
       if (feature) {
         actions.setSelectedFeature(feature);
+        feature.setStyle(styleFunction(feature, undefined, true));
       } else {
         clearSelection();
       }

--- a/src/domain/common/utils/liikennehaittaindeksi.test.ts
+++ b/src/domain/common/utils/liikennehaittaindeksi.test.ts
@@ -1,6 +1,6 @@
 import { getStatusByIndex, getColorByStatus, LIIKENNEHAITTA_STATUS } from './liikennehaittaindeksi';
 
-const INDEX_BLUE = `rgba(36, 114, 198, 1)`;
+const INDEX_BLUE = `rgba(0, 98, 185, 1)`;
 const INDEX_GREEN = `rgba(0, 146, 70, 1)`;
 const INDEX_YELLOW = `rgba(255, 218, 7, 1)`;
 const INDEX_RED = 'rgba(196, 18, 62, 1)';

--- a/src/domain/common/utils/liikennehaittaindeksi.ts
+++ b/src/domain/common/utils/liikennehaittaindeksi.ts
@@ -9,7 +9,7 @@ const getColorWithOpacity = (color: LIIKENNEHAITTA_STATUS | null, opacity = 1) =
     case 'GREEN':
       return `rgba(0, 146, 70, ${opacity})`;
     default:
-      return `rgba(36, 114, 198, ${opacity})`;
+      return `rgba(0, 98, 185, ${opacity})`;
   }
 };
 

--- a/src/domain/johtoselvitys_new/Geometries.tsx
+++ b/src/domain/johtoselvitys_new/Geometries.tsx
@@ -218,8 +218,8 @@ export function Geometries({ hankeData }: Readonly<Props>) {
 
           <HankeLayer
             hankeData={hankeData && [hankeData]}
-            startDate={startTime?.toString() || hankeData?.alkuPvm}
-            endDate={endTime?.toString() || hankeData?.loppuPvm}
+            startDate={startTime?.toString() ?? hankeData?.alkuPvm}
+            endDate={endTime?.toString() ?? hankeData?.loppuPvm}
           />
           <VectorLayer source={drawSource} zIndex={101} className="drawLayer" />
 

--- a/src/domain/johtoselvitys_new/Geometries.tsx
+++ b/src/domain/johtoselvitys_new/Geometries.tsx
@@ -225,7 +225,7 @@ export function Geometries({ hankeData }: Readonly<Props>) {
               endDate={endTime?.toString()}
             />
           )}
-          <VectorLayer source={drawSource} zIndex={100} className="drawLayer" />
+          <VectorLayer source={drawSource} zIndex={101} className="drawLayer" />
 
           <FitSource source={drawSource} />
 

--- a/src/domain/johtoselvitys_new/Geometries.tsx
+++ b/src/domain/johtoselvitys_new/Geometries.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Feature } from 'ol';
 import VectorSource, { VectorSourceEvent } from 'ol/source/Vector';
 import Polygon from 'ol/geom/Polygon';
@@ -37,6 +37,8 @@ import LayerControl from '../../common/components/map/controls/LayerControl';
 import { MapTileLayerId } from '../map/types';
 import { useMapDataLayers } from '../map/hooks/useMapLayers';
 import Ortokartta from '../map/components/Layers/Ortokartta';
+import { HankeData } from '../types/hanke';
+import HankeLayer from '../map/components/Layers/HankeLayer';
 
 interface AreaToRemove {
   index: number;
@@ -60,7 +62,11 @@ function getEmptyArea(feature: Feature<Geometry>): JohtoselvitysArea {
   };
 }
 
-export const Geometries: React.FC<React.PropsWithChildren<unknown>> = () => {
+type Props = {
+  hankeData?: HankeData;
+};
+
+export function Geometries({ hankeData }: Readonly<Props>) {
   const { t } = useTranslation();
   const locale = useLocale();
   const {
@@ -137,6 +143,8 @@ export const Geometries: React.FC<React.PropsWithChildren<unknown>> = () => {
 
   const [showSelfIntersectingNotification, setShowSelfIntersectingNotification] = useState(false);
 
+  const showHankeLayer = workTimesSet;
+
   function removeArea(index: number, areaFeature?: Feature<Geometry>) {
     if (areaFeature !== undefined) {
       setAreaToRemove({ index, areaFeature });
@@ -210,6 +218,13 @@ export const Geometries: React.FC<React.PropsWithChildren<unknown>> = () => {
 
           <AddressSearchContainer position={{ top: '1rem', left: '1rem' }} zIndex={101} />
 
+          {showHankeLayer && (
+            <HankeLayer
+              hankeData={hankeData && [hankeData]}
+              startDate={startTime?.toString()}
+              endDate={endTime?.toString()}
+            />
+          )}
           <VectorLayer source={drawSource} zIndex={100} className="drawLayer" />
 
           <FitSource source={drawSource} />
@@ -315,5 +330,5 @@ export const Geometries: React.FC<React.PropsWithChildren<unknown>> = () => {
       />
     </div>
   );
-};
+}
 export default Geometries;

--- a/src/domain/johtoselvitys_new/Geometries.tsx
+++ b/src/domain/johtoselvitys_new/Geometries.tsx
@@ -143,8 +143,6 @@ export function Geometries({ hankeData }: Readonly<Props>) {
 
   const [showSelfIntersectingNotification, setShowSelfIntersectingNotification] = useState(false);
 
-  const showHankeLayer = workTimesSet;
-
   function removeArea(index: number, areaFeature?: Feature<Geometry>) {
     if (areaFeature !== undefined) {
       setAreaToRemove({ index, areaFeature });
@@ -218,13 +216,11 @@ export function Geometries({ hankeData }: Readonly<Props>) {
 
           <AddressSearchContainer position={{ top: '1rem', left: '1rem' }} zIndex={101} />
 
-          {showHankeLayer && (
-            <HankeLayer
-              hankeData={hankeData && [hankeData]}
-              startDate={startTime?.toString()}
-              endDate={endTime?.toString()}
-            />
-          )}
+          <HankeLayer
+            hankeData={hankeData && [hankeData]}
+            startDate={startTime?.toString() || hankeData?.alkuPvm}
+            endDate={endTime?.toString() || hankeData?.loppuPvm}
+          />
           <VectorLayer source={drawSource} zIndex={101} className="drawLayer" />
 
           <FitSource source={drawSource} />

--- a/src/domain/johtoselvitys_new/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys_new/JohtoselvitysContainer.tsx
@@ -315,7 +315,7 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
         state: StepState.available,
       },
       {
-        element: <Geometries />,
+        element: <Geometries hankeData={hankeData} />,
         label: t('form:headers:alueet'),
         /*
          * Determine initial state for the form step.

--- a/src/domain/map/HankeMap.tsx
+++ b/src/domain/map/HankeMap.tsx
@@ -46,7 +46,7 @@ const HankeMap: React.FC<React.PropsWithChildren<unknown>> = () => {
           <FeatureClick />
           <GeometryHover>
             <HankeHoverBox />
-            <HankeLayer />
+            <HankeLayer startDate={hankeFilterStartDate} endDate={hankeFilterEndDate} />
           </GeometryHover>
         </HankkeetProvider>
 

--- a/src/domain/map/HankeMap.tsx
+++ b/src/domain/map/HankeMap.tsx
@@ -46,7 +46,12 @@ const HankeMap: React.FC<React.PropsWithChildren<unknown>> = () => {
           <FeatureClick />
           <GeometryHover>
             <HankeHoverBox />
-            <HankeLayer startDate={hankeFilterStartDate} endDate={hankeFilterEndDate} />
+            <HankeLayer
+              startDate={hankeFilterStartDate}
+              endDate={hankeFilterEndDate}
+              centerOnMap
+              highlightFeatures
+            />
           </GeometryHover>
         </HankkeetProvider>
 

--- a/src/domain/map/components/Layers/HankeLayer.tsx
+++ b/src/domain/map/components/Layers/HankeLayer.tsx
@@ -1,25 +1,34 @@
-import React, { useRef, useMemo, useContext } from 'react';
+import { useRef, useMemo, useContext } from 'react';
 import { Vector as VectorSource } from 'ol/source';
 import VectorLayer from '../../../../common/components/map/layers/VectorLayer';
 import { byAllHankeFilters } from '../../utils';
-import { useDateRangeFilter } from '../../hooks/useDateRangeFilter';
 import { styleFunction } from '../../utils/geometryStyle';
 import CenterProjectOnMap from '../interations/CenterProjectOnMap';
 import HankkeetContext from '../../HankkeetProviderContext';
 import HighlightFeatureOnMap from '../interations/HighlightFeatureOnMap';
 import useHankeFeatures from '../../hooks/useHankeFeatures';
+import { HankeData } from '../../../types/hanke';
 
-const HankeLayer = () => {
-  const { hankkeet } = useContext(HankkeetContext);
+type Props = {
+  hankeData?: HankeData[];
+  startDate?: string | null;
+  endDate?: string | null;
+};
+
+const currentYear = new Date().getFullYear();
+
+function HankeLayer({
+  hankeData,
+  startDate = `${currentYear}-01-01`,
+  endDate = `${currentYear + 1}-12-31`,
+}: Readonly<Props>) {
+  const { hankkeet: hankkeetFromContext } = useContext(HankkeetContext);
   const hankeSource = useRef(new VectorSource());
-  const { hankeFilterStartDate, hankeFilterEndDate } = useDateRangeFilter();
+  const hankkeet = hankeData || hankkeetFromContext;
 
   const hankkeetFilteredByAll = useMemo(
-    () =>
-      hankkeet.filter(
-        byAllHankeFilters({ startDate: hankeFilterStartDate, endDate: hankeFilterEndDate }),
-      ),
-    [hankkeet, hankeFilterStartDate, hankeFilterEndDate],
+    () => hankkeet.filter(byAllHankeFilters({ startDate, endDate })),
+    [hankkeet, startDate, endDate],
   );
 
   useHankeFeatures(hankeSource.current, hankkeetFilteredByAll);
@@ -40,6 +49,6 @@ const HankeLayer = () => {
       />
     </>
   );
-};
+}
 
 export default HankeLayer;

--- a/src/domain/map/components/Layers/HankeLayer.tsx
+++ b/src/domain/map/components/Layers/HankeLayer.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useRef, useMemo, useContext } from 'react';
 import { Vector as VectorSource } from 'ol/source';
+import { FeatureLike } from 'ol/Feature';
 import VectorLayer from '../../../../common/components/map/layers/VectorLayer';
 import { byAllHankeFilters } from '../../utils';
 import { styleFunction } from '../../utils/geometryStyle';
@@ -13,6 +15,8 @@ type Props = {
   hankeData?: HankeData[];
   startDate?: string | null;
   endDate?: string | null;
+  centerOnMap?: boolean;
+  highlightFeatures?: boolean;
 };
 
 const currentYear = new Date().getFullYear();
@@ -21,6 +25,8 @@ function HankeLayer({
   hankeData,
   startDate = `${currentYear}-01-01`,
   endDate = `${currentYear + 1}-12-31`,
+  centerOnMap = false,
+  highlightFeatures = false,
 }: Readonly<Props>) {
   const { hankkeet: hankkeetFromContext } = useContext(HankkeetContext);
   const hankeSource = useRef(new VectorSource());
@@ -38,8 +44,8 @@ function HankeLayer({
       <div style={{ display: 'none' }} data-testid="countOfFilteredHankkeet">
         {hankkeetFilteredByAll.length}
       </div>
-      <CenterProjectOnMap source={hankeSource.current} />
-      <HighlightFeatureOnMap source={hankeSource.current} />
+      {centerOnMap && <CenterProjectOnMap source={hankeSource.current} />}
+      {highlightFeatures && <HighlightFeatureOnMap source={hankeSource.current} />}
 
       <VectorLayer
         source={hankeSource.current}

--- a/src/domain/map/components/Layers/HankeLayer.tsx
+++ b/src/domain/map/components/Layers/HankeLayer.tsx
@@ -1,7 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useRef, useMemo, useContext } from 'react';
 import { Vector as VectorSource } from 'ol/source';
-import { FeatureLike } from 'ol/Feature';
 import VectorLayer from '../../../../common/components/map/layers/VectorLayer';
 import { byAllHankeFilters } from '../../utils';
 import { styleFunction } from '../../utils/geometryStyle';

--- a/src/domain/map/hooks/useHankeFeatures.ts
+++ b/src/domain/map/hooks/useHankeFeatures.ts
@@ -20,24 +20,22 @@ export default function useHankeFeatures(source: Vector, hankkeet: HankeData[]) 
             return [];
           }
 
-          const features = new GeoJSON().readFeatures(
+          const feature = new GeoJSON().readFeatures(
             alue.geometriat.featureCollection,
-          ) as Feature<Geometry>[];
+          )[0] as Feature<Geometry>;
 
-          features.forEach((feature) => {
-            feature.setProperties(
-              {
-                liikennehaittaindeksi: hanke.tormaystarkasteluTulos
-                  ? hanke.tormaystarkasteluTulos.liikennehaittaindeksi.indeksi
-                  : null,
-                areaName: alue.nimi,
-              },
-              true,
-            );
-          });
+          feature.setProperties(
+            {
+              liikennehaittaindeksi: hanke.tormaystarkasteluTulos
+                ? hanke.tormaystarkasteluTulos.liikennehaittaindeksi.indeksi
+                : null,
+              areaName: alue.nimi,
+            },
+            true,
+          );
 
-          return features;
-        }) as Feature<Geometry>[];
+          return feature;
+        });
 
         source.addFeatures(hankeFeatures);
       }

--- a/src/domain/map/hooks/useHankeFeatures.ts
+++ b/src/domain/map/hooks/useHankeFeatures.ts
@@ -19,19 +19,26 @@ export default function useHankeFeatures(source: Vector, hankkeet: HankeData[]) 
           if (!alue.geometriat) {
             return [];
           }
-          return new GeoJSON().readFeatures(alue.geometriat.featureCollection);
+
+          const features = new GeoJSON().readFeatures(
+            alue.geometriat.featureCollection,
+          ) as Feature<Geometry>[];
+
+          features.forEach((feature) => {
+            feature.setProperties(
+              {
+                liikennehaittaindeksi: hanke.tormaystarkasteluTulos
+                  ? hanke.tormaystarkasteluTulos.liikennehaittaindeksi.indeksi
+                  : null,
+                areaName: alue.nimi,
+              },
+              true,
+            );
+          });
+
+          return features;
         }) as Feature<Geometry>[];
 
-        hankeFeatures.forEach((feature) => {
-          feature.setProperties(
-            {
-              liikennehaittaindeksi: hanke.tormaystarkasteluTulos
-                ? hanke.tormaystarkasteluTulos.liikennehaittaindeksi.indeksi
-                : null,
-            },
-            true,
-          );
-        });
         source.addFeatures(hankeFeatures);
       }
     });

--- a/src/domain/map/utils/geometryStyle.ts
+++ b/src/domain/map/utils/geometryStyle.ts
@@ -7,7 +7,7 @@ import {
   LIIKENNEHAITTA_STATUS,
 } from '../../common/utils/liikennehaittaindeksi';
 
-const opacity = 0.45;
+const opacity = 0.65;
 const opacityHL = 0.75;
 
 const stroke = new Stroke({ color: 'black', width: 1 });

--- a/src/domain/mocks/data/hankkeet-data.ts
+++ b/src/domain/mocks/data/hankkeet-data.ts
@@ -139,6 +139,7 @@ const hankkeet: HankeDataDraft[] = [
         meluHaitta: HANKE_MELUHAITTA.PITKAKESTOINEN_TOISTUVA_HAITTA,
         polyHaitta: HANKE_POLYHAITTA.PITKAKESTOINEN_TOISTUVA_HAITTA,
         tarinaHaitta: HANKE_TARINAHAITTA.SATUNNAINEN_HAITTA,
+        nimi: 'Hankealue 1',
         geometriat: {
           id: 37,
           version: 0,
@@ -193,6 +194,7 @@ const hankkeet: HankeDataDraft[] = [
         tarinaHaitta: HANKE_TARINAHAITTA.SATUNNAINEN_HAITTA,
         kaistaHaitta: HANKE_KAISTAHAITTA.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
         kaistaPituusHaitta: HANKE_KAISTAPITUUSHAITTA.PITUUS_10_99_METRIA,
+        nimi: 'Hankealue 2',
         geometriat: {
           featureCollection: {
             type: 'FeatureCollection',


### PR DESCRIPTION
# Description

Show hanke areas in johtoselvitys form areas page if they exist. By default they are shown. Functionality to control what layers are displayed will be implemented later.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2341

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new johtoselvitys for hanke which has hanke areas
2. Fill first page of johtoselvitys form and go to second page
3. Check that hanke areas are displayed on map

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
