### PR TITLE
HAI-1995 Add information to hanke list and hanke view when there are no hanke areas

### DIFF
--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -287,12 +287,12 @@ test('Should show map if there are hanke areas', async () => {
   expect(screen.getByTestId('hanke-map')).toBeInTheDocument();
 });
 
-test('Should not show map if there are no hanke areas', async () => {
+test('Should show map placeholder text if there are no hanke areas', async () => {
   render(<HankeViewContainer hankeTunnus="HAI22-5" />);
 
   await waitForLoadingToFinish();
 
-  expect(screen.queryByTestId('hanke-map')).not.toBeInTheDocument();
+  expect(screen.getByText('Hankealueita ei ole määritelty')).toBeInTheDocument();
 });
 
 test('Should not show user management button if access rights feature is not enabled', async () => {

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -56,6 +56,7 @@ import AttachmentSummary from '../edit/components/AttachmentSummary';
 import useHankeAttachments from '../hankeAttachments/useHankeAttachments';
 import MainHeading from '../../../common/components/mainHeading/MainHeading';
 import HankeGeneratedStateNotification from '../edit/components/HankeGeneratedStateNotification';
+import MapPlaceholder from '../../map/components/MapPlaceholder/MapPlaceholder';
 
 type AreaProps = {
   area: HankeAlue;
@@ -277,7 +278,7 @@ const HankeView: React.FC<Props> = ({
         </InformationViewHeaderButtons>
       </InformationViewHeader>
 
-      <InformationViewContentContainer hideSideBar={alueet === undefined || alueet?.length === 0}>
+      <InformationViewContentContainer hideSideBar={!features.hanke}>
         <InformationViewMainContent>
           <FeatureFlags flags={['hanke']}>
             <HankeGeneratedStateNotification
@@ -369,10 +370,10 @@ const HankeView: React.FC<Props> = ({
             </TabPanel>
           </Tabs>
         </InformationViewMainContent>
-        <FeatureFlags flags={['hanke']}>
-          {alueet?.length > 0 && (
-            <InformationViewSidebar testId="hanke-map">
-              <OwnHankeMapHeader hankeTunnus={hankeData.hankeTunnus} />
+        <InformationViewSidebar testId="hanke-map">
+          <OwnHankeMapHeader hankeTunnus={hankeData.hankeTunnus} showLink={alueet.length > 0} />
+          {alueet?.length > 0 ? (
+            <>
               <OwnHankeMap hanke={hankeData} />
               {alueet?.map((area, index) => {
                 return (
@@ -385,9 +386,11 @@ const HankeView: React.FC<Props> = ({
                   />
                 );
               })}
-            </InformationViewSidebar>
+            </>
+          ) : (
+            <MapPlaceholder />
           )}
-        </FeatureFlags>
+        </InformationViewSidebar>
       </InformationViewContentContainer>
     </InformationViewContainer>
   );

--- a/src/domain/hanke/portfolio/HankePortfolio.test.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolio.test.tsx
@@ -209,6 +209,7 @@ describe('HankePortfolioComponent', () => {
     await user.click(screen.getByText(editedHankeList[1].nimi));
 
     expect(screen.getAllByTestId('hanke-map')).toHaveLength(1);
+    expect(screen.getAllByText('Hankealueita ei ole määritelty')).toHaveLength(1);
   });
 });
 

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -46,6 +46,7 @@ import MainHeading from '../../../common/components/mainHeading/MainHeading';
 import useFocusToElement from '../../../common/hooks/useFocusToElement';
 import HDSLink from '../../../common/components/Link/Link';
 import HankeCreateDialog from '../hankeCreateDialog/HankeCreateDialog';
+import MapPlaceholder from '../../map/components/MapPlaceholder/MapPlaceholder';
 
 type CustomAccordionProps = {
   hanke: HankeData;
@@ -241,12 +242,19 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke, signedInUser, 
             </FeatureFlags>
           </div>
           <div>
-            {hanke.alueet?.length > 0 && isOpen && (
-              <div data-testid="hanke-map">
-                <OwnHankeMapHeader hankeTunnus={hanke.hankeTunnus} />
-                <OwnHankeMap hanke={hanke} />
-              </div>
-            )}
+            <FeatureFlags flags={['hanke']}>
+              <OwnHankeMapHeader
+                hankeTunnus={hanke.hankeTunnus}
+                showLink={hanke.alueet?.length > 0}
+              />
+              {hanke.alueet?.length > 0 && isOpen ? (
+                <div data-testid="hanke-map">
+                  <OwnHankeMap hanke={hanke} />
+                </div>
+              ) : (
+                <MapPlaceholder />
+              )}
+            </FeatureFlags>
           </div>
         </FeatureFlags>
 

--- a/src/domain/map/components/MapPlaceholder/MapPlaceholder.tsx
+++ b/src/domain/map/components/MapPlaceholder/MapPlaceholder.tsx
@@ -1,0 +1,22 @@
+import { Box, Flex } from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Shows a placeholder text for the map when there are no areas to display.
+ */
+export default function MapPlaceholder() {
+  const { t } = useTranslation();
+
+  return (
+    <Flex
+      justifyContent="center"
+      alignItems="center"
+      height="321px"
+      backgroundColor="var(--color-black-10)"
+    >
+      <Box as="p" fontSize="var(--fontsize-body-s)">
+        {t('hankePortfolio:noAreas')}
+      </Box>
+    </Flex>
+  );
+}

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -897,6 +897,7 @@
     "hankkeentyyppiHelperText": "Valitse hankkeen työmaan tyyppi tai tyypit",
     "areaLocation": "Alueiden sijainti",
     "openMapToNewWindow": "Avaa kartta uuteen ikkunaan",
+    "noAreas": "Hankealueita ei ole määritelty",
     "showHankeButton": "Näytä hanke",
     "showApplicationsButton": "Näytä hankkeen hakemukset",
     "generatedStateLabel": "Hanke muodostettu johtoselvityksen perusteella",


### PR DESCRIPTION
# Description

When there are no hanke areas yet, a placeholder text is shown in place of a map in hanke list and hanke view.

### Jira Issue:

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check that hanke with no areas has the placeholder text in place of a map in hanke list and hanke view.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
