### PR TITLE
HAI-2545 Show not found text in user management mobile view if there are no search results

### DIFF
--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -203,6 +203,20 @@ test('Filtering works', async () => {
   expect(screen.getAllByText(`${users[7].etunimi} ${users[7].sukunimi}`)).toHaveLength(2);
 });
 
+test('Should show not found text if filtering has no results', async () => {
+  render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
+
+  await waitForLoadingToFinish();
+  fireEvent.change(screen.getByRole('combobox', { name: 'Haku' }), {
+    target: { value: 'natti' },
+  });
+
+  await waitFor(() =>
+    expect((screen.getByRole('table') as HTMLTableElement).tBodies[0].rows).toHaveLength(0),
+  );
+  expect(screen.getByText('Haulla ei löytynyt yhtään henkilöä')).toBeInTheDocument();
+});
+
 test('Should show error notification if information is not found', async () => {
   server.use(
     rest.get('/api/hankkeet/:hankeTunnus/kayttajat', async (req, res, ctx) => {

--- a/src/domain/hanke/accessRights/AccessRightsView.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.tsx
@@ -49,6 +49,7 @@ import UserDeleteNotification from '../hankeUsers/UserDeleteNotification';
 import UserDeleteInfoErrorNotification from '../hankeUsers/UserDeleteInfoErrorNotification';
 import { useLocalizedRoutes } from '../../../common/hooks/useLocalizedRoutes';
 import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
+import Text from '../../../common/components/text/Text';
 
 function UserIcon({
   user,
@@ -468,6 +469,11 @@ function AccessRightsView({ hankeUsers, hankeTunnus, hankeName, signedInUser }: 
               </UserCard>
             );
           })}
+          {page.length === 0 && (
+            <Text tag="p" spacingTop="m" spacingBottom="s" className="heading-m">
+              {t('hankeUsers:notifications:usersNotFound')}
+            </Text>
+          )}
         </div>
 
         <div className={styles.pagination}>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1020,7 +1020,8 @@
       "invitationSentErrorLabel": "Virhe linkin lähettämisessä",
       "invitationSentErrorText": "<0>Kutsulinkin lähettämisessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>",
       "userDeletedLabel": "Käyttäjä poistettu",
-      "userDeletedText": "Käyttäjä poistettiin onnistuneesti"
+      "userDeletedText": "Käyttäjä poistettiin onnistuneesti",
+      "usersNotFound": "Haulla ei löytynyt yhtään henkilöä"
     },
     "buttons": {
       "resendInvitation": "Lähetä kutsulinkki uudelleen",


### PR DESCRIPTION
# Description

In user management mobile view if there are no search results, show not found text.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2545

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Go to user management view of some hanke with browser window in small size
2. Type some search text that has no results
3. Text "Haulla ei löytynyt yhtään henkilöä" should be displayed

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
