### PR TITLE
HAI-2538 Update invitation sent date after resending invitation in edit user view

### DIFF
--- a/src/domain/hanke/accessRights/AccessRightsView.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.tsx
@@ -484,7 +484,7 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
         {resendInvitationMutation.isSuccess && (
           <InvitationSuccessNotification onClose={() => resendInvitationMutation.reset()}>
             {t('hankeUsers:notifications:invitationSentSuccessText', {
-              email: hankeUsers.find((user) => user.id === resendInvitationMutation.data)
+              email: hankeUsers.find((user) => user.id === resendInvitationMutation.data.id)
                 ?.sahkoposti,
             })}
           </InvitationSuccessNotification>

--- a/src/domain/hanke/hankeUsers/EditUserView.test.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.test.tsx
@@ -6,7 +6,7 @@ import { waitForLoadingToFinish } from '../../../testUtils/helperFunctions';
 import { readAll, reset } from '../../mocks/data/users';
 import { USER_EDIT_HANKE } from '../../mocks/signedInUser';
 import * as hankeUsersApi from './hankeUsersApi';
-import React from 'react';
+import { formatToFinnishDate } from '../../../common/utils/date';
 
 jest.setTimeout(10000);
 
@@ -68,6 +68,21 @@ test('Should show status text of invitation send to user and Invitation send but
 
   expect(screen.getByText('Kutsulinkki Haitattomaan lähetetty 15.1.2024')).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Lähetä kutsulinkki uudelleen' })).toBeInTheDocument();
+});
+
+test('Should update user invitation sent date when resending invitation', async () => {
+  const today = new Date().toISOString();
+  const { user } = render(
+    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa7" hankeTunnus="HAI22-2" />,
+  );
+  await waitForLoadingToFinish();
+
+  expect(screen.getByText('Kutsulinkki Haitattomaan lähetetty 15.1.2024')).toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: 'Lähetä kutsulinkki uudelleen' }));
+  await waitForLoadingToFinish();
+
+  expect(screen.getByText(`Kutsulinkki Haitattomaan lähetetty ${formatToFinnishDate(today)}`));
 });
 
 test('Permissions dropdown should be disabled and delete button should be hidden if only one user has all rights', async () => {

--- a/src/domain/hanke/hankeUsers/hankeUsersApi.ts
+++ b/src/domain/hanke/hankeUsers/hankeUsersApi.ts
@@ -81,9 +81,12 @@ export async function identifyUser(id: string) {
   return data;
 }
 
+/**
+ * Resend invitation to hanke to a user
+ */
 export async function resendInvitation(kayttajaId: string) {
-  await api.post(`kayttajat/${kayttajaId}/kutsu`);
-  return kayttajaId;
+  const { data } = await api.post<HankeUser>(`kayttajat/${kayttajaId}/kutsu`);
+  return data;
 }
 
 export async function getUserDeleteInfo(kayttajaId?: string | null) {

--- a/src/domain/hanke/hankeUsers/hooks/useResendInvitation.ts
+++ b/src/domain/hanke/hankeUsers/hooks/useResendInvitation.ts
@@ -1,9 +1,10 @@
 import { useRef } from 'react';
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { resendInvitation } from '../hankeUsersApi';
 import { HankeUser } from '../hankeUser';
 
 export default function useResendInvitation() {
+  const queryClient = useQueryClient();
   const resendInvitationMutation = useMutation(resendInvitation);
 
   // List of user ids for tracking which users have been sent the invitation link
@@ -12,7 +13,8 @@ export default function useResendInvitation() {
   function sendInvitation(user: HankeUser) {
     resendInvitationMutation.mutate(user.id, {
       onSuccess(data) {
-        linksSentTo.current.push(data);
+        linksSentTo.current.push(data.id);
+        queryClient.setQueryData(['hankeUser', data.id], data);
       },
     });
   }

--- a/src/domain/mocks/data/users.ts
+++ b/src/domain/mocks/data/users.ts
@@ -97,3 +97,12 @@ export async function remove(userId: string) {
   }
   users = users.filter((user) => user.id !== userToRemove.id);
 }
+
+export async function resendInvitation(userId: string) {
+  const user = await read(userId);
+  if (!user) {
+    throw new ApiError(`No user with id ${userId}`, 404);
+  }
+  user.kutsuttu = new Date().toISOString();
+  return user;
+}

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -333,7 +333,9 @@ export const handlers = [
   }),
 
   rest.post(`${apiUrl}/kayttajat/:kayttajaId/kutsu`, async (req, res, ctx) => {
-    return res(ctx.delay(), ctx.status(204));
+    const { kayttajaId } = req.params;
+    const user = await usersDB.resendInvitation(kayttajaId as string);
+    return res(ctx.delay(), ctx.json(user), ctx.status(200));
   }),
 
   rest.get(`${apiUrl}/kayttajat/:id/deleteInfo`, async (req, res, ctx) => {


### PR DESCRIPTION
# Description

Backend returns updated user after resending invitation, so invitation sent date is updated from that response in edit user view.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2538

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Go to edit some hanke user
2. Press "Lähetä kutsulinkki uudelleen" button
3. Date in "Kutsulinkki Haitattomaan lähetetty" text should be updated to today

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
