### PR TITLE
HAI-2406 Show notification with missing fields required for public hanke in each page of hanke form

### DIFF
--- a/src/domain/forms/MultipageForm.tsx
+++ b/src/domain/forms/MultipageForm.tsx
@@ -1,6 +1,7 @@
 import React, { useReducer } from 'react';
 import { LoadingSpinner, Notification, Stepper, StepState } from 'hds-react';
 import { Box, Flex } from '@chakra-ui/react';
+import { AnyObject, ObjectSchema } from 'yup';
 import styles from './MultipageForm.module.scss';
 import useLocale from '../../common/hooks/useLocale';
 import Text from '../../common/components/text/Text';
@@ -27,6 +28,7 @@ interface FormStep extends StepperStep {
   element: React.ReactNode;
   label: string;
   state: StepState;
+  validationSchema?: ObjectSchema<AnyObject>;
 }
 
 interface Props {
@@ -48,7 +50,7 @@ interface Props {
   isLoading?: boolean;
   isLoadingText?: string;
   /** Function that is called when step is changed */
-  onStepChange?: () => void;
+  onStepChange?: (stepIndex: number) => void;
   onSubmit?: () => void;
   /**
    * Function that is called with a function that changes step and current step index,
@@ -57,6 +59,8 @@ interface Props {
   stepChangeValidator?: (changeStep: () => void, stepIndex: number) => void;
   notificationLabel?: string;
   notificationText?: string;
+  formErrorsNotification?: React.ReactNode;
+  formData?: unknown;
 }
 
 /**
@@ -75,6 +79,8 @@ const MultipageForm: React.FC<Props> = ({
   stepChangeValidator,
   notificationLabel,
   notificationText,
+  formErrorsNotification,
+  formData,
 }) => {
   const locale = useLocale();
 
@@ -90,7 +96,11 @@ const MultipageForm: React.FC<Props> = ({
       window.scrollTo(0, 0);
       dispatch(value);
       if (onStepChange) {
-        onStepChange();
+        onStepChange(
+          value.type === ACTION_TYPE.COMPLETE_STEP
+            ? value.payload.stepIndex + 1
+            : value.payload.stepIndex,
+        );
       }
     }
 
@@ -105,15 +115,21 @@ const MultipageForm: React.FC<Props> = ({
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
     stepIndex: number,
   ) {
-    handleStepChange({ type: ACTION_TYPE.SET_ACTIVE, payload: stepIndex });
+    handleStepChange({ type: ACTION_TYPE.SET_ACTIVE, payload: { stepIndex, formData } });
   }
 
   function handlePrevious() {
-    handleStepChange({ type: ACTION_TYPE.SET_ACTIVE, payload: state.activeStepIndex - 1 });
+    handleStepChange({
+      type: ACTION_TYPE.SET_ACTIVE,
+      payload: { stepIndex: state.activeStepIndex - 1, formData },
+    });
   }
 
   function handleNext() {
-    handleStepChange({ type: ACTION_TYPE.COMPLETE_STEP, payload: state.activeStepIndex });
+    handleStepChange({
+      type: ACTION_TYPE.COMPLETE_STEP,
+      payload: { stepIndex: state.activeStepIndex, formData },
+    });
   }
 
   return (
@@ -131,6 +147,8 @@ const MultipageForm: React.FC<Props> = ({
           {notificationText}
         </Notification>
       )}
+
+      {formErrorsNotification}
 
       <div className={styles.stepper}>
         {isLoading ? (

--- a/src/domain/forms/formStepReducer.ts
+++ b/src/domain/forms/formStepReducer.ts
@@ -6,21 +6,33 @@ export function createStepReducer(totalSteps: number) {
     switch (action.type) {
       case 'completeStep': {
         const activeStepIndex =
-          action.payload === totalSteps - 1 ? totalSteps - 1 : action.payload + 1;
+          action.payload.stepIndex === totalSteps - 1
+            ? totalSteps - 1
+            : action.payload.stepIndex + 1;
         return {
           activeStepIndex,
           steps: state.steps.map((step, index) => {
-            if (index === action.payload && index !== totalSteps - 1) {
+            if (index === action.payload.stepIndex && index !== totalSteps - 1) {
               // current step but not last one
               return {
-                state: StepState.completed,
+                ...step,
+                state:
+                  !step.validationSchema ||
+                  step.validationSchema.isValidSync(action.payload.formData)
+                    ? StepState.completed
+                    : StepState.attention,
                 label: step.label,
               };
             }
-            if (index === action.payload + 1) {
+            if (index === action.payload.stepIndex + 1) {
               // next step
               return {
-                state: StepState.available,
+                ...step,
+                state:
+                  !step.validationSchema ||
+                  step.validationSchema.isValidSync(action.payload.formData)
+                    ? StepState.available
+                    : StepState.attention,
                 label: step.label,
               };
             }
@@ -30,11 +42,23 @@ export function createStepReducer(totalSteps: number) {
       }
       case 'setActive': {
         return {
-          activeStepIndex: action.payload,
+          activeStepIndex: action.payload.stepIndex,
           steps: state.steps.map((step, index) => {
-            if (index === action.payload) {
+            if (index === action.payload.stepIndex) {
               return {
+                ...step,
                 state: StepState.available,
+                label: step.label,
+              };
+            }
+            if (index === state.activeStepIndex) {
+              return {
+                ...step,
+                state: !step.validationSchema
+                  ? StepState.available
+                  : step.validationSchema.isValidSync(action.payload.formData)
+                    ? StepState.completed
+                    : StepState.attention,
                 label: step.label,
               };
             }

--- a/src/domain/forms/formStepReducer.ts
+++ b/src/domain/forms/formStepReducer.ts
@@ -51,12 +51,12 @@ export function createStepReducer(totalSteps: number) {
                 label: step.label,
               };
             }
-            if (index === state.activeStepIndex) {
+            if (index === state.activeStepIndex && index !== totalSteps - 1) {
               return {
                 ...step,
-                state: !step.validationSchema
-                  ? StepState.available
-                  : step.validationSchema.isValidSync(action.payload.formData)
+                state:
+                  !step.validationSchema ||
+                  step.validationSchema.isValidSync(action.payload.formData)
                     ? StepState.completed
                     : StepState.attention,
                 label: step.label,

--- a/src/domain/forms/formStepReducer.ts
+++ b/src/domain/forms/formStepReducer.ts
@@ -21,19 +21,13 @@ export function createStepReducer(totalSteps: number) {
                   step.validationSchema.isValidSync(action.payload.formData)
                     ? StepState.completed
                     : StepState.attention,
-                label: step.label,
               };
             }
             if (index === action.payload.stepIndex + 1) {
               // next step
               return {
                 ...step,
-                state:
-                  !step.validationSchema ||
-                  step.validationSchema.isValidSync(action.payload.formData)
-                    ? StepState.available
-                    : StepState.attention,
-                label: step.label,
+                state: StepState.available,
               };
             }
             return step;
@@ -48,7 +42,6 @@ export function createStepReducer(totalSteps: number) {
               return {
                 ...step,
                 state: StepState.available,
-                label: step.label,
               };
             }
             if (index === state.activeStepIndex && index !== totalSteps - 1) {
@@ -59,7 +52,6 @@ export function createStepReducer(totalSteps: number) {
                   step.validationSchema.isValidSync(action.payload.formData)
                     ? StepState.completed
                     : StepState.attention,
-                label: step.label,
               };
             }
             return step;

--- a/src/domain/forms/hooks/useValidationErrors.ts
+++ b/src/domain/forms/hooks/useValidationErrors.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { AnyObject, ObjectSchema, ValidationError } from 'yup';
-import { isEqual } from 'lodash';
+import { cloneDeep, isEqual } from 'lodash';
 
 /**
  * Validates input data and returns validation errors if validation fails
@@ -11,7 +11,7 @@ export function useValidationErrors<T>(schema: ObjectSchema<AnyObject>, data: T)
 
   useEffect(() => {
     if (!isEqual(ref.current, data)) {
-      ref.current = data;
+      ref.current = cloneDeep(data);
       schema
         .validate(data, { abortEarly: false })
         .then(() => {

--- a/src/domain/forms/types.ts
+++ b/src/domain/forms/types.ts
@@ -1,4 +1,5 @@
 import { StepState } from 'hds-react';
+import { AnyObject, ObjectSchema } from 'yup';
 
 export enum ACTION_TYPE {
   COMPLETE_STEP = 'completeStep',
@@ -8,6 +9,7 @@ export enum ACTION_TYPE {
 export interface StepperStep {
   label: string;
   state: StepState;
+  validationSchema?: ObjectSchema<AnyObject>;
 }
 
 export interface State {
@@ -17,5 +19,5 @@ export interface State {
 
 export interface Action {
   type: ACTION_TYPE;
-  payload: number;
+  payload: { stepIndex: number; formData?: unknown };
 }

--- a/src/domain/hanke/edit/HankeForm.tsx
+++ b/src/domain/hanke/edit/HankeForm.tsx
@@ -177,17 +177,13 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
     {
       element: <HankeFormPerustiedot errors={errors} register={register} formData={formValues} />,
       label: t('hankeForm:perustiedotForm:header'),
-      state: hankePerustiedotPublicSchema.isValidSync(formData)
-        ? StepState.available
-        : StepState.attention,
+      state: StepState.available,
       validationSchema: hankePerustiedotPublicSchema,
     },
     {
       element: <HankeFormAlueet errors={errors} register={register} formData={formValues} />,
       label: t('hankeForm:hankkeenAlueForm:header'),
-      state: hankeAlueetPublicSchema.isValidSync(formData)
-        ? StepState.available
-        : StepState.attention,
+      state: StepState.available,
       validationSchema: hankeAlueetPublicSchema,
     },
     {
@@ -198,9 +194,7 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
     {
       element: <HankeFormYhteystiedot errors={errors} register={register} formData={formValues} />,
       label: t('form:yhteystiedot:header'),
-      state: hankeYhteystiedotPublicSchema.isValidSync(formData)
-        ? StepState.available
-        : StepState.attention,
+      state: StepState.available,
       validationSchema: hankeYhteystiedotPublicSchema,
     },
     {

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -205,7 +205,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
               }
             >
               <Fieldset
-                heading={t('form:yhteystiedot:titles:omistaja')}
+                heading={t('form:yhteystiedot:titles:omistaja', { count: index + 1 })}
                 style={{ paddingTop: 'var(--spacing-s)' }}
               >
                 <ContactFields
@@ -232,7 +232,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
         language={locale}
         headingLevel={3}
         heading={t('form:yhteystiedot:titles:propertyDeveloperInfo')}
-        initiallyOpen={rakennuttajat.length > 0}
+        initiallyOpen={true}
       >
         {rakennuttajat.map((item, index) => {
           return (
@@ -247,7 +247,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
               }
             >
               <Fieldset
-                heading={t('form:yhteystiedot:titles:rakennuttajat')}
+                heading={t('form:yhteystiedot:titles:rakennuttajat', { count: index + 1 })}
                 style={{ paddingTop: 'var(--spacing-s)' }}
               >
                 <ContactFields
@@ -274,7 +274,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
         language={locale}
         headingLevel={3}
         heading={t('form:yhteystiedot:titles:implementerInfo')}
-        initiallyOpen={toteuttajat.length > 0}
+        initiallyOpen={true}
       >
         {toteuttajat.map((item, index) => {
           return (
@@ -289,7 +289,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
               }
             >
               <Fieldset
-                heading={t('form:yhteystiedot:titles:toteuttajat')}
+                heading={t('form:yhteystiedot:titles:toteuttajat', { count: index + 1 })}
                 style={{ paddingTop: 'var(--spacing-s)' }}
               >
                 <ContactFields
@@ -316,7 +316,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
         language={locale}
         headingLevel={3}
         heading={t('form:yhteystiedot:titles:otherInfo')}
-        initiallyOpen={muutTahot.length > 0}
+        initiallyOpen={true}
       >
         {muutTahot.map((item, index) => {
           const fieldPath = `${FORMFIELD.MUUTTAHOT}.${index}`;
@@ -333,7 +333,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
               }
             >
               <Fieldset
-                heading={t('form:yhteystiedot:titles:muut')}
+                heading={t('form:yhteystiedot:titles:muut', { count: index + 1 })}
                 style={{ paddingTop: 'var(--spacing-s)' }}
               >
                 <ResponsiveGrid>

--- a/src/domain/hanke/edit/components/MissingFieldsNotification.tsx
+++ b/src/domain/hanke/edit/components/MissingFieldsNotification.tsx
@@ -1,0 +1,51 @@
+import { FieldPath, UseFormGetValues } from 'react-hook-form';
+import { ValidationError } from 'yup';
+import { useTranslation } from 'react-i18next';
+import { Link, Notification } from 'hds-react';
+import { Box } from '@chakra-ui/react';
+import { HankeDataFormState } from '../types';
+
+export default function HankeFormMissingFieldsNotification({
+  formErrors,
+  getValues,
+}: {
+  formErrors: ValidationError[];
+  getValues: UseFormGetValues<HankeDataFormState>;
+}) {
+  const { t } = useTranslation();
+
+  function mapToErrorListItem(error: ValidationError) {
+    const errorPath = error.path?.replace('[', '.').replace(']', '');
+    // Get parts of the path: for example for path 'alueet.0.meluHaitta' returns ['alueet', '0', 'meluHaitta'],
+    // and for example for 'alueet' just ['alueet']
+    const pathParts = errorPath?.match(/(\w+)/g) || [];
+
+    if (pathParts.length === 1 && pathParts[0] === 'alueet') {
+      pathParts[0] = 'alueet.empty';
+    }
+
+    const linkText =
+      pathParts.length === 1
+        ? t(`hankeForm:missingFields:${pathParts[0]}`)
+        : t(`hankeForm:missingFields:${pathParts[0]}:${pathParts[2]}`, {
+            count: Number(pathParts[1]) + 1,
+            alueName: getValues(`alueet.${pathParts[1]}.nimi` as FieldPath<HankeDataFormState>),
+          });
+
+    return (
+      <li key={errorPath}>
+        <Link href={`#${errorPath}`} disableVisitedStyles>
+          {linkText}
+        </Link>
+      </li>
+    );
+  }
+
+  return (
+    <Notification label={t('hankePortfolio:draftState:labels:missingFields')} type="alert">
+      <Box as="ul" marginLeft="var(--spacing-m)">
+        {formErrors.map(mapToErrorListItem)}
+      </Box>
+    </Notification>
+  );
+}

--- a/src/domain/hanke/edit/hankePublicSchema.ts
+++ b/src/domain/hanke/edit/hankePublicSchema.ts
@@ -8,7 +8,6 @@ import {
   HANKE_POLYHAITTA_KEY,
   HANKE_TARINAHAITTA_KEY,
   HANKE_VAIHE_KEY,
-  HankeGeometria,
 } from '../../types/hanke';
 import { CONTACT_FORMFIELD, FORMFIELD } from './types';
 
@@ -53,8 +52,6 @@ const hankeAlueSchema = yup.object({
   [FORMFIELD.KAISTAPITUUSHAITTA]: yup
     .mixed<HANKE_KAISTAPITUUSHAITTA_KEY>()
     .required(getMessage(HANKE_PAGES.ALUEET)),
-  [FORMFIELD.NIMI]: yup.string().required(getMessage(HANKE_PAGES.ALUEET)),
-  [FORMFIELD.GEOMETRIAT]: yup.mixed<HankeGeometria>().required(getMessage(HANKE_PAGES.ALUEET)),
 });
 
 const yhteystietoSchema = yup.object({
@@ -90,3 +87,19 @@ export const hankePublicSchema = yup.object({
   [FORMFIELD.TOTEUTTAJAT]: yup.array(yhteystietoSchema),
   [FORMFIELD.MUUTTAHOT]: yup.array(yhteystietoSchema.omit([CONTACT_FORMFIELD.TUNNUS])),
 });
+
+export const hankePerustiedotPublicSchema = hankePublicSchema.pick([
+  FORMFIELD.NIMI,
+  FORMFIELD.KUVAUS,
+  FORMFIELD.KATUOSOITE,
+  FORMFIELD.VAIHE,
+]);
+
+export const hankeAlueetPublicSchema = hankePublicSchema.pick([FORMFIELD.HANKEALUEET]);
+
+export const hankeYhteystiedotPublicSchema = hankePublicSchema.pick([
+  FORMFIELD.OMISTAJAT,
+  FORMFIELD.RAKENNUTTAJAT,
+  FORMFIELD.TOTEUTTAJAT,
+  FORMFIELD.MUUTTAHOT,
+]);

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -159,13 +159,17 @@
       "instructions": "Hankkeelle lisättävät tahot saavat sähköpostiinsa linkin, jonka kautta he pystyvät liittymään hankkeeseeen Haitattomassa. Tämän jälkeen he pystyvät tarkastelemaan hanketta ja luomaan hankkeelle hakemuksia.",
       "titles": {
         "omistaja": "Hankkeen omistaja",
+        "omistaja_other": "Hankkeen omistaja {{count}}",
         "omistajatPlural": "Omistajat",
         "omistajaInfo": "Hankkeen omistajan tiedot",
         "rakennuttajat": "Rakennuttaja",
+        "rakennuttajat_other": "Rakennuttaja {{count}}",
         "rakennuttajatPlural": "Rakennuttajat",
         "toteuttajat": "Toteuttaja",
+        "toteuttajat_other": "Toteuttaja {{count}}",
         "toteuttajatPlural": "Toteuttajat",
         "muut": "Muu taho",
+        "muut_other": "Muu taho {{count}}",
         "muutPlural": "Muut tahot",
         "lisaaOmistaja": "Lisää omistaja",
         "lisaaRakennuttaja": "Lisää rakennuttaja",
@@ -525,6 +529,42 @@
       "insertOmaOrganisaatio": "Syötä oma organisaatio",
       "rights": "Käyttöoikeutesi hankkeelle"
     },
+    "missingFields": {
+      "nimi": "$t(hankeForm:labels:nimi)",
+      "vaihe": "$t(hankeForm:labels:vaihe)",
+      "kuvaus": "$t(hankeForm:labels:kuvaus)",
+      "tyomaaKatuosoite": "$t(hankeForm:labels:tyomaaKatuosoite)",
+      "alueet": {
+        "empty": "$t(hankeForm:hankkeenAlueForm:subHeader): Hankealueen piirtäminen",
+        "haittaAlkuPvm": "{{alueName}}: $t(hankeForm:labels:haittaAlkuPvm)",
+        "haittaLoppuPvm": "{{alueName}}: $t(hankeForm:labels:haittaLoppuPvm)",
+        "kaistaHaitta": "{{alueName}}: $t(hankeForm:labels:kaistaHaitta)",
+        "kaistaPituusHaitta": "{{alueName}}: $t(hankeForm:labels:kaistaPituusHaitta)",
+        "meluHaitta": "{{alueName}}: $t(hankeForm:labels:meluHaitta)",
+        "polyHaitta": "{{alueName}}: $t(hankeForm:labels:polyHaitta)",
+        "tarinaHaitta": "{{alueName}}: $t(hankeForm:labels:tarinaHaitta)"
+      },
+      "omistajat": {
+        "nimi": "$t(form:yhteystiedot:titles:omistaja): $t(form:yhteystiedot:labels:nimi)",
+        "email": "$t(form:yhteystiedot:titles:omistaja): $t(form:yhteystiedot:labels:email)",
+        "ytunnus": "$t(form:yhteystiedot:titles:omistaja): $t(form:yhteystiedot:labels:ytunnus)"
+      },
+      "toteuttajat": {
+        "nimi": "$t(form:yhteystiedot:titles:toteuttajat): $t(form:yhteystiedot:labels:nimi)",
+        "email": "$t(form:yhteystiedot:titles:toteuttajat): $t(form:yhteystiedot:labels:email)",
+        "ytunnus": "$t(form:yhteystiedot:titles:toteuttajat): $t(form:yhteystiedot:labels:ytunnus)"
+      },
+      "rakennuttajat": {
+        "nimi": "$t(form:yhteystiedot:titles:rakennuttajat): $t(form:yhteystiedot:labels:nimi)",
+        "email": "$t(form:yhteystiedot:titles:rakennuttajat): $t(form:yhteystiedot:labels:email)",
+        "ytunnus": "$t(form:yhteystiedot:titles:rakennuttajat): $t(form:yhteystiedot:labels:ytunnus)"
+      },
+      "muut": {
+        "nimi": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:nimi)",
+        "email": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:email)",
+        "ytunnus": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:ytunnus)"
+      }
+    },
     "toolTips": {
       "tipOpenLabel": "Ohje",
       "perustiedot": "Hankkeen pakolliset perustiedot tulee täyttää. Mikäli kaikki pakolliset tiedot eivät ole täytettynä, uusi hanke tallentuu Haitattomaan, muttei voi edetä vaikutusten arviointiin. Hankkeen tietojen täydentämistä voi jatkaa myöhemmin avaamalla se hankelistan kautta",
@@ -837,7 +877,9 @@
     },
     "draftState": {
       "labels": {
-        "insufficientPhases": "Hanke on luonnostilassa. Sen näkyvyys muille hankkeille on rajoitettua, eikä sille voi lisätä hakemuksia. Seuraavissa vaiheissa on puuttuvia tietoja:"
+        "draft": "Hanke on luonnostilassa. Sen näkyvyys muille hankkeille on rajoitettua, eikä sille voi lisätä hakemuksia.",
+        "insufficientPhases": "$t(hankePortfolio:draftState:labels:draft) Seuraavissa vaiheissa on puuttuvia tietoja:",
+        "missingFields": "$t(hankePortfolio:draftState:labels:draft) Seuraavat kentät tällä sivulla vaaditaan hankeen julkaisemiseksi:"
       }
     }
   },


### PR DESCRIPTION
# Description

Notification is updated when user fills fields and disappears when all required fields have been filled. Is summary page there is notification about what pages have missing information.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2406

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new hanke
2. Check in perustiedot, alueet and yhteystiedot page that missing fields are shown in notification on top of the form and that they and the notification disappear from each page as the required fields are filled.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
