### PR TITLE
HAI-2445 Fix showing hanke areas in johtoselvitys form when hanke is generated

### DIFF
--- a/src/domain/johtoselvitys_new/Geometries.test.tsx
+++ b/src/domain/johtoselvitys_new/Geometries.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { cloneDeep } from 'lodash';
 import { render, screen } from '../../testUtils/render';
 import { Geometries } from './Geometries';
 import hankkeet from '../mocks/data/hankkeet-data';
@@ -54,4 +54,17 @@ test('Hanke areas are visible if work start and end dates are between hanke star
   );
 
   expect(screen.getByTestId('countOfFilteredHankkeet')).toHaveTextContent('0');
+});
+
+test('Hanke areas are not visible if hanke is generated', async () => {
+  const testHanke = cloneDeep(hankkeet[1]);
+  testHanke.generated = true;
+  const { user } = render(<TestComponent hankeData={testHanke as HankeData} />);
+  await user.type(screen.getByRole('textbox', { name: 'Työn arvioitu alkupäivä *' }), '27.11.2024');
+  await user.type(
+    screen.getByRole('textbox', { name: 'Työn arvioitu loppupäivä *' }),
+    '27.11.2024',
+  );
+
+  expect(screen.queryByTestId('countOfFilteredHankkeet')).not.toBeInTheDocument();
 });

--- a/src/domain/johtoselvitys_new/Geometries.tsx
+++ b/src/domain/johtoselvitys_new/Geometries.tsx
@@ -219,11 +219,15 @@ export function Geometries({ hankeData }: Readonly<Props>) {
 
           <AddressSearchContainer position={{ top: '1rem', left: '1rem' }} zIndex={101} />
 
-          <HankeLayer
-            hankeData={hankeData && [hankeData]}
-            startDate={startTime?.toString() ?? hankeData?.alkuPvm}
-            endDate={endTime?.toString() ?? hankeData?.loppuPvm}
-          />
+          {/* Don't show hanke areas when hanke is generated */}
+          {!hankeData?.generated && (
+            <HankeLayer
+              hankeData={hankeData && [hankeData]}
+              startDate={startTime?.toString() ?? hankeData?.alkuPvm}
+              endDate={endTime?.toString() ?? hankeData?.loppuPvm}
+            />
+          )}
+
           <VectorLayer source={drawSource} zIndex={101} className="drawLayer" />
 
           <FitSource source={drawSource} />


### PR DESCRIPTION
# Description

Hanke areas are not shown when editing johtoselvitys form when hanke is in generated state so that they don't confuse user.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2445

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create new johtoselvitys from johtoselvitys create dialog
2. Fill information for first two pages so that there are work areas
3. Save form either by going forward or backward in the form or save and quit
4. Go to areas page and modify work area(s) to see that hanke areas of the generated hanke are not visible

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
