### PR TITLE
HAI-2544 Show Send Application button always and disable it when send is not allowed

### DIFF
--- a/src/domain/johtoselvitys_new/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys_new/JohtoselvitysContainer.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { Button, IconCross, IconEnvelope, IconSaveDiskette, StepState } from 'hds-react';
+import {
+  Button,
+  IconCross,
+  IconEnvelope,
+  IconSaveDiskette,
+  Notification,
+  StepState,
+} from 'hds-react';
 import { FormProvider, useForm, FieldPath } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -117,7 +124,7 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
     reset,
   } = formContext;
 
-  // Setup a callback to save application id to session storage
+  // Set up a callback to save application id to session storage
   // when the page is about to be unloaded if the application
   // has been saved (id exists) and user is not editing
   // previously created application. This is done so that
@@ -413,10 +420,10 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
           }
 
           const lastStep = activeStepIndex === formSteps.length - 1;
-          const showSendButton =
-            lastStep &&
-            isApplicationDraft(getValues('alluStatus') as AlluStatus | null) &&
-            isContactIn(signedInUser, getValues('applicationData'));
+          const isDraft = isApplicationDraft(getValues('alluStatus') as AlluStatus | null);
+          const isContact = isContactIn(signedInUser, getValues('applicationData'));
+          const showSendButton = lastStep && isDraft;
+          const disableSendButton = showSendButton && !isContact;
 
           const saveAndQuitIsLoading =
             applicationCreateMutation.isLoading ||
@@ -455,16 +462,21 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
               >
                 {t('hankeForm:saveDraftButton')}
               </Button>
-
               {showSendButton && (
                 <Button
                   type="submit"
                   iconLeft={<IconEnvelope aria-hidden="true" />}
                   isLoading={applicationSendMutation.isLoading}
                   loadingText={t('common:buttons:sendingText')}
+                  disabled={disableSendButton}
                 >
                   {t('hakemus:buttons:sendApplication')}
                 </Button>
+              )}
+              {disableSendButton && (
+                <Notification size="small" style={{ marginTop: 'var(--spacing-xs)' }} type="info">
+                  {t('hakemus:notifications:sendApplicationDisabled')}
+                </Notification>
               )}
             </FormActions>
           );

--- a/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
@@ -437,7 +437,7 @@ test('Should show and disable send button and show notification when user is not
   expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).toBeDisabled();
   expect(
     screen.queryByText(
-      'Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö',
+      'Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö.',
     ),
   ).toBeInTheDocument();
 });

--- a/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
@@ -402,9 +402,14 @@ test('Should not show send button when application has moved to pending state', 
 
   expect(screen.queryByText('Vaihe 5/5: Yhteenveto')).toBeInTheDocument();
   expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      'Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö',
+    ),
+  ).not.toBeInTheDocument();
 });
 
-test('Should not show send button when user is not a contact person', async () => {
+test('Should show and disable send button and show notification when user is not a contact person', async () => {
   server.use(
     rest.get('/api/hankkeet/:hankeTunnus/whoami', async (_, res, ctx) => {
       return res(
@@ -419,16 +424,25 @@ test('Should not show send button when user is not a contact person', async () =
   );
 
   const { user } = render(
-    <JohtoselvitysContainer application={applications[1] as Application<JohtoselvitysData>} />,
+    <JohtoselvitysContainer
+      hankeData={hankkeet[1] as HankeData}
+      application={applications[0] as Application<JohtoselvitysData>}
+    />,
   );
 
   await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
 
   expect(screen.queryByText('Vaihe 5/5: Yhteenveto')).toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).toBeDisabled();
+  expect(
+    screen.queryByText(
+      'Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö',
+    ),
+  ).toBeInTheDocument();
 });
 
-test('Should show send button when application is edited in draft state and user is a contact person', async () => {
+test('Should show and enable button when application is edited in draft state and user is a contact person', async () => {
   server.use(
     rest.get('/api/hankkeet/:hankeTunnus/whoami', async (_, res, ctx) => {
       return res(
@@ -452,6 +466,12 @@ test('Should show send button when application is edited in draft state and user
   await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
 
   expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).toBeEnabled();
+  expect(
+    screen.queryByText(
+      'Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö',
+    ),
+  ).not.toBeInTheDocument();
 });
 
 test('Should not allow start date be after end date', async () => {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -731,7 +731,8 @@
       "cancelSuccessText": "Hakemus peruttiin onnistuneesti",
       "noApplications": "Hankkeella ei ole lisättyjä hakemuksia",
       "maxAttachmentsNumberExceeded": "Tiedoston ({{fileName}}) lataus epäonnistui, liitteiden enimmäismäärä ({{maxNumber}} kpl) ylitetty.",
-      "sentApplicationPersonalInfoNotification": "Lähetetyn hakemuksen omia tietoja ei voi muokata"
+      "sentApplicationPersonalInfoNotification": "Lähetetyn hakemuksen omia tietoja ei voi muokata",
+      "sendApplicationDisabled": "Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö."
     },
     "sentDialog": {
       "title": "Hakemus lähetetty",


### PR DESCRIPTION
# Description

Show Send Application button always (if application is a draft) and disable it when the user is not a contact person on the application. Show a notification in this case.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2544

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

1. Create new johtoselvitys and fill it
2. Add a new contact person (other than yourself)
3. Send button should be visible and disabled and a notification should be shown (under the buttons).

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
