### PR TITLE
HAI-2533 Fix updating hakemus status tag color in hakemus list

### DIFF
--- a/src/domain/application/components/ApplicationStatusTag.module.scss
+++ b/src/domain/application/components/ApplicationStatusTag.module.scss
@@ -4,10 +4,10 @@
 }
 
 .bgYellow {
-  background-color: var(--color-alert);
+  background-color: var(--color-alert) !important;
 }
 
 .bgGreen {
-  background-color: var(--color-success);
-  color: var(--color-white);
+  background-color: var(--color-success) !important;
+  color: var(--color-white) !important;
 }

--- a/src/domain/application/components/ApplicationStatusTag.module.scss
+++ b/src/domain/application/components/ApplicationStatusTag.module.scss
@@ -2,3 +2,12 @@
   display: flex;
   align-items: center;
 }
+
+.bgYellow {
+  background-color: var(--color-alert);
+}
+
+.bgGreen {
+  background-color: var(--color-success);
+  color: var(--color-white);
+}

--- a/src/domain/application/components/ApplicationStatusTag.test.tsx
+++ b/src/domain/application/components/ApplicationStatusTag.test.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import { fireEvent, render, screen } from '../../../testUtils/render';
+import ApplicationStatusTag from './ApplicationStatusTag';
+import { AlluStatusStrings } from '../types/application';
+
+test('Should show tag with default background (not have yellow or green background) when status is null', () => {
+  render(<ApplicationStatusTag status={null} />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).toHaveTextContent('Luonnos');
+  expect(tag).not.toHaveClass('bgYellow');
+  expect(tag).not.toHaveClass('bgGreen');
+});
+
+test('Should show tag with default background (not have yellow or green background) when status is REPLACED', () => {
+  render(<ApplicationStatusTag status="REPLACED" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).not.toHaveClass('bgYellow');
+  expect(tag).not.toHaveClass('bgGreen');
+  expect(tag).toHaveTextContent('Korvattu');
+});
+
+test('Should show tag with default background (not have yellow or green background) when status is CANCELLED', () => {
+  render(<ApplicationStatusTag status="CANCELLED" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).not.toHaveClass('bgYellow');
+  expect(tag).not.toHaveClass('bgGreen');
+  expect(tag).toHaveTextContent('Hakemus peruttu');
+});
+
+test('Should show tag with default background (not have yellow or green background) when status is ARCHIVED', () => {
+  render(<ApplicationStatusTag status="ARCHIVED" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).not.toHaveClass('bgYellow');
+  expect(tag).not.toHaveClass('bgGreen');
+  expect(tag).toHaveTextContent('Työ arkistoitu');
+});
+
+test('Should show tag with green background when status is DECISION', () => {
+  render(<ApplicationStatusTag status="DECISION" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).toHaveClass('bgGreen');
+  expect(tag).toHaveTextContent('Päätös');
+});
+
+test('Should show tag with green background when status is FINISHED', () => {
+  render(<ApplicationStatusTag status="FINISHED" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).toHaveClass('bgGreen');
+  expect(tag).toHaveTextContent('Työ valmis');
+});
+
+test('Should show tag with green background when status is OPERATIONAL_CONDITION', () => {
+  render(<ApplicationStatusTag status="OPERATIONAL_CONDITION" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).toHaveClass('bgGreen');
+  expect(tag).toHaveTextContent('Toiminnallinen kunto');
+});
+
+test('Should show tag with yellow background when status is PENDING', () => {
+  render(<ApplicationStatusTag status="PENDING" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).toHaveClass('bgYellow');
+  expect(tag).toHaveTextContent('Odottaa käsittelyä');
+});
+
+test('Should show tag with yellow background when status is PENDING_CLIENT', () => {
+  render(<ApplicationStatusTag status="PENDING_CLIENT" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).toHaveClass('bgYellow');
+  expect(tag).toHaveTextContent('Näkyy viranomaiselle');
+});
+
+test('Should show tag with yellow background when status is HANDLING', () => {
+  render(<ApplicationStatusTag status="HANDLING" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).toHaveClass('bgYellow');
+  expect(tag).toHaveTextContent('Käsittelyssä');
+});
+
+test('Should show tag with yellow background when status is WAITING_INFORMATION', () => {
+  render(<ApplicationStatusTag status="WAITING_INFORMATION" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).toHaveClass('bgYellow');
+  expect(tag).toHaveTextContent('Täydennyspyyntö');
+});
+
+test('Should show tag with yellow background when status is INFORMATION_RECEIVED', () => {
+  render(<ApplicationStatusTag status="INFORMATION_RECEIVED" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).toHaveClass('bgYellow');
+  expect(tag).toHaveTextContent('Täydennetty käsittelyyn');
+});
+
+test('Should show tag with yellow background when status is RETURNED_TO_PREPARATION', () => {
+  render(<ApplicationStatusTag status="RETURNED_TO_PREPARATION" />);
+  const tag = screen.getByTestId('application-status-tag');
+
+  expect(tag).toHaveClass('bgYellow');
+  expect(tag).toHaveTextContent('Käsittelyssä');
+});
+
+function TestComponent({ changedStatus }: { changedStatus: AlluStatusStrings }) {
+  const [alluStatus, setAlluStatus] = useState<AlluStatusStrings | null>(null);
+
+  function changeStatus() {
+    setAlluStatus(changedStatus);
+  }
+
+  return (
+    <>
+      <ApplicationStatusTag status={alluStatus} />
+      <button onClick={changeStatus}>Change status</button>
+    </>
+  );
+}
+
+test('Should change background color from default to yellow when status changes from null to PENDING', async () => {
+  render(<TestComponent changedStatus="PENDING" />);
+  const tag = screen.getByTestId('application-status-tag');
+  const button = screen.getByRole('button');
+
+  expect(tag).not.toHaveClass('bgYellow');
+
+  fireEvent.click(button);
+
+  expect(tag).toHaveClass('bgYellow');
+});

