### PR TITLE
HAI-1989 Show list of hanke form pages with missing information in hanke view

### DIFF
--- a/src/domain/forms/hooks/useValidationErrors.ts
+++ b/src/domain/forms/hooks/useValidationErrors.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef, useState } from 'react';
+import { AnyObject, ObjectSchema, ValidationError } from 'yup';
+import { isEqual } from 'lodash';
+
+/**
+ * Validates input data and returns validation errors if validation fails
+ */
+export function useValidationErrors<T>(schema: ObjectSchema<AnyObject>, data: T) {
+  const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
+  const ref = useRef<T | null>(null);
+
+  useEffect(() => {
+    if (!isEqual(ref.current, data)) {
+      ref.current = data;
+      schema
+        .validate(data, { abortEarly: false })
+        .then(() => {
+          setValidationErrors([]);
+        })
+        .catch((error: ValidationError) => {
+          setValidationErrors(error.inner);
+        });
+    }
+  }, [schema, data]);
+
+  return validationErrors;
+}

--- a/src/domain/hanke/edit/components/HankeDraftStateNotification.tsx
+++ b/src/domain/hanke/edit/components/HankeDraftStateNotification.tsx
@@ -1,7 +1,11 @@
-import { Notification } from 'hds-react';
 import React from 'react';
+import { Notification } from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import { Box } from '@chakra-ui/react';
+import { uniq } from 'lodash';
 import { HankeData } from '../../../types/hanke';
