### PR TITLE
HAI-2541 Stricter user deletion check

### DIFF
--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -8,6 +8,7 @@ import { HankeUser, SignedInUser } from '../hankeUsers/hankeUser';
 import AccessRightsView from './AccessRightsView';
 import { USER_ALL } from '../../mocks/signedInUser';
 import { reset } from '../../mocks/data/users';
+import { cloneDeep } from 'lodash';
 
 jest.setTimeout(50000);
 
@@ -417,7 +418,7 @@ test('Should not be able to delete user who is the only yhteyshenkilö of the om
   const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
 
   await waitForLoadingToFinish();
-  await user.click(screen.getAllByRole('button', { name: 'Poista käyttäjä' })[4]);
+  await user.click(screen.getAllByRole('button', { name: 'Poista käyttäjä' })[3]);
 
   await screen.findByText('Käyttäjää ei voi poistaa');
   expect(
@@ -432,7 +433,7 @@ test('Should not be able to delete user who has sent hakemuksia', async () => {
   const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
 
   await waitForLoadingToFinish();
-  await user.click(screen.getAllByRole('button', { name: 'Poista käyttäjä' })[1]);
+  await user.click(screen.getAllByRole('button', { name: 'Poista käyttäjä' })[0]);
 
   await screen.findByText('Käyttäjää ei voi poistaa');
   expect(
@@ -447,7 +448,7 @@ test('Should not be able to delete user who has sent hakemuksia, which are pendi
   const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
 
   await waitForLoadingToFinish();
-  await user.click(screen.getAllByRole('button', { name: 'Poista käyttäjä' })[2]);
+  await user.click(screen.getAllByRole('button', { name: 'Poista käyttäjä' })[1]);
 
   await screen.findByText('Käyttäjää ei voi poistaa');
   expect(
@@ -461,7 +462,7 @@ test('Should be able to delete user who has draft hakemuksia, but should notify 
   const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-2" />);
 
   await waitForLoadingToFinish();
-  await user.click(screen.getAllByRole('button', { name: 'Poista käyttäjä' })[3]);
+  await user.click(screen.getAllByRole('button', { name: 'Poista käyttäjä' })[2]);
 
   await screen.findByText('Poista käyttäjä hankkeelta');
   expect(
@@ -479,11 +480,13 @@ test('Should be able to delete user who has draft hakemuksia, but should notify 
 });
 
 test('User should be able to delete themselves', async () => {
+  const hankeUsers = cloneDeep(users).slice(0, 5) as HankeUser[];
+  hankeUsers[3].tunnistautunut = true;
   const { user } = render(
     <AccessRightsView
       hankeTunnus="HAI22-2"
       hankeName="Aidasmäentien vesihuollon rakentaminen"
-      hankeUsers={users.slice(0, 5) as HankeUser[]}
+      hankeUsers={hankeUsers}
       signedInUser={{ ...USER_ALL, hankeKayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6' }}
     />,
   );

--- a/src/domain/hanke/hankeUsers/EditUserView.test.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.test.tsx
@@ -85,16 +85,16 @@ test('Should update user invitation sent date when resending invitation', async 
   expect(screen.getByText(`Kutsulinkki Haitattomaan lähetetty ${formatToFinnishDate(today)}`));
 });
 
-test('Permissions dropdown should be disabled and delete button should be hidden if only one user has all rights', async () => {
+test('Permissions dropdown should be disabled and delete button should be hidden if only one user is identified and has all rights', async () => {
   const hankeTunnus = 'HAI22-2';
-  const users = (await readAll(hankeTunnus)).slice(1, 4);
+  const users = (await readAll(hankeTunnus)).slice(0, 4);
   server.use(
     rest.get('/api/hankkeet/:hankeTunnus/kayttajat', async (req, res, ctx) => {
       return res(ctx.status(200), ctx.json({ kayttajat: users }));
     }),
   );
 
-  render(<EditUserContainer id={users[2].id} hankeTunnus={hankeTunnus} />);
+  render(<EditUserContainer id={users[0].id} hankeTunnus={hankeTunnus} />);
   await waitForLoadingToFinish();
 
   expect(screen.getByRole('button', { name: /käyttöoikeudet/i })).toBeDisabled();
@@ -277,7 +277,7 @@ test('Should show error notification if user delete info request fails', async (
     }),
   );
   const { user } = render(
-    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />,
+    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa7" hankeTunnus="HAI22-2" />,
   );
   await waitForLoadingToFinish();
   await user.click(screen.getByRole('button', { name: /poista käyttäjä/i }));
@@ -292,7 +292,7 @@ test('Should show error notification if deleting user fails', async () => {
     }),
   );
   const { user } = render(
-    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />,
+    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afb6" hankeTunnus="HAI22-2" />,
   );
   await waitForLoadingToFinish();
   await user.click(screen.getByRole('button', { name: /poista käyttäjä/i }));

--- a/src/domain/hanke/hankeUsers/utils.ts
+++ b/src/domain/hanke/hankeUsers/utils.ts
@@ -43,9 +43,12 @@ export function showUserDeleteButton(
   hankeUsers?: HankeUser[],
   signedInUser?: SignedInUser,
 ) {
+  // Check if user is the only identified user with all rights
+  const usersWithAllRights = hankeUsers?.filter(
+    (hankeUser) => hankeUser.kayttooikeustaso === 'KAIKKI_OIKEUDET' && hankeUser.tunnistautunut,
+  );
   const isOnlyWithAllRights =
-    user.kayttooikeustaso === 'KAIKKI_OIKEUDET' &&
-    hankeUsers?.filter((hankeUser) => hankeUser.kayttooikeustaso === 'KAIKKI_OIKEUDET').length ===
-      1;
+    usersWithAllRights?.length === 1 && usersWithAllRights[0].id === user.id;
+
   return Boolean(signedInUser?.kayttooikeudet.includes('DELETE_USER') && !isOnlyWithAllRights);
 }


### PR DESCRIPTION
# Description

Show delete button for users if they are not the only identified user with KAIKKI_OIKEUDET permission. Before the check did not count identified status.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2541

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

1. Create a johtoselvityshakemus
2. Add a contact person
3. Give them KAIKKI_OIKEUDET
4. Check that you cannot remove yourself from hanke

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
