### PR TITLE
HAI-2546 Do not show 'show hanke' button when hanke feature is not enabled

### DIFF
--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -251,9 +251,11 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke, signedInUser, 
         </FeatureFlags>
 
         <div className={styles.hankeCardButtons}>
-          <Button theme="coat" onClick={navigateToHanke}>
-            {t('hankePortfolio:showHankeButton')}
-          </Button>
+          <FeatureFlags flags={['hanke']}>
+            <Button theme="coat" onClick={navigateToHanke}>
+              {t('hankePortfolio:showHankeButton')}
+            </Button>
+          </FeatureFlags>
           <Button theme="coat" variant="secondary" onClick={() => navigateToApplications()}>
             {t('hankePortfolio:showApplicationsButton')}
           </Button>


### PR DESCRIPTION
# Description

Put 'show hanke' button inside featureflags component.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2546

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Disable hanke feature by setting `REACT_APP_FEATURE_HANKE=0` and run the application. "Näytä hanke" button should not be shown in hanke list.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