+import { useValidationErrors } from '../../../forms/hooks/useValidationErrors';
+import { Message, hankePublicSchema } from '../hankePublicSchema';
 
 type Props = {
   /** Hanke data */
@@ -11,20 +15,32 @@ type Props = {
 };
 
 /**
- * Show hanke draft state notification if it's status is DRAFT
+ * Show hanke draft state notification if there are required fields missing
  */
-const HankeDraftStateNotification: React.FC<Props> = ({ hanke, className }) => {
+const HankeDraftStateNotification: React.FC<Readonly<Props>> = ({ hanke, className }) => {
   const { t } = useTranslation();
+  const hankePublicErrors = useValidationErrors(hankePublicSchema, hanke);
+  const errorPages = uniq(
+    hankePublicErrors.map((error) => (error.message as unknown as Message).values.page),
+  );
 
-  if (hanke.status === 'DRAFT') {
+  if (errorPages.length > 0) {
     return (
       <Notification
-        size="small"
-        label={t('hankePortfolio:draftStateLabel')}
+        label={t('hankePortfolio:draftState:labels:insufficientPhases')}
         className={className}
         type="alert"
+        dataTestId="hankeDraftStateNotification"
       >
-        {t('hankePortfolio:draftState')}
+        <Box as="ul" marginLeft="var(--spacing-m)">
+          {errorPages.map((page) => {
+            return (
+              <li key={page} aria-label={t(`hankePortfolio:tabit:${page}`)}>
+                {t(`hankePortfolio:tabit:${page}`)}
+              </li>
+            );
+          })}
+        </Box>
       </Notification>
     );
   }

--- a/src/domain/hanke/edit/hankePublicSchema.ts
+++ b/src/domain/hanke/edit/hankePublicSchema.ts
@@ -1,0 +1,92 @@
+import yup from '../../../common/utils/yup';
+import isValidBusinessId from '../../../common/utils/isValidBusinessId';
+import {
+  CONTACT_TYYPPI,
+  HANKE_KAISTAHAITTA_KEY,
+  HANKE_KAISTAPITUUSHAITTA_KEY,
+  HANKE_MELUHAITTA_KEY,
+  HANKE_POLYHAITTA_KEY,
+  HANKE_TARINAHAITTA_KEY,
+  HANKE_VAIHE_KEY,
+  HankeGeometria,
+} from '../../types/hanke';
+import { CONTACT_FORMFIELD, FORMFIELD } from './types';
+
+enum ERROR_KEYS {
+  REQUIRED = 'required',
+  MIN = 'min',
+}
+
+enum HANKE_PAGES {
+  PERUSTIEDOT = 'perustiedot',
+  ALUEET = 'alueet',
+  HAITTOJENHALLINTA = 'haittojenHallinta',
+  YHTEYSTIEDOT = 'yhteystiedot',
+}
+
+export type Message = {
+  key: string;
+  values: {
+    page: string;
+  };
+};
+
+function getMessage(page: string, key: string = ERROR_KEYS.REQUIRED): Message {
+  return { key, values: { page } };
+}
+
+const hankeAlueSchema = yup.object({
+  [FORMFIELD.HAITTA_ALKU_PVM]: yup.date().required(getMessage(HANKE_PAGES.ALUEET)),
+  [FORMFIELD.HAITTA_LOPPU_PVM]: yup.date().required(getMessage(HANKE_PAGES.ALUEET)),
+  [FORMFIELD.MELUHAITTA]: yup
+    .mixed<HANKE_MELUHAITTA_KEY>()
+    .required(getMessage(HANKE_PAGES.ALUEET)),
+  [FORMFIELD.POLYHAITTA]: yup
+    .mixed<HANKE_POLYHAITTA_KEY>()
+    .required(getMessage(HANKE_PAGES.ALUEET)),
+  [FORMFIELD.TARINAHAITTA]: yup
+    .mixed<HANKE_TARINAHAITTA_KEY>()
+    .required(getMessage(HANKE_PAGES.ALUEET)),
+  [FORMFIELD.KAISTAHAITTA]: yup
+    .mixed<HANKE_KAISTAHAITTA_KEY>()
+    .required(getMessage(HANKE_PAGES.ALUEET)),
+  [FORMFIELD.KAISTAPITUUSHAITTA]: yup
+    .mixed<HANKE_KAISTAPITUUSHAITTA_KEY>()
+    .required(getMessage(HANKE_PAGES.ALUEET)),
+  [FORMFIELD.NIMI]: yup.string().required(getMessage(HANKE_PAGES.ALUEET)),
+  [FORMFIELD.GEOMETRIAT]: yup.mixed<HankeGeometria>().required(getMessage(HANKE_PAGES.ALUEET)),
+});
+
+const yhteystietoSchema = yup.object({
+  [CONTACT_FORMFIELD.NIMI]: yup.string().required(getMessage(HANKE_PAGES.YHTEYSTIEDOT)),
+  [CONTACT_FORMFIELD.EMAIL]: yup.string().email().required(getMessage(HANKE_PAGES.YHTEYSTIEDOT)),
+  [CONTACT_FORMFIELD.TUNNUS]: yup
+    .string()
+    .nullable()
+    .when('tyyppi', {
+      is: (value: string) => value === CONTACT_TYYPPI.YRITYS || value === CONTACT_TYYPPI.YHTEISO,
+      then: (schema) =>
+        schema.test(
+          'is-business-id',
+          getMessage(CONTACT_FORMFIELD.TUNNUS, HANKE_PAGES.YHTEYSTIEDOT),
+          isValidBusinessId,
+        ),
+      otherwise: (schema) => schema,
+    }),
+});
+
+export const hankePublicSchema = yup.object({
+  [FORMFIELD.NIMI]: yup.string().required(getMessage(HANKE_PAGES.PERUSTIEDOT)),
+  [FORMFIELD.KUVAUS]: yup.string().required(getMessage(HANKE_PAGES.PERUSTIEDOT)),
+  [FORMFIELD.KATUOSOITE]: yup.string().required(getMessage(HANKE_PAGES.PERUSTIEDOT)),
+  [FORMFIELD.VAIHE]: yup.mixed<HANKE_VAIHE_KEY>().required(getMessage(HANKE_PAGES.PERUSTIEDOT)),
+  [FORMFIELD.HANKEALUEET]: yup
+    .array(hankeAlueSchema)
+    .min(1, getMessage(HANKE_PAGES.ALUEET, ERROR_KEYS.MIN)),
+  [FORMFIELD.OMISTAJAT]: yup
+    .array(yhteystietoSchema)
+    .min(1, getMessage(HANKE_PAGES.YHTEYSTIEDOT, ERROR_KEYS.MIN)),
+  [FORMFIELD.RAKENNUTTAJAT]: yup.array(yhteystietoSchema),
+  [FORMFIELD.TOTEUTTAJAT]: yup.array(yhteystietoSchema),
+  [FORMFIELD.MUUTTAHOT]: yup.array(yhteystietoSchema.omit([CONTACT_FORMFIELD.TUNNUS])),
+});

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -76,7 +76,7 @@ export const hankeSchema: yup.ObjectSchema<HankeDataFormState> = yup.object().sh
   [FORMFIELD.KATUOSOITE]: yup.string().nullable(),
   [FORMFIELD.VAIHE]: yup.mixed<HANKE_VAIHE_KEY>().nullable(),
   [FORMFIELD.HANKEALUEET]: yup.array(hankeAlueSchema),
-  [FORMFIELD.OMISTAJAT]: yup.array(contactSchema).defined().length(1),
+  [FORMFIELD.OMISTAJAT]: yup.array(contactSchema).defined(),
   [FORMFIELD.RAKENNUTTAJAT]: yup.array(contactSchema).defined(),
   [FORMFIELD.TOTEUTTAJAT]: yup.array(contactSchema).defined(),
   [FORMFIELD.MUUTTAHOT]: yup.array(otherPartySchema).defined(),

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { rest } from 'msw';
-import { render, screen } from '../../../testUtils/render';
+import { render, screen, within } from '../../../testUtils/render';
 import { waitForLoadingToFinish } from '../../../testUtils/helperFunctions';
 import HankeViewContainer from './HankeViewContainer';
 import { server } from '../../mocks/test-server';
@@ -26,9 +25,27 @@ test('Draft state notification is rendered when hanke is in draft state', async 
 
   await waitForLoadingToFinish();
 
-  const draftStateElements = screen.queryAllByText(/hanke on luonnostilassa/i, { exact: false });
+  const draftStateElement = screen.getByTestId('hankeDraftStateNotification');
+  const { getByRole } = within(draftStateElement);
 
-  expect(draftStateElements[0]).toBeInTheDocument();
+  expect(draftStateElement).toBeInTheDocument();
+  expect(getByRole('listitem', { name: /perustiedot/i })).toBeInTheDocument();
+  expect(getByRole('listitem', { name: /alueet/i })).toBeInTheDocument();
+  expect(getByRole('listitem', { name: /yhteystiedot/i })).toBeInTheDocument();
+});
+
+test('Draft state notification only shows form pages with missing information', async () => {
+  render(<HankeViewContainer hankeTunnus="HAI22-4" />);
+
+  await waitForLoadingToFinish();
+
+  const draftStateElement = screen.getByTestId('hankeDraftStateNotification');
+  const { queryByRole, getByRole } = within(draftStateElement);
+
+  expect(draftStateElement).toBeInTheDocument();
+  expect(queryByRole('listitem', { name: /perustiedot/i })).not.toBeInTheDocument();
+  expect(getByRole('listitem', { name: /alueet/i })).toBeInTheDocument();
+  expect(getByRole('listitem', { name: /yhteystiedot/i })).toBeInTheDocument();
 });
 
 test('Add application button is displayed when hanke is in PUBLIC state', async () => {
@@ -52,9 +69,9 @@ test('Draft state notification is not rendered when hanke is not in draft state'
 
   await waitForLoadingToFinish();
 
-  const draftStateElements = screen.queryAllByText(/hanke on luonnostilassa/i, { exact: false });
+  const draftStateElement = screen.queryByText(/hanke on luonnostilassa/i, { exact: false });
 
-  expect(draftStateElements.length).toBe(0);
+  expect(draftStateElement).not.toBeInTheDocument();
 });
 
 test('Generated state notification is rendered when hanke is in generated state', async () => {

--- a/src/domain/mocks/data/hankkeet-data.ts
+++ b/src/domain/mocks/data/hankkeet-data.ts
@@ -29,6 +29,7 @@ const hankkeet: HankeDataDraft[] = [
     toteuttajat: [],
     muut: [],
     tyomaaTyyppi: [],
+    alueet: [],
   },
   {
     id: 2,
@@ -294,6 +295,7 @@ const hankkeet: HankeDataDraft[] = [
         tarinaHaitta: HANKE_TARINAHAITTA.PITKAKESTOINEN_TOISTUVA_HAITTA,
         kaistaHaitta: HANKE_KAISTAHAITTA.VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA,
         kaistaPituusHaitta: HANKE_KAISTAPITUUSHAITTA.PITUUS_ALLE_10_METRIA,
+        nimi: 'Hankealue 1',
         geometriat: {
           featureCollection: {
             type: 'FeatureCollection',
@@ -351,6 +353,7 @@ const hankkeet: HankeDataDraft[] = [
     toteuttajat: [],
     muut: [],
     tyomaaTyyppi: [],
+    alueet: [],
   },
   {
     id: 5,
@@ -373,6 +376,7 @@ const hankkeet: HankeDataDraft[] = [
     toteuttajat: [],
     muut: [],
     tyomaaTyyppi: [],
+    alueet: [],
   },
   {
     id: 6,
@@ -395,6 +399,7 @@ const hankkeet: HankeDataDraft[] = [
     toteuttajat: [],
     muut: [],
     tyomaaTyyppi: [],
+    alueet: [],
   },
   {
     id: 7,
@@ -417,6 +422,7 @@ const hankkeet: HankeDataDraft[] = [
     toteuttajat: [],
     muut: [],
     tyomaaTyyppi: [],
+    alueet: [],
   },
   {
     id: 8,
@@ -439,6 +445,7 @@ const hankkeet: HankeDataDraft[] = [
     toteuttajat: [],
     muut: [],
     tyomaaTyyppi: [],
+    alueet: [],
   },
   {
     id: 9,
@@ -461,6 +468,7 @@ const hankkeet: HankeDataDraft[] = [
     toteuttajat: [],
     muut: [],
     tyomaaTyyppi: [],
+    alueet: [],
   },
   {
     id: 10,
@@ -483,6 +491,7 @@ const hankkeet: HankeDataDraft[] = [
     toteuttajat: [],
     muut: [],
     tyomaaTyyppi: [],
+    alueet: [],
   },
   {
     id: 11,
@@ -506,6 +515,7 @@ const hankkeet: HankeDataDraft[] = [
     muut: [],
     tyomaaTyyppi: [],
     generated: true,
+    alueet: [],
   },
 ];
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -747,8 +747,6 @@
     "openMapToNewWindow": "Open the map in a new window",
     "showHankeButton": "Show project",
     "showApplicationsButton": "Show project applications",
-    "draftStateLabel": "The project is a draft",
-    "draftState": "The project is in a draft state. You must enter nuisance information on the areas and other mandatory information to publish the project and add permits.",
     "clearFiltersButton": "Clear filters",
     "filtersInfoText": "Changing the filters will update the project list.",
     "tabit": {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -801,8 +801,6 @@
     "openMapToNewWindow": "Avaa kartta uuteen ikkunaan",
     "showHankeButton": "Näytä hanke",
     "showApplicationsButton": "Näytä hankkeen hakemukset",
-    "draftStateLabel": "Hanke on luonnostilassa",
-    "draftState": "Hanke on luonnostilassa. Alueiden haittatiedot ja muut pakolliset tiedot on täytettävä hankkeen julkaisemiseksi ja lupien lisäämiseksi.",
     "generatedStateLabel": "Hanke muodostettu johtoselvityksen perusteella",
     "generatedState": "Tämä hanke on muodostettu johtoselvityksen perusteella.",
     "clearFiltersButton": "Tyhjennä hakuehdot",
@@ -836,6 +834,11 @@
     },
     "ariaLabels": {
       "expandHankeCard": "Laajenna hankkeen tiedot"
+    },
+    "draftState": {
+      "labels": {
+        "insufficientPhases": "Hanke on luonnostilassa. Sen näkyvyys muille hankkeille on rajoitettua, eikä sille voi lisätä hakemuksia. Seuraavissa vaiheissa on puuttuvia tietoja:"
+      }
     }
   },
   "publicHankkeet": {

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -747,8 +747,6 @@
     "openMapToNewWindow": "Öppna kartan i ett nytt fönster",
     "showHankeButton": "Visa projekt",
     "showApplicationsButton": "Visa projektets ansökningar",
-    "draftStateLabel": "Projektet är i utkastfasen",
-    "draftState": "Projektet är i utkastfasen. Uppgifter om områdenas olägenheter och övriga obligatoriska uppgifter ska fyllas i för att publicera projektet och lägga till tillstånd.",
     "clearFiltersButton": "Töm sökuppgifter",
     "filtersInfoText": "Ändring av sökvillkoren uppdaterar projektlistan.",
     "tabit": {


### PR DESCRIPTION
# Description

When hanke is in draft state, list of hanke form pages with missing information is shown in hanke view.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1989

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new hanke and go to its page
2. There should be a notification that hanke in draft state with page names that have missing information (should show 'Perustiedot', 'Alueet' and 'Yhteystiedot'
3. Edit hanke and fill perustiedot page
4. Go back to hanke page and check that 'Alueet' and 'Yhteystiedot' are only shown with missing information
5. Edit hanke and fill alueet and yhteystiedot pages
6. Go back to hanke page and check that draft state notification is not shown

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
