### PR TITLE
HAI-2451 Hide hanke-related access rights

### DIFF
--- a/src/domain/hanke/accessRights/AccessRightsInfo.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsInfo.tsx
@@ -2,9 +2,11 @@ import { Accordion } from 'hds-react';
 import { Language } from '../../../common/types/language';
 import { Trans, useTranslation } from 'react-i18next';
 import styles from './AccessRightsInfo.module.scss';
+import FeatureFlags from '../../../common/components/featureFlags/FeatureFlags';
 
 function AccessRightsInfo() {
   const { t, i18n } = useTranslation();
+
   return (
     <Accordion
       className={styles.infoAccordion}
@@ -19,19 +21,21 @@ function AccessRightsInfo() {
             hankkeella ei ole päätöksen saaneita hakemuksia.
           </Trans>
         </li>
-        <li>
-          <Trans i18nKey="hankeUsers:accessRightsInfo:KAIKKIEN_MUOKKAUS">
-            <strong>Hankkeen ja hakemusten muokkaus -oikeus</strong> mahdollistaa hankkeen ja sen
-            hakemusten sisällön muokkaamisen ja luonnin sekä muiden käyttöoikeuksien muokkaamisen,
-            paitsi “Kaikki oikeudet”, jolla voi poistaa hankkeen.
-          </Trans>
-        </li>
-        <li>
-          <Trans i18nKey="hankeUsers:accessRightsInfo:HANKEMUOKKAUS">
-            <strong>Hankemuokkaus-oikeus</strong> mahdollistaa hankkeen tietojen muokkaamisen, mutta
-            ei käyttöoikeuksien muokkausta. Hakemustietoihin on tällöin katseluoikeudet.
-          </Trans>
-        </li>
+        <FeatureFlags flags={['hanke']}>
+          <li>
+            <Trans i18nKey="hankeUsers:accessRightsInfo:KAIKKIEN_MUOKKAUS">
+              <strong>Hankkeen ja hakemusten muokkaus -oikeus</strong> mahdollistaa hankkeen ja sen
+              hakemusten sisällön muokkaamisen ja luonnin sekä muiden käyttöoikeuksien muokkaamisen,
+              paitsi “Kaikki oikeudet”, jolla voi poistaa hankkeen.
+            </Trans>
+          </li>
+          <li>
+            <Trans i18nKey="hankeUsers:accessRightsInfo:HANKEMUOKKAUS">
+              <strong>Hankemuokkaus-oikeus</strong> mahdollistaa hankkeen tietojen muokkaamisen,
+              mutta ei käyttöoikeuksien muokkausta. Hakemustietoihin on tällöin katseluoikeudet.
+            </Trans>
+          </li>
+        </FeatureFlags>
         <li>
           <Trans i18nKey="hankeUsers:accessRightsInfo:HAKEMUSASIOINTI">
             <strong>Hakemusasiointi-oikeus</strong> mahdollistaa uusien hakemusten luomisen

--- a/src/domain/hanke/hankeUsers/EditUserView.test.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.test.tsx
@@ -6,6 +6,7 @@ import { waitForLoadingToFinish } from '../../../testUtils/helperFunctions';
 import { readAll, reset } from '../../mocks/data/users';
 import { USER_EDIT_HANKE } from '../../mocks/signedInUser';
 import * as hankeUsersApi from './hankeUsersApi';
+import React from 'react';
 
 jest.setTimeout(10000);
 
@@ -285,4 +286,36 @@ test('Should show error notification if deleting user fails', async () => {
   await user.click(screen.getByRole('button', { name: 'Poista' }));
 
   expect(screen.getByText(/tapahtui virhe/i)).toBeInTheDocument();
+});
+
+test('Should not be able to select hanke editing access rights if the feature is not enabled', async () => {
+  const OLD_ENV = { ...window._env_ };
+  window._env_ = { ...OLD_ENV, REACT_APP_FEATURE_HANKE: '0' };
+
+  render(<EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afb4" hankeTunnus="HAI22-2" />);
+  await waitForLoadingToFinish();
+
+  fireEvent.click(screen.getByRole('button', { name: /käyttöoikeudet/i }));
+
+  expect(screen.queryByText('Hankkeen ja hakemusten muokkaus')).not.toBeInTheDocument();
+  expect(screen.queryByText('Hankemuokkaus')).not.toBeInTheDocument();
+
+  jest.resetModules();
+  window._env_ = OLD_ENV;
+});
+
+test('Should be able to select hanke editing access rights if the feature is enabled', async () => {
+  const OLD_ENV = { ...window._env_ };
+  window._env_ = { ...OLD_ENV, REACT_APP_FEATURE_HANKE: '1' };
+
+  render(<EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afb4" hankeTunnus="HAI22-2" />);
+  await waitForLoadingToFinish();
+
+  fireEvent.click(screen.getByRole('button', { name: /käyttöoikeudet/i }));
+
+  expect(screen.queryByText('Hankkeen ja hakemusten muokkaus')).toBeInTheDocument();
+  expect(screen.queryByText('Hankemuokkaus')).toBeInTheDocument();
+
+  jest.resetModules();
+  window._env_ = OLD_ENV;
 });

--- a/src/domain/hanke/hankeUsers/EditUserView.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.tsx
@@ -45,6 +45,7 @@ import UserDeleteDialog from './UserDeleteDialog';
 import UserDeleteInfoErrorNotification from './UserDeleteInfoErrorNotification';
 import { useEffect, useState } from 'react';
 import { useLocalizedRoutes } from '../../../common/hooks/useLocalizedRoutes';
+import { useFeatureFlags } from '../../../common/components/featureFlags/FeatureFlagsContext';
 
 type Props = {
   user: HankeUser;
@@ -86,6 +87,7 @@ function EditUserView({
   const { HANKEPORTFOLIO } = useLocalizedRoutes();
   const hankeViewPath = useHankeViewPath(hankeTunnus);
   const getHankeUsersPath = useLinkPath(ROUTES.ACCESS_RIGHTS);
+  const features = useFeatureFlags();
   const formContext = useForm({
     mode: 'onTouched',
     defaultValues: {
@@ -127,6 +129,10 @@ function EditUserView({
   // Options for the dropdown
   const accessRightLevelOptions: AccessRightLevelOption[] = $enum(AccessRightLevel)
     .getValues()
+    .filter(
+      (rightLevel) =>
+        features.hanke || (rightLevel !== 'KAIKKIEN_MUOKKAUS' && rightLevel !== 'HANKEMUOKKAUS'),
+    )
     .map((rightLevel) => {
       return { label: t(`hankeUsers:accessRightLevels:${rightLevel}`), value: rightLevel };
     });


### PR DESCRIPTION
# Description

Hanke-related access rights are not shown or selectable in user management if the hanke feature is not enabled.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2451

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Enabled and disable hanke feature in UI and see that the selections for access rights are according to the specs.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
