### PR TITLE
HAI-2462 Fix navigating back to sent johtoselvitys

### DIFF
--- a/src/common/components/HDSConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/common/components/HDSConfirmationDialog/ConfirmationDialog.tsx
@@ -9,7 +9,7 @@ type Props = {
   title: string;
   description: string | React.ReactNode;
   isOpen: boolean;
-  close: () => void;
+  close?: () => void;
   mainAction: () => void;
   mainBtnLabel: string;
   mainBtnIcon?: React.ReactElement;
@@ -18,6 +18,7 @@ type Props = {
   showCloseButton?: boolean;
   showSecondaryButton?: boolean;
   isLoading?: boolean;
+  headerIcon?: React.ReactNode;
 };
 
 const ConfirmationDialog: React.FC<React.PropsWithChildren<Props>> = ({
@@ -33,6 +34,12 @@ const ConfirmationDialog: React.FC<React.PropsWithChildren<Props>> = ({
   showCloseButton = false,
   showSecondaryButton = true,
   isLoading = false,
+  headerIcon = (
+    <IconAlertCircleFill
+      aria-hidden="true"
+      color={variant === 'primary' ? 'var(--color-bus)' : 'var(--color-brick)'}
+    />
+  ),
 }) => {
   const { t } = useTranslation();
 
@@ -48,16 +55,7 @@ const ConfirmationDialog: React.FC<React.PropsWithChildren<Props>> = ({
       close={showCloseButton ? (close as any) : undefined}
       closeButtonLabelText={t('common:ariaLabels:closeButtonLabelText')}
     >
-      <Dialog.Header
-        id="dialog-title"
-        title={title}
-        iconLeft={
-          <IconAlertCircleFill
-            aria-hidden="true"
-            color={variant === 'primary' ? 'var(--color-bus)' : 'var(--color-brick)'}
-          />
-        }
-      />
+      <Dialog.Header id="dialog-title" title={title} iconLeft={headerIcon} />
       <Dialog.Content>
         {typeof description === 'string' ? (
           <p data-testid="dialog-description-test">{description}</p>

--- a/src/domain/application/hooks/useNavigateToApplicationView.ts
+++ b/src/domain/application/hooks/useNavigateToApplicationView.ts
@@ -1,0 +1,16 @@
+import { useNavigate } from 'react-router-dom';
+import useLinkPath from '../../../common/hooks/useLinkPath';
+import { ROUTES } from '../../../common/types/route';
+
+export default function useNavigateToApplicationView(applicationId?: string) {
+  const navigate = useNavigate();
+  const getApplicationViewPath = useLinkPath(ROUTES.HAKEMUS);
+
+  function navigateToApplicationView() {
+    if (applicationId) {
+      navigate(getApplicationViewPath({ id: applicationId }));
+    }
+  }
+
+  return navigateToApplicationView;
+}

--- a/src/domain/johtoselvitys_new/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys_new/JohtoselvitysContainer.tsx
@@ -373,14 +373,6 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
     return changeFormStep(changeStep, pageFieldsToValidate[stepIndex], trigger);
   }
 
-  const notificationLabel =
-    getValues('alluStatus') === AlluStatus.PENDING
-      ? t('form:notifications:labels:editSentApplication')
-      : undefined;
-  const notificationText =
-    getValues('alluStatus') === AlluStatus.PENDING
-      ? t('form:notifications:descriptions:editSentApplication')
-      : undefined;
   const attachmentsUploadingText: string = t('common:components:fileUpload:loadingText');
 
   return (
@@ -408,8 +400,6 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
         onStepChange={handleStepChange}
         onSubmit={handleSubmit(sendCableApplication)}
         stepChangeValidator={validateStepChange}
-        notificationLabel={notificationLabel}
-        notificationText={notificationText}
       >
         {function renderFormActions(activeStepIndex, handlePrevious, handleNext) {
           async function handleSaveAndQuit() {

--- a/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { rest } from 'msw';
 import { render, cleanup, fireEvent, screen, waitFor, act, within } from '../../testUtils/render';
 import Johtoselvitys from '../../pages/Johtoselvitys';
@@ -500,28 +499,6 @@ test('Should not allow step change when current step is invalid', async () => {
   // Expect to still be in the same page
   expect(screen.queryByText('Vaihe 3/5: Yhteystiedot')).toBeInTheDocument();
   expect(screen.queryByText('Kentän arvo on virheellinen')).toBeInTheDocument();
-});
-
-test('Should not show inline notification by default', () => {
-  render(
-    <JohtoselvitysContainer application={applications[0] as Application<JohtoselvitysData>} />,
-  );
-
-  expect(screen.queryByTestId('form-notification')).not.toBeInTheDocument();
-});
-
-test('Should show inline notification when editing a form that is in pending state', () => {
-  render(
-    <JohtoselvitysContainer application={applications[1] as Application<JohtoselvitysData>} />,
-  );
-
-  expect(screen.queryByTestId('form-notification')).toBeInTheDocument();
-  expect(screen.queryByText('Olet muokkaamassa jo lähetettyä hakemusta.')).toBeInTheDocument();
-  expect(
-    screen.queryByText(
-      'Hakemusta voit muokata niin kauan, kun sitä ei vielä ole otettu käsittelyyn. Uusi versio hakemuksesta lähtee viranomaiselle automaattisesti lomakkeen tallennuksen yhteydessä.',
-    ),
-  ).toBeInTheDocument();
 });
 
 test('Validation error is shown if no work is about checkbox is selected', async () => {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -732,6 +732,11 @@
       "maxAttachmentsNumberExceeded": "Tiedoston ({{fileName}}) lataus epäonnistui, liitteiden enimmäismäärä ({{maxNumber}} kpl) ylitetty.",
       "sentApplicationPersonalInfoNotification": "Lähetetyn hakemuksen omia tietoja ei voi muokata"
     },
+    "sentDialog": {
+      "title": "Hakemus lähetetty",
+      "description": "Hakemus on lähetetty, eikä sitä voi enää muokata. Tarkastele hakemuksen tietoja hakemussivulla.",
+      "button": "Siirry hakemussivulle"
+    },
     "status": {
       "PENDING_CLIENT": "Näkyy viranomaiselle",
       "PENDING": "Odottaa käsittelyä",

--- a/src/pages/EditJohtoselvitysPage.test.tsx
+++ b/src/pages/EditJohtoselvitysPage.test.tsx
@@ -1,0 +1,30 @@
+import { Route, Routes } from 'react-router-dom';
+import { render, screen } from '../testUtils/render';
+import EditJohtoselvitysPage from './EditJohtoselvitysPage';
+
+test('Should show dialog with button to navigate to application view when navigating to johtoselvitys that has been sent', async () => {
+  const { user } = render(
+    <Routes>
+      <Route path="/fi/johtoselvityshakemus/:id/muokkaa" element={<EditJohtoselvitysPage />} />
+    </Routes>,
+    undefined,
+    '/fi/johtoselvityshakemus/2/muokkaa',
+  );
+
+  await screen.findByText(/hakemus lähetetty/i);
+  await user.click(screen.getByText('Siirry hakemussivulle'));
+
+  expect(window.location.pathname).toBe('/fi/hakemus/2');
+});
+
+test('Should not show dialog with button to navigate to application view when editing johtoselvitys that has not been sent', () => {
+  render(
+    <Routes>
+      <Route path="/fi/johtoselvityshakemus/:id/muokkaa" element={<EditJohtoselvitysPage />} />
+    </Routes>,
+    undefined,
+    '/fi/johtoselvityshakemus/1/muokkaa',
+  );
+
+  expect(screen.queryByText(/hakemus lähetetty/i)).not.toBeInTheDocument();
+});


### PR DESCRIPTION
# Description

If user navigates to johtoselvitys that has been sent either by pressing back button in browser or by browser address bar, show a dialog with text that johtoselvitys has been sent and a button to navigate back to hakemus view.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2462

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create new johtoselvitys from johtoselvitys create dialog
2. Fill all required information and send the application
3. Press browser back button to go back to johtoselvitys form
4. Dialog with text "Hakemus on lähetetty, eikä sitä voi enää muokata. Tarkastele hakemuksen tietoja hakemussivulla." should be shown
5. Press the "Siirry hakemussivulle" button
6. You should end up to hakemus view

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
