### PR TITLE
HAI-2274 Create separate johtoselvitys from modal dialog

### DIFF
--- a/src/common/components/header/Header.tsx
+++ b/src/common/components/header/Header.tsx
@@ -16,6 +16,7 @@ import { Language, LANGUAGES } from '../../types/language';
 import { SKIP_TO_ELEMENT_ID } from '../../constants/constants';
 import { useFeatureFlags } from '../featureFlags/FeatureFlagsContext';
 import HankeCreateDialog from '../../../domain/hanke/hankeCreateDialog/HankeCreateDialog';
+import JohtoselvitysCreateDialog from '../../../domain/johtoselvitys_new/johtoselvitysCreateDialog/JohtoselvitysCreateDialog';
 
 const languageLabels = {
   fi: 'Suomi',
@@ -32,6 +33,7 @@ function HaitatonHeader() {
   const features = useFeatureFlags();
   const logoSrc = i18n.language === 'sv' ? logoSv : logoFi;
   const [showHankeCreateDialog, setShowHankeCreateDialog] = useState(false);
+  const [showJohtoselvitysCreateDialog, setShowJohtoselvitysCreateDialog] = useState(false);
 
   const isMapPath = useMatch({
     path: PUBLIC_HANKKEET.path,
@@ -94,6 +96,14 @@ function HaitatonHeader() {
 
   function closeHankeCreateDialog() {
     setShowHankeCreateDialog(false);
+  }
+
+  function openJohtoselvitysCreateDialog() {
+    setShowJohtoselvitysCreateDialog(true);
+  }
+
+  function closeJohtoselvitysCreateDialog() {
+    setShowJohtoselvitysCreateDialog(false);
   }
 
   return (
@@ -162,7 +172,8 @@ function HaitatonHeader() {
           <Header.Link
             label={t('homepage:johtotietoselvitys:title')}
             as={NavLink}
-            to={JOHTOSELVITYSHAKEMUS.path}
+            to="#"
+            onClick={openJohtoselvitysCreateDialog}
             active={Boolean(isCableReportApplicationPath)}
             data-testid="cableReportApplicationLink"
           />
@@ -186,6 +197,10 @@ function HaitatonHeader() {
         </Header.NavigationMenu>
       )}
       <HankeCreateDialog isOpen={showHankeCreateDialog} onClose={closeHankeCreateDialog} />
+      <JohtoselvitysCreateDialog
+        isOpen={showJohtoselvitysCreateDialog}
+        onClose={closeJohtoselvitysCreateDialog}
+      />
     </Header>
   );
 }

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -2,6 +2,8 @@ import { AttachmentMetadata } from '../../../common/types/attachment';
 import { Polygon, Position } from 'geojson';
 import { Coordinate } from 'ol/coordinate';
 import { CRS } from '../../../common/types/hanke';
+import yup from '../../../common/utils/yup';
+import { newJohtoselvitysSchema } from '../../johtoselvitys_new/validationSchema';
 
 export type ApplicationType = 'CABLE_REPORT';
 
@@ -124,6 +126,8 @@ export type JohtoselvitysData = {
   propertyConnectivity: boolean;
   rockExcavation: boolean | null;
 };
+
+export type NewJohtoselvitysData = yup.InferType<typeof newJohtoselvitysSchema>;
 
 export interface Application {
   id: number | null;

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -5,7 +5,16 @@ import {
   AlluStatusStrings,
   Application,
   ApplicationDeletionResult,
+  NewJohtoselvitysData,
 } from './types/application';
+
+/**
+ * Create new johtoselvitys without hanke being created first
+ */
+export async function createJohtoselvitys(data: NewJohtoselvitysData) {
+  const response = await api.post<Application>('johtoselvityshakemus', data);
+  return response.data;
+}
 
 /**
  * Save application to Haitaton backend

--- a/src/domain/forms/components/OwnInformationFields.tsx
+++ b/src/domain/forms/components/OwnInformationFields.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next';
+import { Box } from '@chakra-ui/react';
+import { TextInput as HDSTextInput } from 'hds-react';
+import TextInput from '../../../common/components/textInput/TextInput';
+import useUser from '../../auth/useUser';
+
+function OwnInformationFields() {
+  const { t } = useTranslation();
+  const user = useUser();
+
+  return (
+    <>
+      <Box marginBottom="var(--spacing-s)">
+        <h3 className="heading-s">{t('form:labels:omatTiedot')}</h3>
+      </Box>
+      <Box marginBottom="var(--spacing-m)">
+        <HDSTextInput
+          id="user-name"
+          label={t('form:yhteystiedot:labels:nimi')}
+          value={`${user.data?.profile?.name}`}
+          helperText={t('form:labels:fromHelsinkiProfile')}
+          readOnly
+        />
+      </Box>
+      <Box marginBottom="var(--spacing-s)" maxWidth={328}>
+        <TextInput
+          name="perustaja.sahkoposti"
+          label={t('hankeForm:labels:email')}
+          required
+          defaultValue={user.data?.profile.email}
+        />
+      </Box>
+      <Box maxWidth={328}>
+        <TextInput
+          name="perustaja.puhelinnumero"
+          label={t('hankeForm:labels:puhelinnumero')}
+          required
+        />
+      </Box>
+    </>
+  );
+}
+
+export default OwnInformationFields;

--- a/src/domain/hanke/edit/HankeFormPerustiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormPerustiedot.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 import { Tooltip, TextArea, SelectionGroup, RadioButton } from 'hds-react';
 import { $enum } from 'ts-enum-util';
@@ -11,8 +11,8 @@ import { useFormPage } from './hooks/useFormPage';
 import DropdownMultiselect from '../../../common/components/dropdown/DropdownMultiselect';
 import Checkbox from '../../../common/components/checkbox/Checkbox';
 import { getInputErrorText } from '../../../common/utils/form';
-import { useLocalizedRoutes } from '../../../common/hooks/useLocalizedRoutes';
 import Link from '../../../common/components/Link/Link';
+import JohtoselvitysCreateDialog from '../../johtoselvitys_new/johtoselvitysCreateDialog/JohtoselvitysCreateDialog';
 
 const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
   errors,
@@ -21,7 +21,7 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
 }) => {
   const { t } = useTranslation();
   const { setValue, watch } = useFormContext();
-  const { JOHTOSELVITYSHAKEMUS } = useLocalizedRoutes();
+  const [showJohtoselvitysCreateDialog, setShowJohtoselvitysCreateDialog] = useState(false);
   useFormPage();
 
   // Subscribe to vaihe changes in order to update the selected radio button
@@ -33,6 +33,14 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
     setValue(FORMFIELD.VAIHE, newValue);
   };
 
+  function openJohtoselvitysCreateDialog() {
+    setShowJohtoselvitysCreateDialog(true);
+  }
+
+  function closeJohtoselvitysCreateDialog() {
+    setShowJohtoselvitysCreateDialog(false);
+  }
+
   return (
     <div className="form0">
       <div className="formInstructions">
@@ -40,8 +48,11 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
           <p>Hankkeen luonnin kautta pääset lähettämään myös hakemuksia.</p>
           <p>
             <strong>HUOM!</strong> Mikäli teet pelkkää johtoselvitystä yksityiselle alueelle,
-            <Link href={JOHTOSELVITYSHAKEMUS.path}>täytä hakemus</Link>. Yleisten alueiden
-            johtoselvitykset haetaan hankkeen luonnin jälkeen kaivuilmoituksen kautta.
+            <Link href="#" onClick={openJohtoselvitysCreateDialog}>
+              täytä hakemus
+            </Link>
+            . Yleisten alueiden johtoselvitykset haetaan hankkeen luonnin jälkeen kaivuilmoituksen
+            kautta.
           </p>
           <p>Lisäämällä hankkeen tiedot, pystyt kopioimaan ne lopuksi tarvitsemiisi hakemuksiin.</p>
         </Trans>
@@ -138,6 +149,11 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
           label={t(`hankeForm:labels:${FORMFIELD.YKT_HANKE}`)}
         />
       </div>
+
+      <JohtoselvitysCreateDialog
+        isOpen={showJohtoselvitysCreateDialog}
+        onClose={closeJohtoselvitysCreateDialog}
+      />
     </div>
   );
 };

--- a/src/domain/hanke/hankeCreateDialog/HankeCreateDialog.tsx
+++ b/src/domain/hanke/hankeCreateDialog/HankeCreateDialog.tsx
@@ -1,13 +1,5 @@
 import { Box } from '@chakra-ui/react';
-import {
-  Button,
-  Dialog,
-  TextInput as HDSTextInput,
-  IconCheck,
-  IconCross,
-  IconInfoCircle,
-  Notification,
-} from 'hds-react';
+import { Button, Dialog, IconCheck, IconCross, IconInfoCircle, Notification } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -15,11 +7,11 @@ import { useMutation } from 'react-query';
 import { yupResolver } from '@hookform/resolvers/yup';
 import TextInput from '../../../common/components/textInput/TextInput';
 import { newHankeSchema } from '../edit/hankeSchema';
-import useUser from '../../auth/useUser';
 import useLinkPath from '../../../common/hooks/useLinkPath';
 import { ROUTES } from '../../../common/types/route';
 import { createHanke } from '../edit/hankeApi';
 import { NewHankeData } from '../edit/types';
+import OwnInformationFields from '../../forms/components/OwnInformationFields';
 
 type Props = {
   isOpen: boolean;
@@ -28,7 +20,6 @@ type Props = {
 
 function HankeCreateDialog({ isOpen, onClose }: Readonly<Props>) {
   const { t } = useTranslation();
-  const user = useUser();
   const navigate = useNavigate();
   const getEditHankePath = useLinkPath(ROUTES.EDIT_HANKE);
   const formContext = useForm<NewHankeData>({
@@ -81,33 +72,7 @@ function HankeCreateDialog({ isOpen, onClose }: Readonly<Props>) {
             <Box marginBottom="var(--spacing-m)">
               <TextInput name="nimi" maxLength={100} required />
             </Box>
-            <Box marginBottom="var(--spacing-s)">
-              <h3 className="heading-s">{t('form:labels:omatTiedot')}</h3>
-            </Box>
-            <Box marginBottom="var(--spacing-m)">
-              <HDSTextInput
-                id="user-name"
-                label={t('form:yhteystiedot:labels:nimi')}
-                value={`${user.data?.profile?.name}`}
-                helperText={t('form:labels:fromHelsinkiProfile')}
-                readOnly
-              />
-            </Box>
-            <Box marginBottom="var(--spacing-s)" maxWidth={328}>
-              <TextInput
-                name="perustaja.sahkoposti"
-                label={t('hankeForm:labels:email')}
-                required
-                defaultValue={user.data?.profile.email}
-              />
-            </Box>
-            <Box maxWidth={328}>
-              <TextInput
-                name="perustaja.puhelinnumero"
-                label={t('hankeForm:labels:puhelinnumero')}
-                required
-              />
-            </Box>
+            <OwnInformationFields />
 
             {isError && (
               <Box marginTop="var(--spacing-m)">

--- a/src/domain/homepage/Homepage.test.tsx
+++ b/src/domain/homepage/Homepage.test.tsx
@@ -83,3 +83,65 @@ describe('Create new hanke from dialog', () => {
     expect(screen.getByLabelText(/sähköposti/i)).toHaveValue(userEmail);
   });
 });
+
+describe('Create johtoselvitys from dialog', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  async function openJohtoselvitysCreateDialog() {
+    jest.spyOn(authService.userManager, 'getUser').mockResolvedValue(mockUser as User);
+    const { user } = render(<Homepage />);
+    await screen.findByRole('heading', {
+      name: 'Auta meitä tekemään Haitattomasta vielä parempi!',
+    });
+    await user.click(screen.getByText('Tee johtoselvityshakemus'));
+    return user;
+  }
+
+  function fillInformation() {
+    const email = 'test@mail.com';
+    const phone = '0401234567';
+    const hankeName = 'Johtoselvitys';
+    fireEvent.change(screen.getByLabelText(/sähköposti/i), { target: { value: email } });
+    fireEvent.change(screen.getByLabelText(/puhelin/i), { target: { value: phone } });
+    fireEvent.change(screen.getByLabelText(/työn nimi/i), { target: { value: hankeName } });
+  }
+
+  test('Should be able to create new johtoselvitys from dialog', async () => {
+    const user = await openJohtoselvitysCreateDialog();
+    fillInformation();
+    await user.click(screen.getByRole('button', { name: /luo hakemus/i }));
+
+    expect(window.location.pathname).toBe('/fi/johtoselvityshakemus/5/muokkaa');
+  });
+
+  test('Should show validation errors and not create johtoselvitys if information is missing', async () => {
+    const user = await openJohtoselvitysCreateDialog();
+    await user.clear(screen.getByLabelText(/sähköposti/i));
+    await user.click(screen.getByRole('button', { name: /luo hakemus/i }));
+
+    expect(screen.getAllByText(/kenttä on pakollinen/i)).toHaveLength(3);
+    expect(window.location.pathname).toBe('/');
+  });
+
+  test('Should show error notification if creating johtoselvitys fails', async () => {
+    server.use(
+      rest.post('/api/johtoselvityshakemus', async (req, res, ctx) => {
+        return res(ctx.status(500), ctx.json({ errorMessage: 'Failed for testing purposes' }));
+      }),
+    );
+    const user = await openJohtoselvitysCreateDialog();
+    fillInformation();
+    await user.click(screen.getByRole('button', { name: /luo hakemus/i }));
+
+    expect(screen.getByText('Tapahtui virhe. Yritä uudestaan.')).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/');
+  });
+
+  test('Email should be pre-filled', async () => {
+    await openJohtoselvitysCreateDialog();
+
+    expect(screen.getByLabelText(/sähköposti/i)).toHaveValue(userEmail);
+  });
+});

--- a/src/domain/homepage/HomepageComponent.tsx
+++ b/src/domain/homepage/HomepageComponent.tsx
@@ -22,14 +22,15 @@ import {
 } from '../../common/components/featureFlags/FeatureFlagsContext';
 import MainHeading from '../../common/components/mainHeading/MainHeading';
 import HankeCreateDialog from '../hanke/hankeCreateDialog/HankeCreateDialog';
+import JohtoselvitysCreateDialog from '../johtoselvitys_new/johtoselvitysCreateDialog/JohtoselvitysCreateDialog';
 
 const Homepage: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { PUBLIC_HANKKEET_MAP, PUBLIC_HANKKEET_LIST, HANKEPORTFOLIO, JOHTOSELVITYSHAKEMUS } =
-    useLocalizedRoutes();
+  const { PUBLIC_HANKKEET_MAP, PUBLIC_HANKKEET_LIST, HANKEPORTFOLIO } = useLocalizedRoutes();
   const [feedbackOpen, setFeedbackOpen] = useState(true);
   const [showHankeCreateDialog, setShowHankeCreateDialog] = useState(false);
+  const [showJohtoselvitysCreateDialog, setShowJohtoselvitysCreateDialog] = useState(false);
   const { data: user } = useUser();
   const isAuthenticated = Boolean(user?.profile);
   const features = useFeatureFlags();
@@ -51,7 +52,7 @@ const Homepage: React.FC<React.PropsWithChildren<unknown>> = () => {
     },
     {
       key: 'johtotietoselvitys',
-      actionLink: JOHTOSELVITYSHAKEMUS.path,
+      actionLink: undefined,
       imgProps: { src: img1, width: 384, height: 245 },
       external: false,
       featureFlags: [],
@@ -131,6 +132,24 @@ const Homepage: React.FC<React.PropsWithChildren<unknown>> = () => {
     setShowHankeCreateDialog(false);
   }
 
+  function openJohtoselvitysCreateDialog() {
+    setShowJohtoselvitysCreateDialog(true);
+  }
+
+  function closeJohtoselvitysCreateDialog() {
+    setShowJohtoselvitysCreateDialog(false);
+  }
+
+  function handleLinkBoxClick(key: string) {
+    if (key === 'hanke') {
+      return openHankeCreateDialog;
+    }
+    if (key === 'johtotietoselvitys') {
+      return openJohtoselvitysCreateDialog;
+    }
+    return undefined;
+  }
+
   return (
     <div className={clsx({ [styles.bgWhite]: !isAuthenticated && !features.publicHankkeet })}>
       <div className={styles.heroContainer}>
@@ -206,7 +225,7 @@ const Homepage: React.FC<React.PropsWithChildren<unknown>> = () => {
                       imgProps={item.imgProps}
                       external={item.external}
                       openInNewTab={item.external}
-                      onClick={item.key === 'hanke' ? openHankeCreateDialog : undefined}
+                      onClick={handleLinkBoxClick(item.key)}
                     />
                   </div>
                 </FeatureFlags>
@@ -218,6 +237,10 @@ const Homepage: React.FC<React.PropsWithChildren<unknown>> = () => {
         </article>
 
         <HankeCreateDialog isOpen={showHankeCreateDialog} onClose={closeHankeCreateDialog} />
+        <JohtoselvitysCreateDialog
+          isOpen={showJohtoselvitysCreateDialog}
+          onClose={closeJohtoselvitysCreateDialog}
+        />
       </Container>
     </div>
   );

--- a/src/domain/johtoselvitys_new/johtoselvitysCreateDialog/JohtoselvitysCreateDialog.tsx
+++ b/src/domain/johtoselvitys_new/johtoselvitysCreateDialog/JohtoselvitysCreateDialog.tsx
@@ -1,0 +1,131 @@
+import { Box } from '@chakra-ui/react';
+import {
+  Button,
+  Dialog,
+  TextInput as HDSTextInput,
+  IconCheck,
+  IconCross,
+  IconInfoCircle,
+  Notification,
+} from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useMutation } from 'react-query';
+import { yupResolver } from '@hookform/resolvers/yup';
+import TextInput from '../../../common/components/textInput/TextInput';
+import useUser from '../../auth/useUser';
+import useLinkPath from '../../../common/hooks/useLinkPath';
+import { ROUTES } from '../../../common/types/route';
+import { NewJohtoselvitysData } from '../../application/types/application';
+import { newJohtoselvitysSchema } from '../validationSchema';
+import { createJohtoselvitys } from '../../application/utils';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+function JohtoselvitysCreateDialog({ isOpen, onClose }: Readonly<Props>) {
+  const { t } = useTranslation();
+  const user = useUser();
+  const navigate = useNavigate();
+  const getEditJohtoselvitysPath = useLinkPath(ROUTES.EDIT_JOHTOSELVITYSHAKEMUS);
+  const formContext = useForm<NewJohtoselvitysData>({
+    mode: 'onTouched',
+    resolver: yupResolver(newJohtoselvitysSchema),
+  });
+  const { handleSubmit, reset: resetForm } = formContext;
+  const { mutate, reset: resetMutation, isLoading, isError } = useMutation(createJohtoselvitys);
+  const dialogTitle = t('johtoselvitysForm:createNewJohtoselvitys');
+
+  function handleClose() {
+    resetForm();
+    resetMutation();
+    onClose();
+  }
+
+  async function submitForm(data: NewJohtoselvitysData) {
+    mutate(data, {
+      onSuccess({ id }) {
+        handleClose();
+        if (id) {
+          navigate(getEditJohtoselvitysPath({ id: id.toString() }));
+        }
+      },
+    });
+  }
+
+  return (
+    <Dialog
+      id="johtoselvitys-create"
+      isOpen={isOpen}
+      aria-labelledby={dialogTitle}
+      variant="primary"
+      close={handleClose}
+      closeButtonLabelText={t('common:ariaLabels:closeButtonLabelText')}
+    >
+      <Dialog.Header
+        id="johtoselvitys-create-title"
+        title={dialogTitle}
+        iconLeft={<IconInfoCircle />}
+      />
+      <FormProvider {...formContext}>
+        <form onSubmit={handleSubmit(submitForm)}>
+          <Dialog.Content>
+            <Box marginBottom="var(--spacing-s)">
+              <h3 className="heading-s">{t('form:labels:omatTiedot')}</h3>
+            </Box>
+            <Box marginBottom="var(--spacing-m)">
+              <HDSTextInput
+                id="user-name"
+                label={t('form:yhteystiedot:labels:nimi')}
+                value={`${user.data?.profile?.name}`}
+                helperText={t('form:labels:fromHelsinkiProfile')}
+                readOnly
+              />
+            </Box>
+            <Box marginBottom="var(--spacing-s)" maxWidth={328}>
+              <TextInput
+                name="perustaja.sahkoposti"
+                label={t('hankeForm:labels:email')}
+                required
+                defaultValue={user.data?.profile.email}
+              />
+            </Box>
+            <Box marginBottom="var(--spacing-m)" maxWidth={328}>
+              <TextInput
+                name="perustaja.puhelinnumero"
+                label={t('hankeForm:labels:puhelinnumero')}
+                required
+              />
+            </Box>
+            <Box marginBottom="var(--spacing-s)">
+              <h3 className="heading-s">{t('hakemus:labels:applicationInfo')}</h3>
+            </Box>
+            <Box marginBottom="var(--spacing-2-xs)">
+              <TextInput name="nimi" label={t('hakemus:labels:nimi')} maxLength={100} required />
+            </Box>
+
+            {isError && (
+              <Box marginTop="var(--spacing-m)">
+                <Notification label={t('common:error')} type="error" />
+              </Box>
+            )}
+          </Dialog.Content>
+
+          <Dialog.ActionButtons>
+            <Button type="submit" iconLeft={<IconCheck />} isLoading={isLoading}>
+              {t('homepage:hakemus:actionText')}
+            </Button>
+            <Button variant="secondary" onClick={handleClose} iconLeft={<IconCross />}>
+              {t('common:confirmationDialog:cancelButton')}
+            </Button>
+          </Dialog.ActionButtons>
+        </form>
+      </FormProvider>
+    </Dialog>
+  );
+}
+
+export default JohtoselvitysCreateDialog;

--- a/src/domain/johtoselvitys_new/johtoselvitysCreateDialog/JohtoselvitysCreateDialog.tsx
+++ b/src/domain/johtoselvitys_new/johtoselvitysCreateDialog/JohtoselvitysCreateDialog.tsx
@@ -1,25 +1,17 @@
 import { Box } from '@chakra-ui/react';
-import {
-  Button,
-  Dialog,
-  TextInput as HDSTextInput,
-  IconCheck,
-  IconCross,
-  IconInfoCircle,
-  Notification,
-} from 'hds-react';
+import { Button, Dialog, IconCheck, IconCross, IconInfoCircle, Notification } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useMutation } from 'react-query';
 import { yupResolver } from '@hookform/resolvers/yup';
 import TextInput from '../../../common/components/textInput/TextInput';
-import useUser from '../../auth/useUser';
 import useLinkPath from '../../../common/hooks/useLinkPath';
 import { ROUTES } from '../../../common/types/route';
 import { NewJohtoselvitysData } from '../../application/types/application';
 import { newJohtoselvitysSchema } from '../validationSchema';
 import { createJohtoselvitys } from '../../application/utils';
+import OwnInformationFields from '../../forms/components/OwnInformationFields';
 
 type Props = {
   isOpen: boolean;
@@ -28,7 +20,6 @@ type Props = {
 
 function JohtoselvitysCreateDialog({ isOpen, onClose }: Readonly<Props>) {
   const { t } = useTranslation();
-  const user = useUser();
   const navigate = useNavigate();
   const getEditJohtoselvitysPath = useLinkPath(ROUTES.EDIT_JOHTOSELVITYSHAKEMUS);
   const formContext = useForm<NewJohtoselvitysData>({
@@ -73,34 +64,8 @@ function JohtoselvitysCreateDialog({ isOpen, onClose }: Readonly<Props>) {
       <FormProvider {...formContext}>
         <form onSubmit={handleSubmit(submitForm)}>
           <Dialog.Content>
-            <Box marginBottom="var(--spacing-s)">
-              <h3 className="heading-s">{t('form:labels:omatTiedot')}</h3>
-            </Box>
-            <Box marginBottom="var(--spacing-m)">
-              <HDSTextInput
-                id="user-name"
-                label={t('form:yhteystiedot:labels:nimi')}
-                value={`${user.data?.profile?.name}`}
-                helperText={t('form:labels:fromHelsinkiProfile')}
-                readOnly
-              />
-            </Box>
-            <Box marginBottom="var(--spacing-s)" maxWidth={328}>
-              <TextInput
-                name="perustaja.sahkoposti"
-                label={t('hankeForm:labels:email')}
-                required
-                defaultValue={user.data?.profile.email}
-              />
-            </Box>
-            <Box marginBottom="var(--spacing-m)" maxWidth={328}>
-              <TextInput
-                name="perustaja.puhelinnumero"
-                label={t('hankeForm:labels:puhelinnumero')}
-                required
-              />
-            </Box>
-            <Box marginBottom="var(--spacing-s)">
+            <OwnInformationFields />
+            <Box marginTop="var(--spacing-m)" marginBottom="var(--spacing-s)">
               <h3 className="heading-s">{t('hakemus:labels:applicationInfo')}</h3>
             </Box>
             <Box marginBottom="var(--spacing-2-xs)">

--- a/src/domain/johtoselvitys_new/validationSchema.ts
+++ b/src/domain/johtoselvitys_new/validationSchema.ts
@@ -105,3 +105,11 @@ export const validationSchema: yup.ObjectSchema<JohtoselvitysFormValues> = yup.o
   selfIntersectingPolygon: yup.boolean().isFalse(),
   geometriesChanged: yup.boolean(),
 });
+
+export const newJohtoselvitysSchema = yup.object({
+  nimi: yup.string().trim().required(),
+  perustaja: yup.object({
+    sahkoposti: yup.string().email().required(),
+    puhelinnumero: yup.string().required(),
+  }),
+});

--- a/src/domain/mocks/data/defaultJohtoselvitysData.ts
+++ b/src/domain/mocks/data/defaultJohtoselvitysData.ts
@@ -1,0 +1,61 @@
+import { ApplicationType } from '../../application/types/application';
+
+export const defaultJohtoselvitysData = {
+  applicationType: 'CABLE_REPORT' as ApplicationType,
+  workDescription: '',
+  startTime: null,
+  endTime: null,
+  areas: [],
+  constructionWork: false,
+  maintenanceWork: false,
+  emergencyWork: false,
+  propertyConnectivity: false,
+  rockExcavation: null,
+  postalAddress: { streetAddress: { streetName: '' }, city: '', postalCode: '' },
+  representativeWithContacts: null,
+  propertyDeveloperWithContacts: null,
+  customerWithContacts: {
+    customer: {
+      type: null,
+      name: '',
+      country: 'FI',
+      email: '',
+      phone: '',
+      registryKey: null,
+      ovt: null,
+      invoicingOperator: null,
+      sapCustomerNumber: null,
+    },
+    contacts: [
+      {
+        firstName: '',
+        lastName: '',
+        email: '',
+        phone: '',
+        orderer: true,
+      },
+    ],
+  },
+  contractorWithContacts: {
+    customer: {
+      type: null,
+      name: '',
+      country: 'FI',
+      email: '',
+      phone: '',
+      registryKey: null,
+      ovt: null,
+      invoicingOperator: null,
+      sapCustomerNumber: null,
+    },
+    contacts: [
+      {
+        firstName: '',
+        lastName: '',
+        email: '',
+        phone: '',
+        orderer: false,
+      },
+    ],
+  },
+};

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -7,6 +7,8 @@ import * as usersDB from './data/users';
 import ApiError from './apiError';
 import { IdentificationResponse, SignedInUser } from '../hanke/hankeUsers/hankeUser';
 import { Yhteyshenkilo, YhteyshenkiloWithoutName } from '../hanke/edit/types';
+import { NewJohtoselvitysData } from '../application/types/application';
+import { defaultJohtoselvitysData } from './data/defaultJohtoselvitysData';
 
 const apiUrl = '/api';
 
@@ -119,6 +121,29 @@ export const handlers = [
     });
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const hakemus = await hakemuksetDB.create({ ...reqBody, hankeTunnus: hanke.hankeTunnus! });
+    return res(ctx.status(200), ctx.json(hakemus));
+  }),
+
+  rest.post(`${apiUrl}/johtoselvityshakemus`, async (req, res, ctx) => {
+    const { nimi }: NewJohtoselvitysData = await req.json();
+    const hanke = await hankkeetDB.create({
+      nimi: nimi,
+      alkuPvm: null,
+      loppuPvm: null,
+      vaihe: null,
+      kuvaus: null,
+      generated: true,
+    });
+    const hakemus = await hakemuksetDB.create({
+      applicationData: {
+        name: nimi,
+        ...defaultJohtoselvitysData,
+      },
+      id: null,
+      alluStatus: null,
+      applicationType: 'CABLE_REPORT',
+      hankeTunnus: hanke.hankeTunnus!,
+    });
     return res(ctx.status(200), ctx.json(hakemus));
   }),
 

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -589,6 +589,7 @@
     }
   },
   "johtoselvitysForm": {
+    "createNewJohtoselvitys": "Tee uusi johtoselvitys",
     "pageHeader": "Johtoselvityshakemus",
     "perustiedot": {
       "instructions": "<p>Huomioithan, että johtoselvitys on voimassa 1 kuukauden. Johtoselvityksen tulee olla voimassa johtojen maastonäyttöjä tilattaessa sekä kaivuilmoitusta tehdessä. Johtoselvitys on tarvittaessa päivitettävä.</p><p>Yleisellä alueella tehtävästä työstä on tehtävä erillinen ilmoitus kaupungille. Katso tarkemmat ohjeet: <a>hel.fi</a></p>"
@@ -634,7 +635,8 @@
       "addedAreas": "Lisäämäsi työalueet",
       "removeAreaTitle": "Poista työalue",
       "removeAreaDescription": "Haluatko varmasti poistaa työalueen {{areaName}}",
-      "applicationAdditionalInfo": "Lisätietoja hakemuksesta"
+      "applicationAdditionalInfo": "Lisätietoja hakemuksesta",
+      "applicationInfo": "Hakemuksen tiedot"
     },
     "notifications": {
       "saveSuccessLabel": "Hakemus tallennettu",


### PR DESCRIPTION
# Description

Separate johtoselvitys without hanke being created first is done by opening a modal dialog and entering users phone number and work name. Email is pre-filled but can be edited. Creating johtoselvitys then works in similar way as creating hanke.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2274

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Use `yarn start-msw` to use API mock as the backend for this is not yet implemented
2. Check that the dialog can be opened by clicking "Tee johtoselvityshakemus" linkbox in home page, "Tee johtoselvityshakemus" link in top bar or "täytä hakemus" link in the first page of hanke form
3. Fill the form in the dialog and click "Luo hakemus" button
4. You should end up in johtoselvitys form where the work name is filled

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
