### PR TITLE
HAI-2302 Show Send button only if the user is one of the contact persons and use new API for sending

### DIFF
--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -57,6 +57,14 @@ export async function sendApplication(applicationId: number) {
 }
 
 /**
+ * Send application to Allu
+ */
+export async function sendApplicationNew(applicationId: number) {
+  const response = await api.post<Application>(`/hakemukset/${applicationId}/laheta`, {});
+  return response.data;
+}
+
+/**
  * Check if application is sent to Allu
  */
 export function isApplicationSent(alluStatus: AlluStatusStrings | null): boolean {

--- a/src/domain/mocks/data/users.ts
+++ b/src/domain/mocks/data/users.ts
@@ -32,6 +32,10 @@ export async function readAll(hankeTunnus: string): Promise<HankeUser[]> {
   return users.filter((user) => user.hankeTunnus === hankeTunnus).map(mapToHankeUser);
 }
 
+export async function readCurrent(): Promise<HankeUser | undefined> {
+  return users.map(mapToHankeUser).find((user) => user.sahkoposti === 'testi@test.com');
+}
+
 async function readFromHanke(hankeTunnus: string, id: string): Promise<HankeUser | undefined> {
   return (await readAll(hankeTunnus)).find((user) => user.id === id);
 }

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -144,6 +144,12 @@ export const handlers = [
       applicationType: 'CABLE_REPORT',
       hankeTunnus: hanke.hankeTunnus!,
     });
+    await usersDB.create(hanke.hankeTunnus!, {
+      etunimi: 'Testi',
+      sukunimi: 'Testinen',
+      sahkoposti: 'testi@test.com',
+      puhelinnumero: '0401234500',
+    });
     return res(ctx.status(200), ctx.json(hakemus));
   }),
 
@@ -165,6 +171,23 @@ export const handlers = [
   }),
 
   rest.post(`${apiUrl}/hakemukset/:id/send-application`, async (req, res, ctx) => {
+    const { id } = req.params;
+    const hakemus = await hakemuksetDB.read(Number(id));
+
+    if (!hakemus) {
+      return res(
+        ctx.status(404),
+        ctx.json({
+          errorMessage: 'Hakemus not found',
+          errorCode: 'HAI1001',
+        }),
+      );
+    }
+
+    return res(ctx.status(200), ctx.json(hakemus));
+  }),
+
+  rest.post(`${apiUrl}/hakemukset/:id/laheta`, async (req, res, ctx) => {
     const { id } = req.params;
     const hakemus = await hakemuksetDB.read(Number(id));
 
@@ -261,10 +284,12 @@ export const handlers = [
       );
     }
 
+    const currentUser = await usersDB.readCurrent();
+
     return res(
       ctx.status(200),
       ctx.json<SignedInUser>({
-        hankeKayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+        hankeKayttajaId: currentUser?.id || '3fa85f64-5717-4562-b3fc-2c963f66afa6',
         kayttooikeustaso: 'KAIKKI_OIKEUDET',
         kayttooikeudet: [
           'VIEW',


### PR DESCRIPTION
# Description

Show Send button only if the user is one of the contact persons and use new API for sending.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2302

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing
With `yarn start-msw` this can be tested by creating a new Johtoselvityshakemus. If you do not add yourself (Testi Testinen) as a contact person the Send button is not shown.


# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