--- a/src/domain/application/components/ApplicationStatusTag.tsx
+++ b/src/domain/application/components/ApplicationStatusTag.tsx
@@ -1,41 +1,51 @@
-import React from 'react';
-import { IconAlertCircle, Tag } from 'hds-react';
+import { IconAlertCircle, IconCheckCircle, Tag } from 'hds-react';
 import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
 import { AlluStatusStrings, AlluStatus } from '../types/application';
 import styles from './ApplicationStatusTag.module.scss';
 
-/**
- * Get theme for status tag.
- * Grey background if there is no Allu status (meaning it's draft)
- * or status is replaced (korvattu),
- * green background with white text if status is decision (päätös)
- * and yellow backround otherwise.
- */
-function getTheme(status: AlluStatusStrings | null) {
-  if (status === null || status === AlluStatus.REPLACED) {
-    return undefined;
-  }
-
-  if (status === AlluStatus.DECISION) {
-    return { '--tag-background': 'var(--color-success)', '--tag-color': 'var(--color-white)' };
-  }
-
-  return { '--tag-background': 'var(--color-alert)' };
-}
-
-function ApplicationStatusTag({ status }: { status: AlluStatusStrings | null }) {
+function ApplicationStatusTag({ status }: Readonly<{ status: AlluStatusStrings | null }>) {
   const { t } = useTranslation();
 
   const statusText = t(`hakemus:status:${status}`);
-  // If application is in draft state or waiting information (täydennyspyyntö),
-  // display alert icon before status text
-  const icon =
-    status === null || status === AlluStatus.WAITING_INFORMATION ? (
-      <IconAlertCircle style={{ marginRight: 'var(--spacing-2-xs)' }} />
-    ) : null;
+
+  // If application is in draft state or waiting information (täydennyspyyntö)
+  // or finished (valmis) display icon before status text
+  let icon = null;
+  if (status === null || status === AlluStatus.WAITING_INFORMATION) {
+    icon = <IconAlertCircle style={{ marginRight: 'var(--spacing-2-xs)' }} />;
+  }
+  if (status === AlluStatus.FINISHED) {
+    icon = <IconCheckCircle style={{ marginRight: 'var(--spacing-2-xs)' }} />;
+  }
+
+  /*
+   * Determine background color for status tag.
+   * Grey (default) background if there is no Allu status (meaning it's draft)
+   * or status is replaced (korvattu) or cancelled (peruttu) or archived (arkistoitu),
+   * green background with white text if status is decision (päätös) or finished (työ valmis)
+   * or operational condition (toiminnallinen kunto),
+   * and yellow background otherwise.
+   */
+  const bgDefault =
+    status === null ||
+    status === AlluStatus.REPLACED ||
+    status === AlluStatus.CANCELLED ||
+    status === AlluStatus.ARCHIVED;
+  const bgGreen =
+    status === AlluStatus.DECISION ||
+    status === AlluStatus.FINISHED ||
+    status === AlluStatus.OPERATIONAL_CONDITION;
+  const bgYellow = !bgDefault && !bgGreen;
 
   return (
-    <Tag theme={getTheme(status)} data-testid="application-status-tag">
+    <Tag
+      className={clsx({
+        [styles.bgYellow]: bgYellow,
+        [styles.bgGreen]: bgGreen,
+      })}
+      data-testid="application-status-tag"
+    >
       <div className={styles.applicationStatusTag}>
         {icon} {statusText}
       </div>

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -114,3 +114,12 @@ export async function remove(id: number) {
   }
   hakemukset = hakemukset.filter((hakemus) => hakemus.id !== id);
 }
+
+export async function sendHakemus(id: number) {
+  const hakemus = await read(id);
+  if (!hakemus) {
+    throw new ApiError(`No application with id ${id}`, 404);
+  }
+  hakemus.alluStatus = 'PENDING';
+  return hakemus;
+}

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -196,7 +196,7 @@ export const handlers = [
 
   rest.post(`${apiUrl}/hakemukset/:id/laheta`, async (req, res, ctx) => {
     const { id } = req.params;
-    const hakemus = await hakemuksetDB.read(Number(id));
+    const hakemus = await hakemuksetDB.sendHakemus(Number(id));
 
     if (!hakemus) {
       return res(


### PR DESCRIPTION
# Description

Fixed a problem where after sending johtoselvityshakemus to Allu, the status tag color of hakemus would not always update correctly to yellow color.

Also made sure that all different statuses have correct colors.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2533

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create new johtoselvitys
2. Fill the form and send it
3. Status tag of the new hakemus should be yellow with text "Odottaa käsittelyä"

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
