### PR TITLE
HAI Add eslint config to Docker Compose build

### DIFF
--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -12,6 +12,8 @@ RUN yarn && yarn cache clean --force
 COPY ./src /builder/src
 COPY ./public /builder/public
 COPY ./tsconfig.json /builder/tsconfig.json
+COPY ./tsconfig.eslint.json /builder/tsconfig.eslint.json
+COPY ./.eslintrc.js /builder/.eslintrc.js
 RUN REACT_APP_DISABLE_SENTRY=1 yarn build
 
 FROM nginx:1.22.1


### PR DESCRIPTION
# Description

Builds using Dockerfile-local are failing, because eslint config files are not copied to the builder.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Other