### PR TITLE
HAI-2254 Make it possible to select hanke users as yhteyshenkilo for yhteystieto in johtoselvitys form

### DIFF
--- a/src/common/components/dropdown/Dropdown.tsx
+++ b/src/common/components/dropdown/Dropdown.tsx
@@ -52,6 +52,7 @@ const Dropdown: React.FC<React.PropsWithChildren<PropTypes>> = ({
         name={name}
         control={control}
         rules={rules}
+        defaultValue={defaultValue}
         render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => {
           return (
             <Select

--- a/src/common/components/dropdown/DropdownMultiselect.tsx
+++ b/src/common/components/dropdown/DropdownMultiselect.tsx
@@ -22,7 +22,8 @@ type PropTypes<T> = {
   tooltip?: TooltipProps;
   icon?: ReactNode;
   clearable?: boolean;
-  mapValueToLabel: (value: T | null) => string;
+  mapValueToLabel: (value: T) => string;
+  transformValue?: (value: T) => T;
 };
 
 function DropdownMultiselect<T>({
@@ -38,6 +39,7 @@ function DropdownMultiselect<T>({
   icon,
   clearable,
   mapValueToLabel,
+  transformValue,
 }: Readonly<PropTypes<T>>) {
   const { t } = useTranslation();
   const { control } = useFormContext();
@@ -68,7 +70,7 @@ function DropdownMultiselect<T>({
               invalid={invalid}
               defaultValue={defaultValue}
               value={value?.map((v: T) => ({
-                value: v,
+                value: transformValue ? transformValue(v) : v,
                 label: mapValueToLabel(v),
               }))}
               onChange={(option: Option<T>[]) => onChange(option.map((o) => o.value))}

--- a/src/common/components/textInput/TextInput.tsx
+++ b/src/common/components/textInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { TextInput as HdsTextInput } from 'hds-react';
 import { useTranslation } from 'react-i18next';
@@ -18,6 +18,7 @@ type PropTypes = {
   helperText?: string;
   shouldUnregister?: boolean;
   className?: string;
+  style?: CSSProperties;
   autoComplete?: string;
   defaultValue?: string;
 };
@@ -34,6 +35,7 @@ const TextInput: React.FC<React.PropsWithChildren<PropTypes>> = ({
   helperText,
   shouldUnregister,
   className,
+  style,
   autoComplete,
   defaultValue = '',
 }) => {
@@ -50,6 +52,7 @@ const TextInput: React.FC<React.PropsWithChildren<PropTypes>> = ({
         <HdsTextInput
           id={name}
           className={className}
+          style={style}
           label={label || t(`hankeForm:labels:${name}`)}
           value={value || ''}
           maxLength={maxLength}

--- a/src/domain/application/components/BasicInformationSummary.tsx
+++ b/src/domain/application/components/BasicInformationSummary.tsx
@@ -9,11 +9,12 @@ import {
 import { JohtoselvitysFormValues } from '../../johtoselvitys/types';
 import { ContactSummary } from './ContactsSummary';
 import { Contact } from '../types/application';
+import { useFeatureFlags } from '../../../common/components/featureFlags/FeatureFlagsContext';
 
 function findOrderer(formData: JohtoselvitysFormValues): Contact | null {
   const customerWithContacts = find(formData.applicationData, (value) => {
     if (typeof value === 'object' && value !== null && 'contacts' in value) {
-      return value.contacts[0]?.orderer;
+      return value.contacts[0]?.orderer || false;
     }
     return false;
   });
@@ -35,6 +36,7 @@ type Props = {
 
 const BasicInformationSummary: React.FC<Props> = ({ formData, children }) => {
   const { t } = useTranslation();
+  const features = useFeatureFlags();
 
   const {
     name,
@@ -76,8 +78,12 @@ const BasicInformationSummary: React.FC<Props> = ({ formData, children }) => {
       <SectionItemContent>
         <p style={{ whiteSpace: 'pre-wrap' }}>{workDescription}</p>
       </SectionItemContent>
-      <SectionItemTitle>{t('form:labels:omatTiedot')}</SectionItemTitle>
-      <SectionItemContent>{orderer && <ContactSummary contact={orderer} />}</SectionItemContent>
+      {!features.accessRights && (
+        <>
+          <SectionItemTitle>{t('form:labels:omatTiedot')}</SectionItemTitle>
+          <SectionItemContent>{orderer && <ContactSummary contact={orderer} />}</SectionItemContent>
+        </>
+      )}
       {children}
     </FormSummarySection>
   );

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -34,6 +34,20 @@ export async function saveApplication(data: Application) {
   return response.data;
 }
 
+export async function saveHakemus({
+  data,
+  convertFormStateToUpdateData,
+}: {
+  data: Application;
+  convertFormStateToUpdateData: (data: Application) => unknown;
+}) {
+  const response = data.id
+    ? await api.put<Application>(`/hakemukset/${data.id}`, convertFormStateToUpdateData(data))
+    : await api.post<Application>('/hakemukset', data);
+
+  return response.data;
+}
+
 /**
  * Send application to Allu
  */

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -10,6 +10,7 @@ import {
   HANKE_CONTACT_TYPE,
   HankeContactTypeKey,
   HankeMuuTaho,
+  HankeYhteyshenkilo,
 } from '../../types/hanke';
 import Text from '../../../common/components/text/Text';
 import { useFormPage } from './hooks/useFormPage';
@@ -48,6 +49,10 @@ function getEmptyOtherContact(): HankeMuuTaho {
   };
 }
 
+function mapHankeYhteyshenkiloToLabel(yhteyshenkilo: HankeYhteyshenkilo) {
+  return `${yhteyshenkilo.etunimi} ${yhteyshenkilo.sukunimi} (${yhteyshenkilo.sahkoposti})`;
+}
+
 const ContactFields: React.FC<
   Readonly<{
     contactType: HankeContactTypeKey;
@@ -56,7 +61,7 @@ const ContactFields: React.FC<
   }>
 > = ({ contactType, index, hankeUsers }) => {
   const { t } = useTranslation();
-  const { watch, setValue, getValues } = useFormContext();
+  const { watch, setValue } = useFormContext();
   const selectedContactType = watch(`${contactType}.${index}.tyyppi`);
   const registryKeyInputDisabled = selectedContactType === CONTACT_TYYPPI.YKSITYISHENKILO;
 
@@ -107,8 +112,9 @@ const ContactFields: React.FC<
       </ResponsiveGrid>
       <ContactPersonSelect
         name={`${contactType}.${index}.${CONTACT_FORMFIELD.YHTEYSHENKILOT}`}
-        defaultValue={getValues(`${contactType}.${index}.${CONTACT_FORMFIELD.YHTEYSHENKILOT}`)}
         hankeUsers={hankeUsers}
+        mapHankeUserToValue={mapHankeUserToHankeYhteyshenkilo}
+        mapValueToLabel={mapHankeYhteyshenkiloToLabel}
       />
     </>
   );
@@ -368,10 +374,9 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
                 </ResponsiveGrid>
                 <ContactPersonSelect
                   name={`${fieldPath}.${CONTACT_FORMFIELD.YHTEYSHENKILOT}`}
-                  defaultValue={getValues(
-                    `${FORMFIELD.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.YHTEYSHENKILOT}`,
-                  )}
                   hankeUsers={hankeUsers}
+                  mapHankeUserToValue={mapHankeUserToHankeYhteyshenkilo}
+                  mapValueToLabel={mapHankeYhteyshenkiloToLabel}
                 />
               </Fieldset>
             </FormContact>

--- a/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
+++ b/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
@@ -1,45 +1,45 @@
 import { useTranslation } from 'react-i18next';
 import { IconUser } from 'hds-react';
 import { HankeUser } from './hankeUser';
-import { HankeYhteyshenkilo } from '../../types/hanke';
-import { mapHankeUserToHankeYhteyshenkilo } from './utils';
 import DropdownMultiselect from '../../../common/components/dropdown/DropdownMultiselect';
 
 /**
  * Combobox component for selecting hanke user as contact person (yhteyshenkilö) for a contact (yhteystieto)
  */
-function ContactPersonSelect({
+function ContactPersonSelect<T>({
   name,
-  defaultValue,
   hankeUsers,
+  mapHankeUserToValue,
+  mapValueToLabel,
+  transformValue,
 }: Readonly<{
   name: string;
-  defaultValue?: HankeYhteyshenkilo[];
   hankeUsers?: HankeUser[];
+  mapHankeUserToValue: (user: HankeUser) => T;
+  mapValueToLabel: (value: T) => string;
+  transformValue?: (value: T) => T;
 }>) {
   const { t } = useTranslation();
 
-  function mapUserToLabel(user: HankeUser | HankeYhteyshenkilo | null) {
-    return user !== null ? `${user.etunimi} ${user.sukunimi} (${user.sahkoposti})` : '';
+  function mapHankeUserToLabel(user: HankeUser): string {
+    return `${user.etunimi} ${user.sukunimi} (${user.sahkoposti})`;
   }
 
   return (
-    <DropdownMultiselect<HankeYhteyshenkilo>
+    <DropdownMultiselect<T>
       id={name}
       name={name}
       label={t('form:yhteystiedot:titles:subContacts')}
       helperText={t('form:yhteystiedot:helperTexts:yhteyshenkilo')}
       icon={<IconUser />}
       clearable={false}
-      mapValueToLabel={mapUserToLabel}
-      defaultValue={defaultValue?.map((value: HankeYhteyshenkilo) => ({
-        value,
-        label: mapUserToLabel(value),
-      }))}
+      mapValueToLabel={mapValueToLabel}
+      transformValue={transformValue}
+      defaultValue={[]}
       options={
         hankeUsers?.map((hankeUser) => ({
-          value: mapHankeUserToHankeYhteyshenkilo(hankeUser),
-          label: mapUserToLabel(hankeUser),
+          value: mapHankeUserToValue(hankeUser),
+          label: mapHankeUserToLabel(hankeUser),
         })) ?? []
       }
     />

--- a/src/domain/hanke/hankeUsers/hankeUsersApi.ts
+++ b/src/domain/hanke/hankeUsers/hankeUsersApi.ts
@@ -18,7 +18,7 @@ export async function getUser(id?: string) {
   return data;
 }
 
-export async function getHankeUsers(hankeTunnus?: string) {
+export async function getHankeUsers(hankeTunnus?: string | null) {
   const { data } = await api.get<{ kayttajat: HankeUser[] }>(`hankkeet/${hankeTunnus}/kayttajat`);
   return data.kayttajat;
 }

--- a/src/domain/hanke/hankeUsers/hooks/useHankeUsers.ts
+++ b/src/domain/hanke/hankeUsers/hooks/useHankeUsers.ts
@@ -2,7 +2,7 @@ import { useQuery } from 'react-query';
 import { HankeUser } from '../hankeUser';
 import { getHankeUsers } from '../hankeUsersApi';
 
-export function useHankeUsers(hankeTunnus?: string) {
+export function useHankeUsers(hankeTunnus?: string | null) {
   return useQuery<HankeUser[]>(['hankeUsers', hankeTunnus], () => getHankeUsers(hankeTunnus), {
     enabled: Boolean(hankeTunnus),
   });

--- a/src/domain/johtoselvitys/Contacts.test.tsx
+++ b/src/domain/johtoselvitys/Contacts.test.tsx
@@ -76,7 +76,7 @@ test('Business id field is not disabled if customer type is company or associati
 
 test('Customer fields can be filled with orderer information', async () => {
   const application = applications[0];
-  const orderer = application.applicationData.customerWithContacts.contacts[0];
+  const orderer = application.applicationData.customerWithContacts?.contacts[0];
   const { user } = render(<Form application={application} />);
 
   await user.click(
@@ -84,19 +84,19 @@ test('Customer fields can be filled with orderer information', async () => {
   );
 
   expect(screen.getByTestId('applicationData.customerWithContacts.customer.name')).toHaveValue(
-    `${orderer.firstName} ${orderer.lastName}`,
+    `${orderer!.firstName} ${orderer!.lastName}`,
   );
   expect(screen.getByTestId('applicationData.customerWithContacts.customer.email')).toHaveValue(
-    orderer.email,
+    orderer!.email,
   );
   expect(screen.getByTestId('applicationData.customerWithContacts.customer.phone')).toHaveValue(
-    orderer.phone,
+    orderer!.phone,
   );
 });
 
 test('Contact fields can be filled with orderer information', async () => {
   const application = applications[0];
-  const orderer = application.applicationData.customerWithContacts.contacts[0];
+  const orderer = application.applicationData.customerWithContacts?.contacts[0];
   const { user } = render(<Form application={application} />);
 
   await user.click(
@@ -105,14 +105,14 @@ test('Contact fields can be filled with orderer information', async () => {
 
   expect(
     screen.getByTestId('applicationData.contractorWithContacts.contacts.0.firstName'),
-  ).toHaveValue(orderer.firstName);
+  ).toHaveValue(orderer!.firstName);
   expect(
     screen.getByTestId('applicationData.contractorWithContacts.contacts.0.lastName'),
-  ).toHaveValue(orderer.lastName);
+  ).toHaveValue(orderer!.lastName);
   expect(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.email')).toHaveValue(
-    orderer.email,
+    orderer!.email,
   );
   expect(screen.getByTestId('applicationData.contractorWithContacts.contacts.0.phone')).toHaveValue(
-    orderer.phone,
+    orderer!.phone,
   );
 });

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -17,6 +17,7 @@ import {
   AttachmentType,
 } from '../application/types/application';
 import * as applicationAttachmentsApi from '../application/attachments';
+import { cloneDeep } from 'lodash';
 
 afterEach(cleanup);
 
@@ -484,7 +485,12 @@ test('Should change users own role and its fields correctly', async () => {
 });
 
 test('Should not change anything if selecting the same role again', async () => {
-  const { user } = render(<JohtoselvitysContainer application={applications[0]} />);
+  const testApplication = cloneDeep(applications[0]);
+  testApplication.applicationData.customerWithContacts =
+    application.applicationData.customerWithContacts;
+  testApplication.applicationData.contractorWithContacts =
+    application.applicationData.contractorWithContacts;
+  const { user } = render(<JohtoselvitysContainer application={testApplication} />);
 
   fireEvent.click(screen.getByRole('button', { name: /rooli/i }));
   // Select the role to be Hakija again
@@ -496,7 +502,12 @@ test('Should not change anything if selecting the same role again', async () => 
 });
 
 test('Should not show send button when application has moved to pending state', async () => {
-  const { user } = render(<JohtoselvitysContainer application={applications[1]} />);
+  const testApplication = cloneDeep(applications[1]);
+  testApplication.applicationData.customerWithContacts =
+    application.applicationData.customerWithContacts;
+  testApplication.applicationData.contractorWithContacts =
+    application.applicationData.contractorWithContacts;
+  const { user } = render(<JohtoselvitysContainer application={testApplication} />);
 
   await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
 
@@ -505,7 +516,12 @@ test('Should not show send button when application has moved to pending state', 
 });
 
 test('Should show send button when application is edited in draft state', async () => {
-  const { user } = render(<JohtoselvitysContainer application={applications[0]} />);
+  const testApplication = cloneDeep(applications[0]);
+  testApplication.applicationData.customerWithContacts =
+    application.applicationData.customerWithContacts;
+  testApplication.applicationData.contractorWithContacts =
+    application.applicationData.contractorWithContacts;
+  const { user } = render(<JohtoselvitysContainer application={testApplication} />);
 
   await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
 
@@ -686,7 +702,12 @@ test('Should be able to upload attachments', async () => {
     .spyOn(applicationAttachmentsApi, 'uploadAttachment')
     .mockImplementation(uploadAttachmentMock);
   initFileGetResponse([]);
-  const { user } = render(<JohtoselvitysContainer application={applications[0]} />);
+  const testApplication = cloneDeep(applications[0]);
+  testApplication.applicationData.customerWithContacts =
+    application.applicationData.customerWithContacts;
+  testApplication.applicationData.contractorWithContacts =
+    application.applicationData.contractorWithContacts;
+  const { user } = render(<JohtoselvitysContainer application={testApplication} />);
   await user.click(screen.getByRole('button', { name: /liitteet/i }));
   const fileUpload = screen.getByLabelText('Raahaa tiedostot tänne');
   user.upload(fileUpload, [
@@ -721,7 +742,12 @@ test('Should be able to delete attachments', async () => {
       attachmentType: 'MUU',
     },
   ]);
-  const { user } = render(<JohtoselvitysContainer application={applications[0]} />);
+  const testApplication = cloneDeep(applications[0]);
+  testApplication.applicationData.customerWithContacts =
+    application.applicationData.customerWithContacts;
+  testApplication.applicationData.contractorWithContacts =
+    application.applicationData.contractorWithContacts;
+  const { user } = render(<JohtoselvitysContainer application={testApplication} />);
   await user.click(screen.getByRole('button', { name: /liitteet/i }));
 
   const { getAllByRole } = within(screen.getByTestId('file-upload-list'));
@@ -765,7 +791,12 @@ test('Should list existing attachments in the attachments page and in summary pa
       attachmentType: 'MUU',
     },
   ]);
-  const { user } = render(<JohtoselvitysContainer application={applications[0]} />);
+  const testApplication = cloneDeep(applications[0]);
+  testApplication.applicationData.customerWithContacts =
+    application.applicationData.customerWithContacts;
+  testApplication.applicationData.contractorWithContacts =
+    application.applicationData.contractorWithContacts;
+  const { user } = render(<JohtoselvitysContainer application={testApplication} />);
   await user.click(screen.getByRole('button', { name: /liitteet/i }));
 
   const { getAllByRole } = within(screen.getByTestId('file-upload-list'));
@@ -794,7 +825,11 @@ test('Summary should show attachments and they are downloadable', async () => {
     .spyOn(applicationAttachmentsApi, 'getAttachmentFile')
     .mockImplementation(jest.fn());
 
-  const testApplication = applications[0];
+  const testApplication = cloneDeep(applications[0]);
+  testApplication.applicationData.customerWithContacts =
+    application.applicationData.customerWithContacts;
+  testApplication.applicationData.contractorWithContacts =
+    application.applicationData.contractorWithContacts;
   initFileGetResponse([ATTACHMENT_META]);
 
   const { user } = render(<JohtoselvitysContainer application={testApplication} />);

--- a/src/domain/johtoselvitys_new/utils.ts
+++ b/src/domain/johtoselvitys_new/utils.ts
@@ -6,9 +6,11 @@ import {
   Application,
   ApplicationArea,
   ApplicationGeometry,
+  ApplicationUpdateCustomerWithContacts,
   CustomerType,
   isCustomerWithContacts,
   JohtoselvitysData,
+  JohtoselvitysUpdateData,
 } from '../application/types/application';
 import { JohtoselvitysArea, JohtoselvitysFormValues } from './types';
 
@@ -45,13 +47,15 @@ export function getAreaGeometries(areas: JohtoselvitysArea[]) {
  * Make sure that each areas geometry coordinates are updated to
  * latest OpenLayers feature coordinates.
  */
-export function convertFormStateToApplicationData(formState: JohtoselvitysFormValues): Application {
+export function convertFormStateToJohtoselvitysUpdateData(
+  formState: JohtoselvitysFormValues,
+): JohtoselvitysUpdateData {
   // eslint-disable-next-line no-param-reassign
   delete formState.geometriesChanged;
   // eslint-disable-next-line no-param-reassign
   delete formState.selfIntersectingPolygon;
 
-  const data: Application = cloneDeep(formState);
+  const applicationData: JohtoselvitysUpdateData = cloneDeep(formState.applicationData);
 
   const updatedAreas: ApplicationArea[] = formState.applicationData.areas.map(
     function mapToApplicationArea({ geometry, feature }): ApplicationArea {
@@ -66,9 +70,22 @@ export function convertFormStateToApplicationData(formState: JohtoselvitysFormVa
     },
   );
 
-  data.applicationData.areas = updatedAreas;
+  applicationData.areas = updatedAreas;
 
-  return data;
+  applicationData.customerWithContacts = ApplicationUpdateCustomerWithContacts.Create(
+    formState.applicationData.customerWithContacts,
+  );
+  applicationData.contractorWithContacts = ApplicationUpdateCustomerWithContacts.Create(
+    formState.applicationData.contractorWithContacts,
+  );
+  applicationData.propertyDeveloperWithContacts = ApplicationUpdateCustomerWithContacts.Create(
+    formState.applicationData.propertyDeveloperWithContacts,
+  );
+  applicationData.representativeWithContacts = ApplicationUpdateCustomerWithContacts.Create(
+    formState.applicationData.representativeWithContacts,
+  );
+
+  return applicationData;
 }
 
 export function convertApplicationDataToFormState(

--- a/src/domain/johtoselvitys_new/validationSchema.ts
+++ b/src/domain/johtoselvitys_new/validationSchema.ts
@@ -19,12 +19,12 @@ const contactSchema = yup
     lastName: yup.string().trim().required(),
     email: yup.string().trim().email().max(100).required(),
     phone: yup.string().trim().max(20).required(),
-    orderer: yup.boolean().defined(),
   })
   .nullable()
   .required();
 
-const customerSchema = contactSchema.omit(['firstName', 'lastName', 'orderer']).shape({
+const customerSchema = contactSchema.omit(['firstName', 'lastName']).shape({
+  yhteystietoId: yup.string().nullable(),
   name: yup.string().trim().required(),
   type: yup.mixed<ContactType>().nullable().required(),
   registryKey: yup // business id i.e. Y-tunnus
@@ -37,15 +37,14 @@ const customerSchema = contactSchema.omit(['firstName', 'lastName', 'orderer']).
         schema.test('is-business-id', 'Is not valid business id', isValidBusinessId),
       otherwise: (schema) => schema,
     }),
-  country: yup.string().defined(),
-  ovt: yup.string().defined().nullable(),
-  invoicingOperator: yup.string().defined().nullable(),
-  sapCustomerNumber: yup.string().defined().nullable(),
 });
 
 const customerWithContactsSchema = yup.object({
-  customer: customerSchema.required(),
-  contacts: yup.array(contactSchema).defined(),
+  customer: customerSchema,
+  contacts: yup
+    .array(contactSchema)
+    .transform((value) => (value === null ? [] : value))
+    .defined(),
 });
 
 const areaSchema = yup.object({

--- a/src/domain/mocks/data/defaultJohtoselvitysData.ts
+++ b/src/domain/mocks/data/defaultJohtoselvitysData.ts
@@ -14,48 +14,6 @@ export const defaultJohtoselvitysData = {
   postalAddress: { streetAddress: { streetName: '' }, city: '', postalCode: '' },
   representativeWithContacts: null,
   propertyDeveloperWithContacts: null,
-  customerWithContacts: {
-    customer: {
-      type: null,
-      name: '',
-      country: 'FI',
-      email: '',
-      phone: '',
-      registryKey: null,
-      ovt: null,
-      invoicingOperator: null,
-      sapCustomerNumber: null,
-    },
-    contacts: [
-      {
-        firstName: '',
-        lastName: '',
-        email: '',
-        phone: '',
-        orderer: true,
-      },
-    ],
-  },
-  contractorWithContacts: {
-    customer: {
-      type: null,
-      name: '',
-      country: 'FI',
-      email: '',
-      phone: '',
-      registryKey: null,
-      ovt: null,
-      invoicingOperator: null,
-      sapCustomerNumber: null,
-    },
-    contacts: [
-      {
-        firstName: '',
-        lastName: '',
-        email: '',
-        phone: '',
-        orderer: false,
-      },
-    ],
-  },
+  customerWithContacts: null,
+  contractorWithContacts: null,
 };

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -24,11 +24,12 @@ const hakemukset: Application[] = [
         },
         contacts: [
           {
-            email: 'matti@test.com',
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            email: 'matti.meikalainen@test.com',
             firstName: 'Matti',
             lastName: 'Meikäläinen',
             orderer: true,
-            phone: '0000000000',
+            phone: '0401234567',
           },
         ],
       },
@@ -71,9 +72,10 @@ const hakemukset: Application[] = [
         },
         contacts: [
           {
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afb1',
             email: 'tauno@test.com',
             firstName: 'Tauno',
-            lastName: 'Työmies',
+            lastName: 'Testinen',
             orderer: false,
             phone: '0401234567',
           },
@@ -116,11 +118,12 @@ const hakemukset: Application[] = [
         },
         contacts: [
           {
-            email: 'matti@test.com',
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            email: 'matti.meikalainen@test.com',
             firstName: 'Matti',
             lastName: 'Meikäläinen',
             orderer: true,
-            phone: '0000000000',
+            phone: '0401234567',
           },
         ],
       },
@@ -210,11 +213,12 @@ const hakemukset: Application[] = [
         },
         contacts: [
           {
-            email: 'matti@test.com',
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            email: 'matti.meikalainen@test.com',
             firstName: 'Matti',
             lastName: 'Meikäläinen',
             orderer: true,
-            phone: '0000000000',
+            phone: '0401234567',
           },
         ],
       },
@@ -236,11 +240,12 @@ const hakemukset: Application[] = [
         },
         contacts: [
           {
-            email: 'matti@test.com',
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            email: 'matti.meikalainen@test.com',
             firstName: 'Matti',
             lastName: 'Meikäläinen',
-            orderer: false,
-            phone: '0000000000',
+            orderer: true,
+            phone: '0401234567',
           },
         ],
       },
@@ -281,11 +286,12 @@ const hakemukset: Application[] = [
         },
         contacts: [
           {
-            email: 'matti@test.com',
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            email: 'matti.meikalainen@test.com',
             firstName: 'Matti',
             lastName: 'Meikäläinen',
             orderer: true,
-            phone: '0000000000',
+            phone: '0401234567',
           },
         ],
       },
@@ -329,11 +335,12 @@ const hakemukset: Application[] = [
         },
         contacts: [
           {
-            email: 'matti@test.com',
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            email: 'matti.meikalainen@test.com',
             firstName: 'Matti',
             lastName: 'Meikäläinen',
-            orderer: false,
-            phone: '0000000000',
+            orderer: true,
+            phone: '0401234567',
           },
         ],
       },

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -1,4 +1,8 @@
-import { Application, HankkeenHakemus } from '../../application/types/application';
+import {
+  Application,
+  HankkeenHakemus,
+  JohtoselvitysUpdateData,
+} from '../../application/types/application';
 import hakemuksetData from './hakemukset-data';
 import { isApplicationPending } from '../../application/utils';
 import ApiError from '../apiError';
@@ -44,12 +48,12 @@ export async function create(data: Application) {
   return newHakemus;
 }
 
-export async function update(id: number, updates: Application) {
-  let hakemus = await read(id);
+export async function update(id: number, updates: JohtoselvitysUpdateData) {
+  const hakemus = await read(id);
   if (!hakemus) {
     throw new Error(`No application with id ${id}`);
   }
-  hakemus = Object.assign(hakemus, updates);
+  hakemus.applicationData = Object.assign(hakemus.applicationData, updates);
   return hakemus;
 }
 

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -7,7 +7,7 @@ import * as usersDB from './data/users';
 import ApiError from './apiError';
 import { IdentificationResponse, SignedInUser } from '../hanke/hankeUsers/hankeUser';
 import { Yhteyshenkilo, YhteyshenkiloWithoutName } from '../hanke/edit/types';
-import { NewJohtoselvitysData } from '../application/types/application';
+import { JohtoselvitysUpdateData, NewJohtoselvitysData } from '../application/types/application';
 import { defaultJohtoselvitysData } from './data/defaultJohtoselvitysData';
 
 const apiUrl = '/api';
@@ -149,7 +149,7 @@ export const handlers = [
 
   rest.put(`${apiUrl}/hakemukset/:id`, async (req, res, ctx) => {
     const { id } = req.params;
-    const reqBody: JohtoselvitysFormValues = await req.json();
+    const reqBody: JohtoselvitysUpdateData = await req.json();
     try {
       const hakemus = await hakemuksetDB.update(Number(id as string), reqBody);
       return res(ctx.status(200), ctx.json(hakemus));


### PR DESCRIPTION
# Description

Added comboboxes to contacts page in johtoselvitys form to select existing hanke users as yhteyshenkilo for hakemus yhteystieto. Creating new user also adds that user as yhteyshenkilo.

Also made a change that johtoselvitys PUT request only sends applicationData instead of the whole hakemus data.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2254

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new johtoselvitys
2. Fill information for first two pages and go to contacts page
3. Add yhteyshenkilö for hakija and työn suorittaja
4. Create new yhteyshenkilö for hakija and check that it is added as yhteyshenkilö
5. Go to summary page
6. Check that johtoselvitys is saved successfully and that yhteyshenkilöt are shown in summary page

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
