### PR TITLE
HAI-2550 Limit work name and description in johtoselvitys form

### DIFF
--- a/src/common/components/textArea/TextArea.tsx
+++ b/src/common/components/textArea/TextArea.tsx
@@ -14,6 +14,7 @@ type Props = {
   shouldUnregister?: boolean;
   className?: string;
   testId?: string;
+  maxLength?: number | undefined;
 };
 
 const TextArea: React.FC<Props> = ({
@@ -26,6 +27,7 @@ const TextArea: React.FC<Props> = ({
   shouldUnregister,
   className,
   testId,
+  maxLength,
 }) => {
   const { t } = useTranslation();
   const { control } = useFormContext();
@@ -54,6 +56,7 @@ const TextArea: React.FC<Props> = ({
             disabled={disabled}
             errorText={getInputErrorText(t, error)}
             ref={ref}
+            maxLength={maxLength}
           />
         );
       }}

--- a/src/domain/johtoselvitys_new/BasicInfo.tsx
+++ b/src/domain/johtoselvitys_new/BasicInfo.tsx
@@ -67,6 +67,7 @@ export function BasicInfo() {
         label={t('hakemus:labels:nimi')}
         required
         autoComplete="on"
+        maxLength={100}
       />
 
       <TextInput
@@ -150,6 +151,7 @@ export function BasicInfo() {
         name="applicationData.workDescription"
         label={t('hakemus:labels:kuvaus')}
         required
+        maxLength={2000}
       />
     </div>
   );

--- a/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys_new/JohtoselvitysForm.test.tsx
@@ -784,3 +784,31 @@ test('Should remove validation error if yhteyshenkilo is created for yhteystieto
     screen.queryByText(/vähintään yksi yhteyshenkilö tulee olla asetettuna/i),
   ).not.toBeInTheDocument();
 });
+
+test('Work name should be limited to 100 characters', async () => {
+  const { user } = render(<JohtoselvitysContainer />);
+  const initialName = 'a'.repeat(99);
+
+  fireEvent.change(screen.getByLabelText(/työn nimi/i), {
+    target: {
+      value: initialName,
+    },
+  });
+  await user.type(screen.getByLabelText(/työn nimi/i), 'bbb');
+
+  expect(screen.getByLabelText(/työn nimi/i)).toHaveValue(initialName.concat('b'));
+});
+
+test('Work description should be limited to 2000 characters', async () => {
+  const { user } = render(<JohtoselvitysContainer />);
+  const initialDescription = 'a'.repeat(1999);
+
+  fireEvent.change(screen.getByLabelText(/työn kuvaus/i), {
+    target: {
+      value: initialDescription,
+    },
+  });
+  await user.type(screen.getByLabelText(/työn kuvaus/i), 'bbb');
+
+  expect(screen.getByLabelText(/työn kuvaus/i)).toHaveValue(initialDescription.concat('b'));
+});


### PR DESCRIPTION
# Description

Added a limit of 100 characters to work name field and a limit of 2000 characters to work description field in johtoselvitys form. Before there were no limits.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2550

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Input name of 100 characters to work name field in johtoselvitys form and check that no more characters can written
2. Do the same for work description field but with 2000 characters
3. Check that the form can be saved successfully with those maximum characters

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
