### PR TITLE
HAI-2391 Implement hanke user delete

### DIFF
--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -50,7 +50,7 @@ test('Renders correct information', async () => {
   expect(screen.getByTestId('roolit-0')).toHaveTextContent('Rakennuttaja, Muu');
   expect(screen.getAllByText(`${users[1].etunimi} ${users[1].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[1].sahkoposti)).toHaveLength(2);
-  expect(screen.getByTestId('roolit-1')).toHaveTextContent('Omistaja');
+  expect(screen.getByTestId('roolit-1')).toHaveTextContent('Rakennuttaja');
   expect(screen.getAllByText(`${users[2].etunimi} ${users[2].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[2].sahkoposti)).toHaveLength(2);
   expect(screen.getByTestId('roolit-2')).toHaveTextContent('Muu');
@@ -58,7 +58,7 @@ test('Renders correct information', async () => {
   expect(screen.getAllByText(users[3].sahkoposti)).toHaveLength(2);
   expect(screen.getAllByText(`${users[4].etunimi} ${users[4].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[4].sahkoposti)).toHaveLength(2);
-  expect(screen.getByTestId('roolit-4')).toHaveTextContent('Toteuttaja');
+  expect(screen.getByTestId('roolit-4')).toHaveTextContent('Omistaja');
   expect(screen.getAllByText(`${users[5].etunimi} ${users[5].sukunimi}`)).toHaveLength(2);
   expect(screen.getAllByText(users[5].sahkoposti)).toHaveLength(2);
   expect(screen.getAllByText(`${users[6].etunimi} ${users[6].sukunimi}`)).toHaveLength(2);
@@ -128,7 +128,7 @@ test('Sorting by users role works', async () => {
   expect(screen.getByTestId('roolit-4')).toHaveTextContent('Muu');
   expect(screen.getByTestId('roolit-5')).toHaveTextContent('Muu');
   expect(screen.getByTestId('roolit-6')).toHaveTextContent('Omistaja');
-  expect(screen.getByTestId('roolit-7')).toHaveTextContent('Omistaja');
+  expect(screen.getByTestId('roolit-7')).toHaveTextContent('Rakennuttaja');
   expect(screen.getByTestId('roolit-8')).toHaveTextContent('Rakennuttaja');
   expect(screen.getByTestId('roolit-9')).toHaveTextContent('Rakennuttaja');
 
@@ -136,9 +136,9 @@ test('Sorting by users role works', async () => {
 
   expect(screen.getByTestId('roolit-0')).toHaveTextContent('Toteuttaja');
   expect(screen.getByTestId('roolit-1')).toHaveTextContent('Rakennuttaja, Toteuttaja');
-  expect(screen.getByTestId('roolit-2')).toHaveTextContent('Rakennuttaja');
+  expect(screen.getByTestId('roolit-2')).toHaveTextContent('Rakennuttaja, Muu');
   expect(screen.getByTestId('roolit-3')).toHaveTextContent('Rakennuttaja');
-  expect(screen.getByTestId('roolit-4')).toHaveTextContent('Omistaja');
+  expect(screen.getByTestId('roolit-4')).toHaveTextContent('Rakennuttaja');
   expect(screen.getByTestId('roolit-5')).toHaveTextContent('Omistaja');
   expect(screen.getByTestId('roolit-6')).toHaveTextContent('Muu');
   expect(screen.getByTestId('roolit-7')).toHaveTextContent('Muu');

--- a/src/domain/hanke/hankeUsers/UserDeleteDialog.tsx
+++ b/src/domain/hanke/hankeUsers/UserDeleteDialog.tsx
@@ -1,0 +1,121 @@
+import { Button, Dialog, IconInfoCircle, IconTrash, Notification } from 'hds-react';
+import { Box } from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
+import { DeleteInfo, HankeUser } from './hankeUser';
+import { useMutation } from 'react-query';
+import { deleteUser } from './hankeUsersApi';
+import { isApplicationPending } from '../../application/utils';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  onDelete: (user: HankeUser) => void;
+  deleteInfo: DeleteInfo;
+  userToDelete: HankeUser | null;
+};
+
+export default function UserDeleteDialog({
+  isOpen,
+  onClose,
+  onDelete,
+  deleteInfo: { onlyOmistajanYhteyshenkilo, activeHakemukset, draftHakemukset },
+  userToDelete,
+}: Readonly<Props>) {
+  const { t } = useTranslation();
+  const hasActiveHakemukset = activeHakemukset.length > 0;
+  const canBeDeleted = !onlyOmistajanYhteyshenkilo && !hasActiveHakemukset;
+  const dialogTitle = canBeDeleted
+    ? t('hankeUsers:deleteDialog:title:canDelete')
+    : t('hankeUsers:deleteDialog:title:cannotDelete');
+
+  const { mutate, isLoading, isError, reset } = useMutation(deleteUser);
+
+  function getDialogText() {
+    if (onlyOmistajanYhteyshenkilo) {
+      return t('hankeUsers:deleteDialog:content:onlyOmistajanYhteyshenkilo');
+    }
+    if (hasActiveHakemukset) {
+      const activeHakemuksetInfo = activeHakemukset
+        .map((hakemus) => {
+          const hakemusStatus = t(`hakemus:status:${hakemus.alluStatus}`);
+          return `${hakemus.applicationIdentifier} ${hakemusStatus}`;
+        })
+        .join(', ');
+      // If all active hakemukset are still pending, return different text than in the case some of them
+      // have moved to other ALLU states
+      if (activeHakemukset.every((hakemus) => isApplicationPending(hakemus.alluStatus))) {
+        return t('hankeUsers:deleteDialog:content:activeHakemuksetPending', {
+          hakemukset: activeHakemuksetInfo,
+        });
+      }
+      return t('hankeUsers:deleteDialog:content:activeHakemuksetHandling', {
+        hakemukset: activeHakemuksetInfo,
+      });
+    }
+    if (draftHakemukset.length > 0) {
+      const draftHakemusNames = draftHakemukset.map((hakemus) => hakemus.nimi).join(', ');
+      return t('hankeUsers:deleteDialog:content:draftHakemukset', {
+        hakemukset: draftHakemusNames,
+      });
+    }
+    return t('hankeUsers:deleteDialog:content:confirmText');
+  }
+
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  function confirmDeleteUser() {
+    mutate(userToDelete?.id, {
+      onSuccess() {
+        onDelete(userToDelete!);
+      },
+    });
+  }
+
+  return (
+    <Dialog
+      id="user-delete"
+      isOpen={isOpen}
+      aria-labelledby={dialogTitle}
+      variant={canBeDeleted ? 'danger' : 'primary'}
+      close={handleClose}
+      closeButtonLabelText={t('common:ariaLabels:closeButtonLabelText')}
+    >
+      <Dialog.Header id="user-delete-title" title={dialogTitle} iconLeft={<IconInfoCircle />} />
+      <Dialog.Content>
+        {getDialogText()}
+        {isError && (
+          <Box marginTop="var(--spacing-m)">
+            <Notification label={t('common:error')} type="error" />
+          </Box>
+        )}
+      </Dialog.Content>
+
+      <Dialog.ActionButtons>
+        {canBeDeleted ? (
+          <>
+            <Button
+              variant="secondary"
+              style={{ borderColor: 'var(--color-error)', color: 'var(--color-error)' }}
+              onClick={handleClose}
+            >
+              {t('common:confirmationDialog:cancelButton')}
+            </Button>
+            <Button
+              variant="danger"
+              iconLeft={<IconTrash />}
+              isLoading={isLoading}
+              onClick={confirmDeleteUser}
+            >
+              {t('common:buttons:remove')}
+            </Button>
+          </>
+        ) : (
+          <Button onClick={handleClose}>{t('common:ariaLabels:closeButtonLabelText')}</Button>
+        )}
+      </Dialog.ActionButtons>
+    </Dialog>
+  );
+}

--- a/src/domain/hanke/hankeUsers/UserDeleteInfoErrorNotification.tsx
+++ b/src/domain/hanke/hankeUsers/UserDeleteInfoErrorNotification.tsx
@@ -1,0 +1,25 @@
+import { Notification } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+
+export default function UserDeleteInfoErrorNotification({
+  onClose,
+}: Readonly<{
+  onClose: () => void;
+}>) {
+  const { t } = useTranslation();
+  return (
+    <Notification
+      position="top-right"
+      dismissible
+      autoClose
+      autoCloseDuration={7000}
+      type="error"
+      label={t('common:error')}
+      closeButtonLabelText={t('common:components:notification:closeButtonLabelText')}
+      onClose={onClose}
+      size="small"
+    >
+      {t('common:error')}
+    </Notification>
+  );
+}

--- a/src/domain/hanke/hankeUsers/UserDeleteNotification.tsx
+++ b/src/domain/hanke/hankeUsers/UserDeleteNotification.tsx
@@ -1,0 +1,24 @@
+import { Notification } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+
+export default function UserDeleteNotification({
+  onClose,
+}: Readonly<{
+  onClose: () => void;
+}>) {
+  const { t } = useTranslation();
+  return (
+    <Notification
+      position="top-right"
+      dismissible
+      autoClose
+      autoCloseDuration={4000}
+      type="success"
+      label={t('hankeUsers:notifications:userDeletedLabel')}
+      closeButtonLabelText={t('common:components:notification:closeButtonLabelText')}
+      onClose={onClose}
+    >
+      {t('hankeUsers:notifications:userDeletedText')}
+    </Notification>
+  );
+}

--- a/src/domain/hanke/hankeUsers/hankeUser.ts
+++ b/src/domain/hanke/hankeUsers/hankeUser.ts
@@ -1,3 +1,5 @@
+import { AlluStatusStrings } from '../../application/types/application';
+
 export enum AccessRightLevel {
   KAIKKI_OIKEUDET = 'KAIKKI_OIKEUDET',
   KAIKKIEN_MUOKKAUS = 'KAIKKIEN_MUOKKAUS',
@@ -29,6 +31,7 @@ export enum Rights {
   MODIFY_APPLICATION_PERMISSIONS = 'MODIFY_APPLICATION_PERMISSIONS',
   RESEND_INVITATION = 'RESEND_INVITATION',
   MODIFY_USER = 'MODIFY_USER',
+  DELETE_USER = 'DELETE_USER',
 }
 
 export type UserRights = Array<keyof typeof Rights>;
@@ -47,4 +50,16 @@ export type IdentificationResponse = {
   kayttajaId: string;
   hankeTunnus: string;
   hankeNimi: string;
+};
+
+type HakemusInfo = {
+  nimi: string;
+  applicationIdentifier: string;
+  alluStatus: AlluStatusStrings | null;
+};
+
+export type DeleteInfo = {
+  activeHakemukset: HakemusInfo[];
+  draftHakemukset: HakemusInfo[];
+  onlyOmistajanYhteyshenkilo: boolean;
 };

--- a/src/domain/hanke/hankeUsers/hankeUsersApi.ts
+++ b/src/domain/hanke/hankeUsers/hankeUsersApi.ts
@@ -1,5 +1,11 @@
 import api from '../../api/api';
-import { HankeUser, IdentificationResponse, SignedInUser, SignedInUserByHanke } from './hankeUser';
+import {
+  DeleteInfo,
+  HankeUser,
+  IdentificationResponse,
+  SignedInUser,
+  SignedInUserByHanke,
+} from './hankeUser';
 import { Yhteyshenkilo, YhteyshenkiloWithoutName } from '../edit/types';
 
 export async function createHankeUser({
@@ -78,4 +84,13 @@ export async function identifyUser(id: string) {
 export async function resendInvitation(kayttajaId: string) {
   await api.post(`kayttajat/${kayttajaId}/kutsu`);
   return kayttajaId;
+}
+
+export async function getUserDeleteInfo(kayttajaId?: string | null) {
+  const { data } = await api.get<DeleteInfo>(`kayttajat/${kayttajaId}/deleteInfo`);
+  return data;
+}
+
+export async function deleteUser(kayttajaId?: string) {
+  await api.delete(`kayttajat/${kayttajaId}`);
 }

--- a/src/domain/hanke/hankeUsers/hooks/useDeleteInfo.ts
+++ b/src/domain/hanke/hankeUsers/hooks/useDeleteInfo.ts
@@ -1,0 +1,9 @@
+import { useQuery } from 'react-query';
+import { DeleteInfo } from '../hankeUser';
+import { getUserDeleteInfo } from '../hankeUsersApi';
+
+export function useDeleteInfo(id?: string | null) {
+  return useQuery<DeleteInfo>(['deleteInfo', id], () => getUserDeleteInfo(id), {
+    enabled: Boolean(id),
+  });
+}

--- a/src/domain/hanke/hankeUsers/hooks/useUserDelete.tsx
+++ b/src/domain/hanke/hankeUsers/hooks/useUserDelete.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { useDeleteInfo } from './useDeleteInfo';
+import { HankeUser } from '../hankeUser';
+
+export function useUserDelete() {
+  const [userToDelete, setUserToDelete] = useState<HankeUser | null>(null);
+  const queryResult = useDeleteInfo(userToDelete?.id);
+
+  function setDeletedUser(user: HankeUser) {
+    setUserToDelete(user);
+  }
+
+  function resetUserToDelete() {
+    setUserToDelete(null);
+  }
+
+  return {
+    deleteInfoQueryResult: queryResult,
+    userToDelete,
+    setDeletedUser,
+    resetUserToDelete,
+  };
+}

--- a/src/domain/hanke/hankeUsers/utils.ts
+++ b/src/domain/hanke/hankeUsers/utils.ts
@@ -1,4 +1,4 @@
-import { HankeUser } from './hankeUser';
+import { HankeUser, SignedInUser } from './hankeUser';
 import { HankeYhteyshenkilo } from '../../types/hanke';
 
 export function mapHankeUserToHankeYhteyshenkilo({
@@ -37,3 +37,15 @@ export const userRoleSorter = (a: string, b: string) => {
     return indexA - indexB;
   }
 };
+
+export function showUserDeleteButton(
+  user: HankeUser,
+  hankeUsers?: HankeUser[],
+  signedInUser?: SignedInUser,
+) {
+  const isOnlyWithAllRights =
+    user.kayttooikeustaso === 'KAIKKI_OIKEUDET' &&
+    hankeUsers?.filter((hankeUser) => hankeUser.kayttooikeustaso === 'KAIKKI_OIKEUDET').length ===
+      1;
+  return Boolean(signedInUser?.kayttooikeudet.includes('DELETE_USER') && !isOnlyWithAllRights);
+}

--- a/src/domain/mocks/data/users-data.json
+++ b/src/domain/mocks/data/users-data.json
@@ -22,7 +22,7 @@
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KAIKKIEN_MUOKKAUS",
     "roolit": [
-      "OMISTAJA"
+      "RAKENNUTTAJA"
     ],
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2",
@@ -50,8 +50,7 @@
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KAIKKI_OIKEUDET",
     "roolit": [
-      "TOTEUTTAJA",
-      "OMISTAJA"
+      "TOTEUTTAJA"
     ],
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2",
@@ -65,7 +64,7 @@
     "puhelinnumero": "0401234567",
     "kayttooikeustaso": "KATSELUOIKEUS",
     "roolit": [
-      "TOTEUTTAJA"
+      "OMISTAJA"
     ],
     "tunnistautunut": false,
     "hankeTunnus": "HAI22-2",

--- a/src/domain/mocks/data/users.ts
+++ b/src/domain/mocks/data/users.ts
@@ -20,6 +20,10 @@ function mapToHankeUser(user: (typeof users)[0]): HankeUser {
   };
 }
 
+export async function reset() {
+  users = [...usersData];
+}
+
 export async function read(id: string): Promise<HankeUser | undefined> {
   return users.map(mapToHankeUser).find((user) => user.id === id);
 }
@@ -80,4 +84,12 @@ export async function update(
     return user.id === updatedUser?.id ? { ...updatedUser, hankeTunnus } : user;
   });
   return updatedUser;
+}
+
+export async function remove(userId: string) {
+  const userToRemove = await read(userId);
+  if (!userToRemove) {
+    throw new ApiError(`No user with id ${userId}`, 404);
+  }
+  users = users.filter((user) => user.id !== userToRemove.id);
 }

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -5,7 +5,7 @@ import * as hankkeetDB from './data/hankkeet';
 import * as hakemuksetDB from './data/hakemukset';
 import * as usersDB from './data/users';
 import ApiError from './apiError';
-import { IdentificationResponse, SignedInUser } from '../hanke/hankeUsers/hankeUser';
+import { DeleteInfo, IdentificationResponse, SignedInUser } from '../hanke/hankeUsers/hankeUser';
 import { Yhteyshenkilo, YhteyshenkiloWithoutName } from '../hanke/edit/types';
 import { NewJohtoselvitysData } from '../application/types/application';
 import { defaultJohtoselvitysData } from './data/defaultJohtoselvitysData';
@@ -277,6 +277,7 @@ export const handlers = [
           'MODIFY_APPLICATION_PERMISSIONS',
           'RESEND_INVITATION',
           'MODIFY_USER',
+          'DELETE_USER',
         ],
       }),
     );
@@ -301,6 +302,89 @@ export const handlers = [
 
   rest.post(`${apiUrl}/kayttajat/:kayttajaId/kutsu`, async (req, res, ctx) => {
     return res(ctx.delay(), ctx.status(204));
+  }),
+
+  rest.get(`${apiUrl}/kayttajat/:id/deleteInfo`, async (req, res, ctx) => {
+    const { id } = req.params;
+    if (id === '3fa85f64-5717-4562-b3fc-2c963f66afa7') {
+      return res(
+        ctx.delay(),
+        ctx.status(200),
+        ctx.json<DeleteInfo>({
+          activeHakemukset: [
+            { nimi: 'Hakemus 1', alluStatus: 'PENDING', applicationIdentifier: 'JS2300001' },
+            { nimi: 'Hakemus 2', alluStatus: 'HANDLING', applicationIdentifier: 'JS2300002' },
+          ],
+          draftHakemukset: [],
+          onlyOmistajanYhteyshenkilo: false,
+        }),
+      );
+    }
+    if (id === '3fa85f64-5717-4562-b3fc-2c963f66afa8') {
+      return res(
+        ctx.delay(),
+        ctx.status(200),
+        ctx.json<DeleteInfo>({
+          activeHakemukset: [
+            { nimi: 'Hakemus 1', alluStatus: 'PENDING', applicationIdentifier: 'JS2300001' },
+            { nimi: 'Hakemus 3', alluStatus: 'PENDING', applicationIdentifier: 'JS2300003' },
+          ],
+          draftHakemukset: [],
+          onlyOmistajanYhteyshenkilo: false,
+        }),
+      );
+    }
+    if (id === '3fa85f64-5717-4562-b3fc-2c963f66afa9') {
+      return res(
+        ctx.delay(),
+        ctx.status(200),
+        ctx.json<DeleteInfo>({
+          activeHakemukset: [],
+          draftHakemukset: [
+            { nimi: 'Hakemus 4', alluStatus: null, applicationIdentifier: 'JS2300004' },
+            { nimi: 'Hakemus 5', alluStatus: null, applicationIdentifier: 'JS2300005' },
+          ],
+          onlyOmistajanYhteyshenkilo: false,
+        }),
+      );
+    }
+    if (id === '3fa85f64-5717-4562-b3fc-2c963f66afb1') {
+      return res(
+        ctx.delay(),
+        ctx.status(200),
+        ctx.json<DeleteInfo>({
+          activeHakemukset: [],
+          draftHakemukset: [],
+          onlyOmistajanYhteyshenkilo: true,
+        }),
+      );
+    }
+    return res(
+      ctx.delay(),
+      ctx.status(200),
+      ctx.json<DeleteInfo>({
+        activeHakemukset: [],
+        draftHakemukset: [],
+        onlyOmistajanYhteyshenkilo: false,
+      }),
+    );
+  }),
+
+  rest.delete(`${apiUrl}/kayttajat/:id`, async (req, res, ctx) => {
+    const { id } = req.params;
+    try {
+      await usersDB.remove(id as string);
+      return res(ctx.status(204));
+    } catch (error) {
+      const { status, message } = error as ApiError;
+      return res(
+        ctx.status(status),
+        ctx.json({
+          errorMessage: message,
+          errorCode: 'HAI1001',
+        }),
+      );
+    }
   }),
 
   rest.get(`${apiUrl}/hakemukset/:id/liitteet`, async (req, res, ctx) => {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -923,11 +923,14 @@
       "invitationSentSuccessLabel": "Kutsulinkki lähetetty",
       "invitationSentSuccessText": "Kutsulinkki lähetetty osoitteeseen {{email}}.",
       "invitationSentErrorLabel": "Virhe linkin lähettämisessä",
-      "invitationSentErrorText": "<0>Kutsulinkin lähettämisessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>"
+      "invitationSentErrorText": "<0>Kutsulinkin lähettämisessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>",
+      "userDeletedLabel": "Käyttäjä poistettu",
+      "userDeletedText": "Käyttäjä poistettiin onnistuneesti"
     },
     "buttons": {
       "resendInvitation": "Lähetä kutsulinkki uudelleen",
-      "edit": "Muokkaa tietoja"
+      "edit": "Muokkaa tietoja",
+      "delete": "Poista käyttäjä"
     },
     "labels": {
       "ownInformation": "Omat käyttäjätietosi",
@@ -936,6 +939,19 @@
       "invitationSent": "Kutsulinkki lähetetty {{date}}",
       "invitationSentLong": "Kutsulinkki Haitattomaan lähetetty {{date}}",
       "userMenu": "Käyttäjävalikko"
+    },
+    "deleteDialog": {
+      "title": {
+        "canDelete": "Poista käyttäjä hankkeelta",
+        "cannotDelete": "Käyttäjää ei voi poistaa"
+      },
+      "content": {
+        "onlyOmistajanYhteyshenkilo": "Käyttäjä on hankkeen omistajan ainut yhteyshenkilö eikä käyttäjää voida siksi poistaa. Lisää ensin hankkeen omistajalle toinen yhteyshenkilö ja palaa sitten poistamaan haluamasi käyttäjä.",
+        "activeHakemuksetPending": "Käyttäjää ei voida poistaa, sillä hänet on lisätty seuraaville hakemuksille: {{hakemukset}}. Voit perua hakemuksen ja tehdä uuden.",
+        "activeHakemuksetHandling": "Käyttäjää ei voida poistaa, sillä hänet on lisätty seuraaville hakemuksille: {{hakemukset}}. Poista käyttäjä hakemukselta tekemällä hakemukseen muutosilmoitus, jossa korvaat käyttäjän toisella. Sen jälkeen voit poistaa käyttäjän käyttäjähallinnassa.",
+        "draftHakemukset": "Käyttäjä on lisätty luonnos-tilassa oleville hakemuksille: {{hakemukset}}. Käyttäjän poistaminen poistaa hänen tietonsa myös hakemukselta. Tarkista tarvittaessa, että hakemuksen kaikki pakolliset yhteystiedot on täytetty. Haluatko varmasti poistaa käyttäjän?",
+        "confirmText": "Käyttäjän yhteystiedot poistetaan kaikista hankkeen rooleista. Haluatko varmasti poistaa käyttäjän?"
+      }
     },
     "userIdentified": "Käyttäjä tunnistautunut"
   },

--- a/src/testUtils/render.tsx
+++ b/src/testUtils/render.tsx
@@ -20,6 +20,7 @@ const AllTheProviders = ({ children }: Props) => {
     defaultOptions: {
       queries: {
         retryDelay: 0,
+        retry: false,
       },
     },
   });


### PR DESCRIPTION
# Description

Added delete buttons to user management view and user edit view.

When clicking the delete button, it is checked from backend if user can be deleted. User who has active hakemuksia or who is the only yhteyshenkilö of omistaja cannot be deleted. Dialog showing the delete information is opened and if user can be deleted there are buttons for confirming and cancelling. Clicking the confirm button deletes the user and a notification is shown.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2391

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Currently as creating johtoselvitys is broken, the best way for testing different scenarios is to use `yarn start-msw` to use mocking (getting delete info for first few users of HAI22-2 hanke return info for different scenarios). Real backend can be used to test at least deleting user who has no hakemuksia.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
