### PR TITLE
HAI-2506 Show feedback notification in home page once per session

### DIFF
--- a/src/domain/homepage/HomepageComponent.tsx
+++ b/src/domain/homepage/HomepageComponent.tsx
@@ -24,12 +24,16 @@ import MainHeading from '../../common/components/mainHeading/MainHeading';
 import HankeCreateDialog from '../hanke/hankeCreateDialog/HankeCreateDialog';
 import JohtoselvitysCreateDialog from '../johtoselvitys_new/johtoselvitysCreateDialog/JohtoselvitysCreateDialog';
 
+const FEEDBACK_NOTIFICATION_CLOSED = 'feedback-notification-closed';
+
 const Homepage: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { PUBLIC_HANKKEET_MAP, PUBLIC_HANKKEET_LIST, HANKEPORTFOLIO, JOHTOSELVITYSHAKEMUS } =
     useLocalizedRoutes();
-  const [feedbackOpen, setFeedbackOpen] = useState(true);
+  const [feedbackOpen, setFeedbackOpen] = useState(
+    !sessionStorage.getItem(FEEDBACK_NOTIFICATION_CLOSED),
+  );
   const [showHankeCreateDialog, setShowHankeCreateDialog] = useState(false);
   const [showJohtoselvitysCreateDialog, setShowJohtoselvitysCreateDialog] = useState(false);
   const { data: user } = useUser();
@@ -190,7 +194,10 @@ const Homepage: React.FC<React.PropsWithChildren<unknown>> = () => {
                 autoClose={false}
                 dismissible
                 closeButtonLabelText={`${t('common:components:notification:closeButtonLabelText')}`}
-                onClose={() => setFeedbackOpen(false)}
+                onClose={() => {
+                  setFeedbackOpen(false);
+                  sessionStorage.setItem(FEEDBACK_NOTIFICATION_CLOSED, 'true');
+                }}
               >
                 <p>
                   {t('homepage:notification:text')}


### PR DESCRIPTION
# Description

When user closes feedback for Haitaton notification in home page, set value to session storage, so that the notification is not shown again on page refresh.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2506

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Close the notification "Auta meitä tekemään Haitattomasta vielä parempi" in home page and refresh the page
2. Notification should not be visible

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
