### PR TITLE
HAI-2439 Add validation that johtoselvitys yhteystieto must have at least one yhteyshenkilö

### DIFF
--- a/src/common/components/dropdown/DropdownMultiselect.tsx
+++ b/src/common/components/dropdown/DropdownMultiselect.tsx
@@ -4,6 +4,7 @@ import { Combobox, Tooltip } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 
 import { TooltipProps } from '../../types/tooltip';
+import { getInputErrorText } from '../../utils/form';
 
 import './dropDown.styles.scss';
 
@@ -17,7 +18,6 @@ type PropTypes<T> = {
   label: string;
   helperText?: string;
   options: Array<Option<T>>;
-  invalid?: boolean;
   errorMsg?: string;
   tooltip?: TooltipProps;
   icon?: ReactNode;
@@ -32,7 +32,6 @@ function DropdownMultiselect<T>({
   options,
   defaultValue,
   label,
-  invalid,
   errorMsg,
   tooltip,
   helperText,
@@ -61,13 +60,13 @@ function DropdownMultiselect<T>({
         control={control}
         defaultValue={defaultValue}
         rules={rules}
-        render={({ field: { onChange, value } }) => {
+        render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => {
           return (
             <Combobox<Option<T>>
               options={options}
               label={label}
               helper={helperText}
-              invalid={invalid}
+              invalid={Boolean(error)}
               defaultValue={defaultValue}
               value={value?.map((v: T) => ({
                 value: transformValue ? transformValue(v) : v,
@@ -80,11 +79,12 @@ function DropdownMultiselect<T>({
               multiselect
               icon={icon}
               clearable={clearable}
+              onBlur={onBlur}
+              error={errorMsg ?? getInputErrorText(t, error)}
             />
           );
         }}
       />
-      {invalid && <span className="error-text">{errorMsg}</span>}
     </div>
   );
 }

--- a/src/domain/hanke/edit/HankeFormPerustiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormPerustiedot.tsx
@@ -134,7 +134,6 @@ const HankeFormPerustiedot: React.FC<React.PropsWithChildren<FormProps>> = ({
           }
           label={t(`hankeForm:labels:${FORMFIELD.TYOMAATYYPPI}`)}
           mapValueToLabel={(value) => t(`hanke:${FORMFIELD.TYOMAATYYPPI}:${value}`)}
-          invalid={!!errors[FORMFIELD.TYOMAATYYPPI]}
           errorMsg={t('hankeForm:insertFieldError')}
         />
       </div>

--- a/src/domain/johtoselvitys_new/validationSchema.ts
+++ b/src/domain/johtoselvitys_new/validationSchema.ts
@@ -44,7 +44,8 @@ const customerWithContactsSchema = yup.object({
   contacts: yup
     .array(contactSchema)
     .transform((value) => (value === null ? [] : value))
-    .defined(),
+    .defined()
+    .min(1, ({ min }) => ({ key: 'yhteyshenkilotMin', values: { min } })),
 });
 
 const areaSchema = yup.object({

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -91,7 +91,8 @@
       "stringMin": "Kentän pituus oltava vähintään {{min}} merkkiä",
       "stringMax": "Kentän pituus oltava enintään {{max}} merkkiä",
       "dateMin": "Ensimmäinen mahdollinen päivä on {{min}}",
-      "dateMax": "Viimeinen mahdollinen päivä on {{max}}"
+      "dateMax": "Viimeinen mahdollinen päivä on {{max}}",
+      "yhteyshenkilotMin": "Vähintään yksi yhteyshenkilö tulee olla asetettuna"
     },
     "errors": {
       "areaRequired": "Vähintään yksi alue vaaditaan",


### PR DESCRIPTION
# Description

If there are no yhteyshenkilöt, error is displayed below dropdown.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2439

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new johtoselvitys and fill first two pages so that you get to contacts page
2. Try to move to next page
3. Along with other validation errors, there should be error "Vähintään yksi yhteyshenkilö tulee olla asetettuna" below "Yhteyshenkilöt" dropdowns
4. Add yhteyshenkilö and move focus away from the field
5. Error should disappear

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
