### PR TITLE
HAI-2442 Add assistive text and placeholder for yhteyshenkilö dropdown

### DIFF
--- a/src/common/components/app/theme.ts
+++ b/src/common/components/app/theme.ts
@@ -17,11 +17,12 @@ import { extendTheme } from '@chakra-ui/react';
 }; */
 
 const breakpoints = {
-  sm: '320px',
-  md: '576px',
-  lg: '768px',
-  xl: '992px',
-  xxl: '1248px',
+  base: '0px',
+  xs: '320px',
+  sm: '576px',
+  md: '768px',
+  lg: '992px',
+  xl: '1248px',
 };
 
 const customTheme = extendTheme({

--- a/src/common/components/dropdown/DropdownMultiselect.tsx
+++ b/src/common/components/dropdown/DropdownMultiselect.tsx
@@ -1,12 +1,10 @@
 import { ReactNode } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { Combobox, Tooltip } from 'hds-react';
+import { Combobox } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 
 import { TooltipProps } from '../../types/tooltip';
 import { getInputErrorText } from '../../utils/form';
-
-import './dropDown.styles.scss';
 
 type Option<T> = { value: T; label: string };
 
@@ -22,6 +20,7 @@ type PropTypes<T> = {
   tooltip?: TooltipProps;
   icon?: ReactNode;
   clearable?: boolean;
+  placeholder?: string;
   mapValueToLabel: (value: T) => string;
   transformValue?: (value: T) => T;
 };
@@ -37,6 +36,7 @@ function DropdownMultiselect<T>({
   helperText,
   icon,
   clearable,
+  placeholder,
   mapValueToLabel,
   transformValue,
 }: Readonly<PropTypes<T>>) {
@@ -44,48 +44,40 @@ function DropdownMultiselect<T>({
   const { control } = useFormContext();
 
   return (
-    <div className="dropdownComp">
-      {!!tooltip && (
-        <Tooltip
-          buttonLabel={tooltip.buttonLabel || t(`hankeForm:toolTips:tipOpenLabel`)}
-          tooltipLabel={tooltip.tooltipLabel || t(`hankeForm:toolTips:tipOpenLabel`)}
-          placement={tooltip.placement}
-        >
-          {t(`${tooltip.tooltipText}`)}
-        </Tooltip>
-      )}
-
-      <Controller
-        name={name}
-        control={control}
-        defaultValue={defaultValue}
-        rules={rules}
-        render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => {
-          return (
-            <Combobox<Option<T>>
-              options={options}
-              label={label}
-              helper={helperText}
-              invalid={Boolean(error)}
-              defaultValue={defaultValue}
-              value={value?.map((v: T) => ({
-                value: transformValue ? transformValue(v) : v,
-                label: mapValueToLabel(v),
-              }))}
-              onChange={(option: Option<T>[]) => onChange(option.map((o) => o.value))}
-              toggleButtonAriaLabel={t('common:components:multiselect:toggle')}
-              selectedItemRemoveButtonAriaLabel={t('common:components:multiselect:removeSelected')}
-              clearButtonAriaLabel={t('common:components:multiselect:clear')}
-              multiselect
-              icon={icon}
-              clearable={clearable}
-              onBlur={onBlur}
-              error={errorMsg ?? getInputErrorText(t, error)}
-            />
-          );
-        }}
-      />
-    </div>
+    <Controller
+      name={name}
+      control={control}
+      defaultValue={defaultValue}
+      rules={rules}
+      render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => {
+        return (
+          <Combobox<Option<T>>
+            options={options}
+            label={label}
+            helper={helperText}
+            invalid={Boolean(error)}
+            defaultValue={defaultValue}
+            value={value?.map((v: T) => ({
+              value: transformValue ? transformValue(v) : v,
+              label: mapValueToLabel(v),
+            }))}
+            onChange={(option: Option<T>[]) => onChange(option.map((o) => o.value))}
+            toggleButtonAriaLabel={t('common:components:multiselect:toggle')}
+            selectedItemRemoveButtonAriaLabel={t('common:components:multiselect:removeSelected')}
+            clearButtonAriaLabel={t('common:components:multiselect:clear')}
+            multiselect
+            icon={icon}
+            clearable={clearable}
+            onBlur={onBlur}
+            error={errorMsg ?? getInputErrorText(t, error)}
+            placeholder={placeholder}
+            tooltipButtonLabel={tooltip?.tooltipButtonLabel}
+            tooltipLabel={tooltip?.tooltipLabel}
+            tooltipText={tooltip?.tooltipText}
+          />
+        );
+      }}
+    />
   );
 }
 

--- a/src/domain/forms/components/NewContactPersonForm.module.scss
+++ b/src/domain/forms/components/NewContactPersonForm.module.scss
@@ -1,7 +1,11 @@
 .fieldset {
-  max-width: 740px;
+  max-width: var(--container-width-m);
   margin-bottom: var(--spacing-s);
   padding-top: var(--spacing-xs);
+}
+
+.infoNotification {
+  margin-bottom: var(--spacing-m);
 }
 
 .formButtons {

--- a/src/domain/forms/components/NewContactPersonForm.tsx
+++ b/src/domain/forms/components/NewContactPersonForm.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { FormProvider, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useMutation } from 'react-query';
-import { Button, Fieldset, IconCheck, IconCross } from 'hds-react';
+import { Button, Fieldset, IconCheck, IconCross, Notification } from 'hds-react';
 import ResponsiveGrid from '../../../common/components/grid/ResponsiveGrid';
 import TextInput from '../../../common/components/textInput/TextInput';
 import { createHankeUser } from '../../hanke/hankeUsers/hankeUsersApi';
@@ -61,6 +61,15 @@ function NewContactPersonForm({ hankeTunnus, onContactPersonAdded, onClose }: Re
         border
         className={styles.fieldset}
       >
+        <Notification
+          type="info"
+          position="inline"
+          label={t('form:yhteystiedot:notifications:descriptions:contactPersonInfo')}
+          size="small"
+          className={styles.infoNotification}
+        >
+          {t('form:yhteystiedot:notifications:descriptions:contactPersonInfo')}
+        </Notification>
         <ResponsiveGrid maxColumns={2}>
           <TextInput
             name={YHTEYSHENKILO_FORMFIELD.ETUNIMI}

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -25,6 +25,7 @@ import { HankeUser } from '../hankeUsers/hankeUser';
 import { useQueryClient } from 'react-query';
 import ContactPersonSelect from '../hankeUsers/ContactPersonSelect';
 import { mapHankeUserToHankeYhteyshenkilo } from '../hankeUsers/utils';
+import { Box } from '@chakra-ui/react';
 
 function getEmptyContact(): Omit<HankeYhteystieto, 'id'> {
   return {
@@ -74,8 +75,8 @@ const ContactFields: React.FC<
   }, [registryKeyInputDisabled, contactType, index, setValue]);
 
   return (
-    <>
-      <ResponsiveGrid>
+    <Box maxWidth="var(--container-width-m)">
+      <ResponsiveGrid maxColumns={2}>
         <Dropdown
           id={`${contactType}.${index}.${CONTACT_FORMFIELD.TYYPPI}`}
           name={`${contactType}.${index}.${CONTACT_FORMFIELD.TYYPPI}`}
@@ -89,7 +90,7 @@ const ContactFields: React.FC<
           })}
         />
       </ResponsiveGrid>
-      <ResponsiveGrid>
+      <ResponsiveGrid maxColumns={2}>
         <TextInput
           name={`${contactType}.${index}.${CONTACT_FORMFIELD.NIMI}`}
           label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.NIMI}`)}
@@ -100,7 +101,7 @@ const ContactFields: React.FC<
           disabled={registryKeyInputDisabled}
         />
       </ResponsiveGrid>
-      <ResponsiveGrid>
+      <ResponsiveGrid maxColumns={2}>
         <TextInput
           name={`${contactType}.${index}.${CONTACT_FORMFIELD.EMAIL}`}
           label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.EMAIL}`)}
