### PR TITLE
HAI-2444 Added new instruction text in area sections

### DIFF
--- a/src/domain/hanke/edit/HankeFormAlueet.tsx
+++ b/src/domain/hanke/edit/HankeFormAlueet.tsx
@@ -100,6 +100,9 @@ const HankeFormAlueet: React.FC<FormProps> = ({ formData }) => {
       <Box mb="var(--spacing-m)">
         <p>{t('hankeForm:hankkeenAlueForm:instructions')}</p>
       </Box>
+      <Box mb="var(--spacing-m)">
+        <p>{t('hankeForm:hankkeenAlueForm:instructions2')}</p>
+      </Box>
 
       <Text tag="h3" styleAs="h4" weight="bold">
         <Box mb="var(--spacing-m)">{t('hankeForm:hankkeenAlueForm:subHeader')}</Box>

--- a/src/domain/johtoselvitys/Geometries.tsx
+++ b/src/domain/johtoselvitys/Geometries.tsx
@@ -174,6 +174,9 @@ export const Geometries: React.FC<React.PropsWithChildren<unknown>> = () => {
       <Text tag="p" spacingBottom="s">
         {t('johtoselvitysForm:alueet:instructions2')}
       </Text>
+      <Text tag="p" spacingBottom="s">
+        {t('johtoselvitysForm:alueet:instructions3')}
+      </Text>
       <Text tag="p" spacingBottom="m">
         {t('form:requiredInstruction')}
       </Text>

--- a/src/domain/johtoselvitys_new/Geometries.tsx
+++ b/src/domain/johtoselvitys_new/Geometries.tsx
@@ -180,6 +180,9 @@ export function Geometries({ hankeData }: Readonly<Props>) {
       <Text tag="p" spacingBottom="s">
         {t('johtoselvitysForm:alueet:instructions2')}
       </Text>
+      <Text tag="p" spacingBottom="s">
+        {t('johtoselvitysForm:alueet:instructions3')}
+      </Text>
       <Text tag="p" spacingBottom="m">
         {t('form:requiredInstruction')}
       </Text>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -554,6 +554,7 @@
       "subHeader": "Hanke-alueet",
       "area": "Alue",
       "instructions": "Hankkeelle voi piirtää useita alueita. Piirretyille alueille muodostuu automaattisesti liikennehaittaindeksit (arvot 1-5, 5 on merkittävin). Indeksit perustuvat hankealueiden sijaintiin pyörä-, joukko- ja autoliikenteen tärkeimmillä reiteillä. Hankealueiden liikenneverkollinen merkittävyys kuvataan kartalla liikennevalovärein (vihreä = ei haittaa, keltainen = todennäköinen haitta, punainen = merkittävä haitta).",
+      "instructions2": "Voit muokata jo piirrettyä aluetta tarttumalla sen reunasta kiinni ja vetämällä pisteen haluamaasi kohtaan.",
       "noAlueet": "Piirrä alue kartalle merkitäksesi haitta-arviot.",
       "haitatHeader": "Alueen haitta-arviot",
       "haitatInstructions": "Anna arvio suurimmista mahdollisista vaikutuksista hankealueella.",
@@ -597,6 +598,7 @@
     "alueet": {
       "instructions1": "Aloita selvitettävän alueen piirtäminen lisäämällä työn alku- ja loppupäivämäärät, jolloin piirtotyökalut ilmestyvät kartan vasempaan alanurkkaan. Tämän jälkeen voit piirtää selvitettävät alueet kartalle. Voit lisätä samalle hakemukselle useampia alueita, mikäli niitä koskeva aikaväli on sama.",
       "instructions2": "Piirtämäsi alueet näkyvät listana kartan alapuolella. Listasta pääset myös poistamaan alueita.",
+      "instructions3": "Voit muokata jo piirrettyä aluetta tarttumalla sen reunasta kiinni ja vetämällä pisteen haluamaasi kohtaan.",
       "giveDates": "Valitse työn päivämäärät piirtääksesi selvitettävät alueet kartalle."
     },
     "liitteet": {


### PR DESCRIPTION
# Description

Added new instruction text in area sections in both Hanke and Johtoselvityshakemus.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2444

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Create a new Hanke and see that the new text is shown in areas section. Same goes for Johtoselvityshakemus.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
