### PR TITLE
Use Nginx 1.22.1 Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /builder
 RUN yarn && yarn cache clean --force
 RUN REACT_APP_DISABLE_SENTRY=0 yarn build
 
-FROM nginx:stable
+FROM nginx:1.22.1
 # Install mods for nginx that include the Headers More mod, that allows the
 # removal of the Server -header
 RUN apt-get update && apt-get --no-install-recommends install -y nginx-extras && apt-get clean

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -14,7 +14,7 @@ COPY ./public /builder/public
 COPY ./tsconfig.json /builder/tsconfig.json
 RUN REACT_APP_DISABLE_SENTRY=1 yarn build
 
-FROM nginx:stable
+FROM nginx:1.22.1
 # Install mods for nginx that include the Headers More mod, that allows the
 # removal of the Server -header
 RUN apt-get update && apt-get --no-install-recommends install -y nginx-extras && apt-get clean


### PR DESCRIPTION
Use Nginx 1.22.1 Docker image since that is the version nginx-extras need and nginx:stable has just been upgraded to 1.26.0-1~bookworm which breaks Docker build