@@ -116,7 +117,7 @@ const ContactFields: React.FC<
         mapHankeUserToValue={mapHankeUserToHankeYhteyshenkilo}
         mapValueToLabel={mapHankeYhteyshenkiloToLabel}
       />
-    </>
+    </Box>
   );
 };
 
@@ -212,7 +213,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
             >
               <Fieldset
                 heading={t('form:yhteystiedot:titles:omistaja', { count: index + 1 })}
-                style={{ paddingTop: 'var(--spacing-s)' }}
+                style={{ paddingTop: 'var(--spacing-s)', minInlineSize: 'auto' }}
               >
                 <ContactFields
                   contactType={HANKE_CONTACT_TYPE.OMISTAJAT}
@@ -254,7 +255,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
             >
               <Fieldset
                 heading={t('form:yhteystiedot:titles:rakennuttajat', { count: index + 1 })}
-                style={{ paddingTop: 'var(--spacing-s)' }}
+                style={{ paddingTop: 'var(--spacing-s)', minInlineSize: 'auto' }}
               >
                 <ContactFields
                   contactType={HANKE_CONTACT_TYPE.RAKENNUTTAJAT}
@@ -296,7 +297,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
             >
               <Fieldset
                 heading={t('form:yhteystiedot:titles:toteuttajat', { count: index + 1 })}
