### PR TITLE
HAI-2371 Add tooltips for icons in user management view

### DIFF
--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -246,7 +246,7 @@ test('Should show correct icons for users', async () => {
   ).toBeInTheDocument();
   expect(
     screen.getByRole('cell', {
-      name: 'Kutsulinkki lähetetty Teppo Työmies',
+      name: 'Kutsulinkki lähetetty 15.1.2024 Teppo Työmies',
     }),
   ).toBeInTheDocument();
 });

--- a/src/domain/hanke/accessRights/AccessRightsView.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.tsx
@@ -13,7 +13,7 @@ import {
   IconPen,
   Button,
 } from 'hds-react';
-import { Box, Flex, Grid, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
+import { Box, Flex, Grid, Menu, MenuButton, MenuItem, MenuList, Tooltip } from '@chakra-ui/react';
 import {
   Column,
   useAsyncDebounce,
@@ -40,6 +40,7 @@ import {
   InvitationSuccessNotification,
 } from '../hankeUsers/InvitationNotification';
 import { userRoleSorter } from '../hankeUsers/utils';
+import { formatToFinnishDate } from '../../../common/utils/date';
 
 function UserIcon({
   user,
@@ -49,26 +50,44 @@ function UserIcon({
 
   if (user.id === signedInUser?.hankeKayttajaId) {
     return (
-      <IconUser
-        className={styles.userIcon}
-        ariaHidden={false}
-        ariaLabel={t('hankeUsers:labels:ownInformation')}
-      />
+      <Tooltip label={t('hankeUsers:labels:ownInformation')}>
+        <Flex>
+          <IconUser
+            className={styles.userIcon}
+            ariaHidden={false}
+            ariaLabel={t('hankeUsers:labels:ownInformation')}
+          />
+        </Flex>
+      </Tooltip>
     );
   } else {
     return user.tunnistautunut ? (
-      <IconCheckCircleFill
-        color="var(--color-success)"
-        className={styles.userIcon}
-        ariaHidden={false}
-        ariaLabel={t('hankeUsers:labels:userIdentified')}
-      />
+      <Tooltip label={t('hankeUsers:labels:userIdentified')}>
+        <Flex>
+          <IconCheckCircleFill
+            color="var(--color-success)"
+            className={styles.userIcon}
+            ariaHidden={false}
+            ariaLabel={t('hankeUsers:labels:userIdentified')}
+          />
+        </Flex>
+      </Tooltip>
     ) : (
-      <IconClock
-        className={styles.userIcon}
-        ariaHidden={false}
-        ariaLabel={t('hankeUsers:notifications:invitationSentSuccessLabel')}
-      />
+      <Tooltip
+        label={t('hankeUsers:labels:invitationSent', {
+          date: formatToFinnishDate(user.kutsuttu),
+        })}
+      >
+        <Flex>
+          <IconClock
+            className={styles.userIcon}
+            ariaHidden={false}
+            ariaLabel={t('hankeUsers:labels:invitationSent', {
+              date: formatToFinnishDate(user.kutsuttu),
+            })}
+          />
+        </Flex>
+      </Tooltip>
     );
   }
 }

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -540,6 +540,7 @@ describe('New contact person form and contact person dropdown', () => {
         kayttooikeustaso: 'KAIKKI_OIKEUDET',
         roolit: [],
         tunnistautunut: true,
+        kutsuttu: null,
       },
       {
         id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
@@ -550,6 +551,7 @@ describe('New contact person form and contact person dropdown', () => {
         kayttooikeustaso: 'KAIKKIEN_MUOKKAUS',
         roolit: [],
         tunnistautunut: false,
+        kutsuttu: '2024-02-15T19:59:59.999Z',
       },
     ];
     server.use(

--- a/src/domain/hanke/hankeUsers/EditUserView.test.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.test.tsx
@@ -65,7 +65,7 @@ test('Should show status text of invitation send to user and Invitation send but
   render(<EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa7" hankeTunnus="HAI22-2" />);
   await waitForLoadingToFinish();
 
-  expect(screen.getByText('Kutsulinkki Haitattomaan lähetetty')).toBeInTheDocument();
+  expect(screen.getByText('Kutsulinkki Haitattomaan lähetetty 15.1.2024')).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Lähetä kutsulinkki uudelleen' })).toBeInTheDocument();
 });
 

--- a/src/domain/hanke/hankeUsers/EditUserView.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.tsx
@@ -38,6 +38,7 @@ import { yhteyshenkiloSchema } from '../edit/hankeSchema';
 import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
 import Text from '../../../common/components/text/Text';
 import { userRoleSorter } from './utils';
+import { formatToFinnishDate } from '../../../common/utils/date';
 
 type Props = {
   user: HankeUser;
@@ -67,6 +68,7 @@ function EditUserView({
     tunnistautunut,
     kayttooikeustaso,
     roolit,
+    kutsuttu,
   },
   hankeUsers,
   signedInUser,
@@ -240,7 +242,11 @@ function EditUserView({
             ) : (
               <>
                 <IconClock />
-                <p>{t('hankeUsers:labels:invitationSent')}</p>
+                <p>
+                  {t('hankeUsers:labels:invitationSentLong', {
+                    date: formatToFinnishDate(kutsuttu),
+                  })}
+                </p>
               </>
             )}
           </Flex>

--- a/src/domain/hanke/hankeUsers/hankeUser.ts
+++ b/src/domain/hanke/hankeUsers/hankeUser.ts
@@ -15,6 +15,7 @@ export type HankeUser = {
   kayttooikeustaso: keyof typeof AccessRightLevel;
   roolit: string[];
   tunnistautunut: boolean;
+  kutsuttu: string | null;
 };
 
 export enum Rights {

--- a/src/domain/mocks/data/users-data.json
+++ b/src/domain/mocks/data/users-data.json
@@ -6,9 +6,13 @@
     "sukunimi": "Meikäläinen",
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KAIKKI_OIKEUDET",
-    "roolit": ["MUU", "RAKENNUTTAJA"],
+    "roolit": [
+      "MUU",
+      "RAKENNUTTAJA"
+    ],
     "tunnistautunut": true,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": null
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa7",
@@ -17,9 +21,12 @@
     "sukunimi": "Työmies",
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KAIKKIEN_MUOKKAUS",
-    "roolit": ["OMISTAJA"],
+    "roolit": [
+      "OMISTAJA"
+    ],
     "tunnistautunut": false,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": "2024-01-15T19:59:59.999Z"
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa8",
@@ -28,9 +35,12 @@
     "sukunimi": "Asiakas",
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "HANKEMUOKKAUS",
-    "roolit": ["MUU"],
+    "roolit": [
+      "MUU"
+    ],
     "tunnistautunut": true,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": null
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa9",
@@ -39,9 +49,13 @@
     "sukunimi": "Viljanen",
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KAIKKI_OIKEUDET",
-    "roolit": ["TOTEUTTAJA", "OMISTAJA"],
+    "roolit": [
+      "TOTEUTTAJA",
+      "OMISTAJA"
+    ],
     "tunnistautunut": false,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": "2024-01-16T19:59:59.999Z"
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb1",
@@ -50,9 +64,12 @@
     "sukunimi": "Testinen",
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
-    "roolit": ["TOTEUTTAJA"],
+    "roolit": [
+      "TOTEUTTAJA"
+    ],
     "tunnistautunut": false,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": "2024-01-17T19:59:59.999Z"
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb2",
@@ -61,9 +78,12 @@
     "sukunimi": "Marjanen",
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
-    "roolit": ["MUU"],
+    "roolit": [
+      "MUU"
+    ],
     "tunnistautunut": false,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": "2024-01-15T19:59:59.999Z"
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb3",
@@ -72,9 +92,12 @@
     "sukunimi": "Marjanen",
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
-    "roolit": ["MUU"],
+    "roolit": [
+      "MUU"
+    ],
     "tunnistautunut": true,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": null
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb4",
@@ -83,9 +106,13 @@
     "sukunimi": "Selkonen",
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "HAKEMUSASIOINTI",
-    "roolit": ["RAKENNUTTAJA", "TOTEUTTAJA"],
+    "roolit": [
+      "RAKENNUTTAJA",
+      "TOTEUTTAJA"
+    ],
     "tunnistautunut": true,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": null
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb5",
@@ -94,9 +121,12 @@
     "sukunimi": "Keijonen",
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
-    "roolit": ["MUU"],
+    "roolit": [
+      "MUU"
+    ],
     "tunnistautunut": true,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": null
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb6",
@@ -105,9 +135,12 @@
     "sukunimi": "Testinen",
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
-    "roolit": ["RAKENNUTTAJA"],
+    "roolit": [
+      "RAKENNUTTAJA"
+    ],
     "tunnistautunut": false,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": "2024-01-15T19:59:59.999Z"
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb7",
@@ -118,7 +151,8 @@
     "kayttooikeustaso": "KATSELUOIKEUS",
     "roolit": [],
     "tunnistautunut": false,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": "2024-02-15T19:59:59.999Z"
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66af5",
@@ -129,6 +163,7 @@
     "kayttooikeustaso": "KATSELUOIKEUS",
     "roolit": [],
     "tunnistautunut": true,
-    "hankeTunnus": "HAI22-2"
+    "hankeTunnus": "HAI22-2",
+    "kutsuttu": null
   }
 ]

--- a/src/domain/mocks/data/users.ts
+++ b/src/domain/mocks/data/users.ts
@@ -16,6 +16,7 @@ function mapToHankeUser(user: (typeof users)[0]): HankeUser {
     kayttooikeustaso: user.kayttooikeustaso as AccessRightLevel,
     roolit: user.roolit,
     tunnistautunut: user.tunnistautunut,
+    kutsuttu: user.kutsuttu,
   };
 }
 
@@ -41,6 +42,7 @@ export async function create(hankeTunnus: string, user: Yhteyshenkilo) {
     kayttooikeustaso: AccessRightLevel.KATSELUOIKEUS,
     roolit: [],
     tunnistautunut: false,
+    kutsuttu: new Date().toISOString(),
   };
   users.push({ ...newUser, hankeTunnus });
   return newUser;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -859,8 +859,10 @@
       "invitationSentErrorText": "<0>An error occurred when sending the invitation link. Please try again later or contact the Haitaton technical support by email <1>haitatontuki@hel.fi</1>.</0>"
     },
     "buttons": {
-      "resendInvitation": "Resend the invitation link",
-      "invitationSent": "Invitation link sent"
+      "resendInvitation": "Resend the invitation link"
+    },
+    "labels": {
+      "invitationSent": "Invitation link sent {{date}}"
     },
     "userIdentified": "User logged in"
   },

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -927,14 +927,14 @@
     },
     "buttons": {
       "resendInvitation": "Lähetä kutsulinkki uudelleen",
-      "invitationSent": "Kutsulinkki lähetetty",
       "edit": "Muokkaa tietoja"
     },
     "labels": {
       "ownInformation": "Omat käyttäjätietosi",
       "userIdentified": "Kirjautunut hankkeelle tunnistautuneena",
       "userIdentifiedLong": "Käyttäjä on kirjautunut hankkeelle tunnistautuneena",
-      "invitationSent": "Kutsulinkki Haitattomaan lähetetty",
+      "invitationSent": "Kutsulinkki lähetetty {{date}}",
+      "invitationSentLong": "Kutsulinkki Haitattomaan lähetetty {{date}}",
       "userMenu": "Käyttäjävalikko"
     },
     "userIdentified": "Käyttäjä tunnistautunut"

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -859,8 +859,10 @@
       "invitationSentErrorText": "<0>Ett fel uppstod när inbjudningslänken skulle skickas. Försök igen senare eller kontakta Haitatons tekniska support med e-post till <1>haitatontuki@hel.fi</1>.</0>"
     },
     "buttons": {
-      "resendInvitation": "Skicka inbjudningslänken på nytt",
-      "invitationSent": "Inbjudningslänken skickades"
+      "resendInvitation": "Skicka inbjudningslänken på nytt"
+    },
+    "labels": {
+      "invitationSent": "Inbjudningslänken skickades {{date}}"
     },
     "userIdentified": "Användaren har identifierat sig"
   },


### PR DESCRIPTION
# Description

Added tooltips for user management view icons which indicate if user has been identified, if invitation has been sent or if it is users own information.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2371

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
