### PR TITLE
HAI-2460 Show user management button if the feature is enabled

### DIFF
--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -277,3 +277,25 @@ test('Should not show map if there are no hanke areas', async () => {
 
   expect(screen.queryByTestId('hanke-map')).not.toBeInTheDocument();
 });
+
+test('Should not show user management button if access rights feature is not enabled', async () => {
+  const OLD_ENV = { ...window._env_ };
+  window._env_ = { ...OLD_ENV, REACT_APP_FEATURE_ACCESS_RIGHTS: '0' };
+  render(<HankeViewContainer hankeTunnus="HAI22-2" />);
+  await waitForLoadingToFinish();
+
+  expect(screen.queryByRole('button', { name: 'Käyttäjähallinta' })).not.toBeInTheDocument();
+  jest.resetModules();
+  window._env_ = OLD_ENV;
+});
+
+test('Should show user management button if access rights feature is enabled', async () => {
+  const OLD_ENV = { ...window._env_ };
+  window._env_ = { ...OLD_ENV, REACT_APP_FEATURE_ACCESS_RIGHTS: '1' };
+  render(<HankeViewContainer hankeTunnus="HAI22-2" />);
+  await waitForLoadingToFinish();
+
+  expect(screen.queryByRole('button', { name: 'Käyttäjähallinta' })).toBeInTheDocument();
+  jest.resetModules();
+  window._env_ = OLD_ENV;
+});

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -209,7 +209,7 @@ const HankeView: React.FC<Props> = ({
         <Text tag="h2" styleAs="h3" weight="bold" spacingBottom="l">
           {hankeData?.hankeTunnus}
         </Text>
-        <FeatureFlags flags={['hanke', 'accessRights']}>
+        <FeatureFlags flags={['accessRights']}>
           <Text tag="p" styleAs="body-s" spacingBottom="l">
             <strong style={{ marginRight: 'var(--spacing-s)' }}>
               {t('hankePortfolio:labels:oikeudet')}:
@@ -246,7 +246,7 @@ const HankeView: React.FC<Props> = ({
               ) : null}
             </CheckRightsByHanke>
           </FeatureFlags>
-          <FeatureFlags flags={['hanke', 'accessRights']}>
+          <FeatureFlags flags={['accessRights']}>
             <Button
               onClick={onEditRights}
               variant="primary"


### PR DESCRIPTION
# Description

"Käyttäjähallinta" button does not depend on hanke feature but only on user management feature.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2460

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Disable `REACT_APP_FEATURE_HANKE` and keep `REACT_APP_FEATURE_ACCESS_RIGHTS` enabled. The button should still be visible and user management available.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
