### PR TITLE
HAI-2481 Fix showing validation error when creating yhteyshenkilo in Johtoselvitys

### DIFF
--- a/src/domain/johtoselvitys_new/Contacts.tsx
+++ b/src/domain/johtoselvitys_new/Contacts.tsx
@@ -196,12 +196,11 @@ export function Contacts() {
     : undefined;
 
   function addYhteyshenkiloForYhteystieto(customerType: CustomerType, contactPerson: HankeUser) {
+    const previousContacts = getValues(`applicationData.${customerType}.contacts`) || [];
     setValue(
       `applicationData.${customerType}.contacts`,
-      getValues(`applicationData.${customerType}.contacts`)?.concat(
-        mapHankeUserToContact(contactPerson),
-      ),
-      { shouldDirty: true },
+      previousContacts.concat(mapHankeUserToContact(contactPerson)),
+      { shouldDirty: true, shouldValidate: true },
     );
     queryClient.invalidateQueries(['hankeUsers', hankeTunnus]);
   }

--- a/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
@@ -760,3 +760,30 @@ test('Should show validation error if there are no yhteyshenkilo set for yhteyst
     screen.queryByText(/vähintään yksi yhteyshenkilö tulee olla asetettuna/i),
   ).not.toBeInTheDocument();
 });
+
+test('Should remove validation error if yhteyshenkilo is created for yhteystieto', async () => {
+  const testApplication = cloneDeep(applications[0]) as Application<JohtoselvitysData>;
+  testApplication.applicationData.customerWithContacts = null;
+  const { user } = render(<JohtoselvitysContainer application={testApplication} />);
+
+  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+  await user.click(screen.getAllByLabelText(/yhteyshenkilöt/i)[0]);
+  await user.tab();
+
+  expect(
+    screen.getByText(/vähintään yksi yhteyshenkilö tulee olla asetettuna/i),
+  ).toBeInTheDocument();
+
+  await user.click(screen.getAllByRole('button', { name: /lisää uusi yhteyshenkilö/i })[0]);
+  fillNewContactPersonForm({
+    etunimi: 'Matti',
+    sukunimi: 'Meikäläinen',
+    sahkoposti: 'matti@test.com',
+    puhelinnumero: '0000000000',
+  });
+  await user.click(screen.getByRole('button', { name: /tallenna ja lisää yhteyshenkilö/i }));
+
+  expect(
+    screen.queryByText(/vähintään yksi yhteyshenkilö tulee olla asetettuna/i),
+  ).not.toBeInTheDocument();
+});


### PR DESCRIPTION
# Description

Fixed problem where validation error for no yhteyshenkilot being set remained when creating new yhteyshenkilo and that yhteyshenkilo is set.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2481

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Fill Johtoselvitys form up to Yhteyshenkilöt page
2. Add yourself as yhteyshenkilö for some role
3. Remove yourself from yhteyshenkilöt
4. There should be error "Vähintään yksi yhteyshenkilö tulee olla asetettuna"
5. Create new yhteyshenkilö for that role
6. Error should disappear

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
