### PR TITLE
HAI-2536 Hide no files selected notification in FileUpload component

### DIFF
--- a/src/common/components/fileUpload/FileUpload.module.scss
+++ b/src/common/components/fileUpload/FileUpload.module.scss
@@ -1,6 +1,11 @@
 .uploadContainer {
-  min-height: 280px;
+  min-height: 250px;
   margin-bottom: var(--spacing-s);
+
+  // Hide the info text that no files are selected
+  [class*='info-text'] {
+    display: none !important;
+  }
 }
 
 .loadingContainer {

--- a/src/common/components/fileUpload/FileUpload.test.tsx
+++ b/src/common/components/fileUpload/FileUpload.test.tsx
@@ -372,7 +372,7 @@ test('Should be able to cancel upload requests', async () => {
   await waitFor(() =>
     expect(screen.queryByText('Tallennetaan tiedostoja')).not.toBeInTheDocument(),
   );
-  expect(abortSpy).toBeCalledTimes(1);
+  expect(abortSpy).toHaveBeenCalledTimes(1);
   abortSpy.mockRestore();
 });
 


### PR DESCRIPTION
# Description

No files selected notification is hidden in FileUpload component because it is not needed and can be confusing to users.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2536

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Check in johtoselvitys and hanke forms attachments pages that the notification "Yhtään tiedostoa ei ole valittu." is not visible.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
