### PR TITLE
HAI-2341 Fix hanke areas not being visible if work start and end dates are on hanke end date

### DIFF
--- a/src/domain/johtoselvitys_new/Geometries.test.tsx
+++ b/src/domain/johtoselvitys_new/Geometries.test.tsx
@@ -2,15 +2,17 @@ import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { render, screen } from '../../testUtils/render';
 import { Geometries } from './Geometries';
+import hankkeet from '../mocks/data/hankkeet-data';
+import { HankeData } from '../types/hanke';
 
 jest.setTimeout(30000);
 
-function TestComponent() {
+function TestComponent({ hankeData }: { hankeData?: HankeData }) {
   const formContext = useForm();
 
   return (
     <FormProvider {...formContext}>
-      <Geometries />
+      <Geometries hankeData={hankeData} />
     </FormProvider>
   );
 }
@@ -32,4 +34,24 @@ test('Areas can be added after start and end dates have been set', async () => {
   ).not.toBeInTheDocument();
   expect(screen.queryByTestId('draw-control-Square')).toBeInTheDocument();
   expect(screen.queryByTestId('draw-control-Polygon')).toBeInTheDocument();
+});
+
+test('Hanke areas are visible if work start and end dates are between hanke start and end dates', async () => {
+  const testHanke = hankkeet[1];
+  const { user } = render(<TestComponent hankeData={testHanke as HankeData} />);
+  await user.type(screen.getByRole('textbox', { name: 'Työn arvioitu alkupäivä *' }), '27.11.2024');
+  await user.type(
+    screen.getByRole('textbox', { name: 'Työn arvioitu loppupäivä *' }),
+    '27.11.2024',
+  );
+
+  expect(screen.getByTestId('countOfFilteredHankkeet')).toHaveTextContent('1');
+
+  await user.type(screen.getByRole('textbox', { name: 'Työn arvioitu alkupäivä *' }), '28.11.2024');
+  await user.type(
+    screen.getByRole('textbox', { name: 'Työn arvioitu loppupäivä *' }),
+    '29.11.2024',
+  );
+
+  expect(screen.getByTestId('countOfFilteredHankkeet')).toHaveTextContent('0');
 });

--- a/src/domain/map/components/Layers/HankeLayer.tsx
+++ b/src/domain/map/components/Layers/HankeLayer.tsx
@@ -8,6 +8,7 @@ import HankkeetContext from '../../HankkeetProviderContext';
 import HighlightFeatureOnMap from '../interations/HighlightFeatureOnMap';
 import useHankeFeatures from '../../hooks/useHankeFeatures';
 import { HankeData } from '../../../types/hanke';
+import { toStartOfDayUTCISO } from '../../../../common/utils/date';
 
 type Props = {
   hankeData?: HankeData[];
@@ -31,7 +32,13 @@ function HankeLayer({
   const hankkeet = hankeData || hankkeetFromContext;
 
   const hankkeetFilteredByAll = useMemo(
-    () => hankkeet.filter(byAllHankeFilters({ startDate, endDate })),
+    () =>
+      hankkeet.filter(
+        byAllHankeFilters({
+          startDate: startDate && toStartOfDayUTCISO(new Date(startDate)),
+          endDate,
+        }),
+      ),
     [hankkeet, startDate, endDate],
   );
 


### PR DESCRIPTION
# Description

Fixed issue where hanke areas were not being visible if work start and end dates are set on hanke end date.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2341

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create new johtoselvitys for hanke which has hanke areas
2. Fill first page of johtoselvitys form and go to second page
3. Set work start and end dates to hanke end date
4. Check that hanke areas are displayed on map

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