-                style={{ paddingTop: 'var(--spacing-s)' }}
+                style={{ paddingTop: 'var(--spacing-s)', minInlineSize: 'auto' }}
               >
                 <ContactFields
                   contactType={HANKE_CONTACT_TYPE.TOTEUTTAJAT}
@@ -340,7 +341,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ formData }) => {
             >
               <Fieldset
                 heading={t('form:yhteystiedot:titles:muut', { count: index + 1 })}
-                style={{ paddingTop: 'var(--spacing-s)' }}
+                style={{ paddingTop: 'var(--spacing-s)', minInlineSize: 'auto' }}
               >
                 <ResponsiveGrid>
                   <TextInput

--- a/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
+++ b/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
-import { IconUser } from 'hds-react';
 import { HankeUser } from './hankeUser';
 import DropdownMultiselect from '../../../common/components/dropdown/DropdownMultiselect';
+import { TooltipProps } from '../../../common/types/tooltip';
 
 /**
  * Combobox component for selecting hanke user as contact person (yhteyshenkilö) for a contact (yhteystieto)
@@ -9,12 +9,14 @@ import DropdownMultiselect from '../../../common/components/dropdown/DropdownMul
 function ContactPersonSelect<T>({
   name,
   hankeUsers,
+  tooltip,
   mapHankeUserToValue,
   mapValueToLabel,
   transformValue,
 }: Readonly<{
   name: string;
   hankeUsers?: HankeUser[];
+  tooltip?: TooltipProps;
   mapHankeUserToValue: (user: HankeUser) => T;
   mapValueToLabel: (value: T) => string;
   transformValue?: (value: T) => T;
@@ -31,7 +33,7 @@ function ContactPersonSelect<T>({
       name={name}
       label={t('form:yhteystiedot:titles:subContacts')}
       helperText={t('form:yhteystiedot:helperTexts:yhteyshenkilo')}
-      icon={<IconUser />}
+      placeholder={t('form:yhteystiedot:placeholders:yhteyshenkilo')}
       clearable={false}
       mapValueToLabel={mapValueToLabel}
       transformValue={transformValue}
@@ -42,6 +44,7 @@ function ContactPersonSelect<T>({
           label: mapHankeUserToLabel(hankeUser),
         })) ?? []
       }
+      tooltip={tooltip}
     />
   );
 }

--- a/src/domain/johtoselvitys_new/Contacts.tsx
+++ b/src/domain/johtoselvitys_new/Contacts.tsx
@@ -94,13 +94,17 @@ const CustomerFields: React.FC<{
   return (
     <Fieldset
       heading={t(`form:yhteystiedot:titles:${customerType}`)}
-      style={{ paddingTop: 'var(--spacing-s)' }}
+      style={{
+        paddingTop: 'var(--spacing-s)',
+        maxWidth: 'var(--container-width-m)',
+        minInlineSize: 'auto',
+      }}
     >
       <TextInput
         name={`applicationData.${customerType}.customer.yhteystietoId`}
         style={{ display: 'none' }}
       />
-      <ResponsiveGrid>
+      <ResponsiveGrid maxColumns={2}>
         <Dropdown
           id={`applicationData.${customerType}.customer.type`}
           name={`applicationData.${customerType}.customer.type`}
@@ -115,7 +119,7 @@ const CustomerFields: React.FC<{
           })}
         />
       </ResponsiveGrid>
-      <ResponsiveGrid>
+      <ResponsiveGrid maxColumns={2}>
         <TextInput
           name={`applicationData.${customerType}.customer.name`}
           label={t('form:yhteystiedot:labels:nimi')}
@@ -129,7 +133,7 @@ const CustomerFields: React.FC<{
           autoComplete="on"
         />
       </ResponsiveGrid>
-      <ResponsiveGrid>
+      <ResponsiveGrid maxColumns={2}>
         <TextInput
           name={`applicationData.${customerType}.customer.email`}
           label={t('form:yhteystiedot:labels:email')}
@@ -149,6 +153,11 @@ const CustomerFields: React.FC<{
         mapHankeUserToValue={mapHankeUserToContact}
         mapValueToLabel={mapContactToLabel}
         transformValue={(value) => removeOrdererFromContact(value)}
+        tooltip={{
+          tooltipButtonLabel: t('hankeForm:toolTips:tipOpenLabel'),
+          tooltipLabel: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
+          tooltipText: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
+        }}
       />
     </Fieldset>
   );

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -212,11 +212,12 @@
         "erillinenYhteyshenkilo": "Erillinen yhteyshenkilö"
       },
       "placeholders": {
-        "otherPartyRole": "Isännöitsijä, konsultti..."
+        "otherPartyRole": "Isännöitsijä, konsultti...",
+        "yhteyshenkilo": "Esim. Matti Meikäläinen tai matti.meikalainen@yritys.fi"
       },
       "helperTexts": {
         "otherPartyRole": "Tahon rooli hankkeessa",
-        "yhteyshenkilo": "Valitsemillesi yhteyshenkilöille lähetetään kutsu hankkeelle sähköpostilla. Yhteyshenkilöt näkyvät kaikille hanketta katseleville tahoille."
+        "yhteyshenkilo": " Voit etsiä jo lisättyä henkilöä kirjoittamalla tai valitsemalla pudotusvalikosta, tai lisätä uuden yhteyshenkilön alta."
       },
       "contactType": {
         "YKSITYISHENKILO": "Yksityishenkilö",
@@ -248,8 +249,12 @@
         },
         "descriptions": {
           "contactPersonSaved": "Yhteyshenkilön tiedot tallennettu ja lisätty hankkelle onnistuneesti.",
-          "contactPersonSaveError": "Yhteyshenkilön tietojen tallennus epäonnistui. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman teknisen tukeen."
+          "contactPersonSaveError": "Yhteyshenkilön tietojen tallennus epäonnistui. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman teknisen tukeen.",
+          "contactPersonInfo": "Lisäämisellesi yhteyshenkilöille lähetetään kutsu hankkeelle sähköpostilla. Yhteystiedot näkyvät muille tähän hankkeeseen lisätyille henkilöille."
         }
+      },
+      "tooltips": {
+        "hakemusYhteyshenkilo": "Lisäämillesi yhteyshenkilöille lähetetään kutsu hakemukselle sähköpostitse."
       }
     }
   },

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -250,7 +250,7 @@
         "descriptions": {
           "contactPersonSaved": "Yhteyshenkilön tiedot tallennettu ja lisätty hankkelle onnistuneesti.",
           "contactPersonSaveError": "Yhteyshenkilön tietojen tallennus epäonnistui. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman teknisen tukeen.",
-          "contactPersonInfo": "Lisäämisellesi yhteyshenkilöille lähetetään kutsu hankkeelle sähköpostilla. Yhteystiedot näkyvät muille tähän hankkeeseen lisätyille henkilöille."
+          "contactPersonInfo": "Lisäämillesi yhteyshenkilöille lähetetään kutsu hankkeelle sähköpostilla. Yhteystiedot näkyvät muille tähän hankkeeseen lisätyille henkilöille."
         }
       },
       "tooltips": {


### PR DESCRIPTION
# Description

Added assistive text and placeholder for yhteyshenkilö dropdown in hanke form and johtoselvitys form.

Added tooltip for yhteyshenkilö dropdown in johtoselvitys form.

Added info notification for new yhteyshenkilö form.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2442

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check that UI matches design: https://www.figma.com/file/CSWoUcI2jslxfOgBYgjKuK/Haitaton-HDS-3.0.0?type=design&node-id=449-9560&mode=design&t=9Inj1EXiHxKyzUaL-4

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
