### PR TITLE
HAI-2435 Added new instruction text in Yhteystiedot section

### DIFF
--- a/src/domain/johtoselvitys_new/Contacts.tsx
+++ b/src/domain/johtoselvitys_new/Contacts.tsx
@@ -199,6 +199,9 @@ export function Contacts() {
 
   return (
     <div>
+      <Text tag="p" spacingBottom="s">
+        {t('johtoselvitysForm:yhteystiedot:instructions')}
+      </Text>
       <Text tag="p" spacingBottom="l">
         {t('form:requiredInstruction')}
       </Text>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -599,6 +599,9 @@
       "instructions2": "Piirtämäsi alueet näkyvät listana kartan alapuolella. Listasta pääset myös poistamaan alueita.",
       "giveDates": "Valitse työn päivämäärät piirtääksesi selvitettävät alueet kartalle."
     },
+    "yhteystiedot": {
+      "instructions": "Lisää osallistuvien tahojen tiedot ja yhteyshenkilöt. Hakemuksen tekijän tulee olla ainakin yhden tahon yhteyshenkilönä. Hakemukseen lisätyille yhteystiedoille lähetetään sähköpostikutsu hankkeelle katseluoikeuksin. Voit muuttaa osallistujien käyttöoikeuksia ja tietoja myöhemmin hankkeen käyttäjähallinnasta."
+    },
     "liitteet": {
       "instructions": "Lisää hakemukselle liitteet, kuten työsuunnitelma."
     }


### PR DESCRIPTION
# Description

Added new instruction text in Yhteystiedot section

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2435

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Create new Johtoselvityshakemus and fill it up until 3/5 Yhteystiedot. There should be new instruction text same as in Figma.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
