### PR TITLE
HAI-2506 Show service notifications once per session

### DIFF
--- a/src/common/components/serviceNotifications/ServiceNotifications.tsx
+++ b/src/common/components/serviceNotifications/ServiceNotifications.tsx
@@ -1,9 +1,17 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Notification } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 
+enum NotificationType {
+  INFO = 'info',
+  WARNING = 'warning',
+  ERROR = 'error',
+}
+
+const NOTIFICATION_CLOSED = 'notification-closed';
+
 /**
- * Notifications to display for warning or error
+ * Notifications to display for info, warning or error
  * in Haitaton service
  */
 function ServiceNotifications() {
@@ -11,15 +19,38 @@ function ServiceNotifications() {
 
   const infoLabel = t('serviceInfo:label');
   const infoText = t('serviceInfo:text');
-  const [infoOpen, setInfoOpen] = useState(Boolean(infoLabel));
+  const infoClosed = Boolean(
+    sessionStorage.getItem(`${NotificationType.INFO}-${NOTIFICATION_CLOSED}`),
+  );
+  const [infoOpen, setInfoOpen] = useState(Boolean(infoLabel) && !infoClosed);
 
   const warningLabel = t('serviceWarning:label');
   const warningText = t('serviceWarning:text');
-  const [warningOpen, setWarningOpen] = useState(Boolean(warningLabel));
+  const warningClosed = Boolean(
+    sessionStorage.getItem(`${NotificationType.WARNING}-${NOTIFICATION_CLOSED}`),
+  );
+  const [warningOpen, setWarningOpen] = useState(Boolean(warningLabel && !warningClosed));
 
   const errorLabel = t('serviceError:label');
   const errorText = t('serviceError:text');
-  const [errorOpen, setErrorOpen] = useState(Boolean(errorLabel));
+  const errorClosed = Boolean(
+    sessionStorage.getItem(`${NotificationType.ERROR}-${NOTIFICATION_CLOSED}`),
+  );
+  const [errorOpen, setErrorOpen] = useState(Boolean(errorLabel) && !errorClosed);
+
+  // Close notification and set correspoding value
+  // to session storage, so that notification is not
+  // shown again on page refresh
+  function closeNotification(notificationType: NotificationType) {
+    sessionStorage.setItem(`${notificationType}-${NOTIFICATION_CLOSED}`, 'true');
+    if (notificationType === NotificationType.INFO) {
+      setInfoOpen(false);
+    } else if (notificationType === NotificationType.WARNING) {
+      setWarningOpen(false);
+    } else if (notificationType === NotificationType.ERROR) {
+      setErrorOpen(false);
+    }
+  }
 
   return (
     <>
@@ -31,7 +62,7 @@ function ServiceNotifications() {
           autoClose={false}
           dismissible
           closeButtonLabelText={`${t('common:components:notification:closeButtonLabelText')}`}
-          onClose={() => setInfoOpen(false)}
+          onClose={() => closeNotification(NotificationType.INFO)}
         >
           {infoText}
         </Notification>
@@ -45,7 +76,7 @@ function ServiceNotifications() {
           autoClose={false}
           dismissible
           closeButtonLabelText={`${t('common:components:notification:closeButtonLabelText')}`}
-          onClose={() => setWarningOpen(false)}
+          onClose={() => closeNotification(NotificationType.WARNING)}
         >
           {warningText}
         </Notification>
@@ -59,7 +90,7 @@ function ServiceNotifications() {
           autoClose={false}
           dismissible
           closeButtonLabelText={`${t('common:components:notification:closeButtonLabelText')}`}
-          onClose={() => setErrorOpen(false)}
+          onClose={() => closeNotification(NotificationType.ERROR)}
         >
           {errorText}
         </Notification>


### PR DESCRIPTION
# Description

When user closes info, warning or error notification set corresponding value to session storage, so that notification is not shown again on page refresh.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2506

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Add text to for example `REACT_APP_INFO_NOTIFICATION_LABEL` and `REACT_APP_INFO_NOTIFICATION_TEXT_FI` environment variables and run` yarn start`
2. Info notification should be shown
3. Close the notification and refresh page
4. Notification should not be shown again

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
