### PR TITLE
HAI-2475 Improve hanke area deletion

### DIFF
--- a/src/common/components/HDSConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/common/components/HDSConfirmationDialog/ConfirmationDialog.tsx
@@ -43,6 +43,29 @@ const ConfirmationDialog: React.FC<React.PropsWithChildren<Props>> = ({
 }) => {
   const { t } = useTranslation();
 
+  const mainButton = (
+    <Button
+      onClick={mainAction}
+      data-testid="dialog-button-test"
+      variant={variant}
+      iconLeft={mainBtnIcon}
+      isLoading={isLoading}
+    >
+      {mainBtnLabel}
+    </Button>
+  );
+
+  const secondaryButton = showSecondaryButton && (
+    <Button
+      variant="secondary"
+      onClick={close}
+      theme={variant === 'danger' ? 'black' : 'default'}
+      data-testid="dialog-cancel-test"
+    >
+      {t('common:confirmationDialog:cancelButton')}
+    </Button>
+  );
+
   return (
     <Dialog
       id="dialog"
@@ -70,24 +93,16 @@ const ConfirmationDialog: React.FC<React.PropsWithChildren<Props>> = ({
         )}
       </Dialog.Content>
       <Dialog.ActionButtons>
-        <Button
-          onClick={mainAction}
-          data-testid="dialog-button-test"
-          variant={variant}
-          iconLeft={mainBtnIcon}
-          isLoading={isLoading}
-        >
-          {mainBtnLabel}
-        </Button>
-        {showSecondaryButton && (
-          <Button
-            variant="secondary"
-            onClick={close}
-            theme={variant === 'danger' ? 'black' : 'default'}
-            data-testid="dialog-cancel-test"
-          >
-            {t('common:confirmationDialog:cancelButton')}
-          </Button>
+        {variant === 'danger' ? (
+          <>
+            {secondaryButton}
+            {mainButton}
+          </>
+        ) : (
+          <>
+            {mainButton}
+            {secondaryButton}
+          </>
         )}
       </Dialog.ActionButtons>
     </Dialog>

--- a/src/domain/hanke/edit/components/Haitat.module.scss
+++ b/src/domain/hanke/edit/components/Haitat.module.scss
@@ -1,5 +1,5 @@
 .haitatContainer {
-  padding: var(--spacing-m);
+  padding: var(--spacing-xs);
   margin-top: var(--spacing-xs);
 }
 
@@ -24,4 +24,9 @@
   & > div:last-child {
     flex: 1 1 250px;
   }
+}
+
+.formRowReverse {
+  flex-direction: row-reverse;
+  align-items: flex-start;
 }

--- a/src/domain/hanke/edit/components/Haitat.tsx
+++ b/src/domain/hanke/edit/components/Haitat.tsx
@@ -164,7 +164,7 @@ const Haitat: React.FC<Props> = ({ index, onRemoveArea }) => {
       <ConfirmationDialog
         title={t('hankeForm:labels:removeAreaTitle')}
         description={t('hankeForm:labels:removeAreaDescription', {
-          areaName: getValues(`${FORMFIELD.HANKEALUEET}.${index}.nimi`) || '',
+          areaName: getValues(`${FORMFIELD.HANKEALUEET}.${index}.nimi`) ?? '',
         })}
         isOpen={areaToRemove !== null}
         close={closeAreaRemoveDialog}

--- a/src/domain/hanke/edit/components/Haitat.tsx
+++ b/src/domain/hanke/edit/components/Haitat.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { Button, Fieldset, IconTrash } from 'hds-react';
+import { Button, Fieldset, IconCross, IconTrash } from 'hds-react';
 import { $enum } from 'ts-enum-util';
-import { Box, Flex, Spacer } from '@chakra-ui/react';
+import { Spacer } from '@chakra-ui/react';
 import { FORMFIELD, HankeDataFormState } from '../types';
 import DatePicker from '../../../../common/components/datePicker/DatePicker';
 import Dropdown from '../../../../common/components/dropdown/Dropdown';
@@ -19,6 +19,7 @@ import {
 import styles from './Haitat.module.scss';
 import TextInput from '../../../../common/components/textInput/TextInput';
 import { getAreaDefaultName } from '../utils';
+import ConfirmationDialog from '../../../../common/components/HDSConfirmationDialog/ConfirmationDialog';
 
 type Props = {
   index: number;
@@ -36,6 +37,8 @@ const Haitat: React.FC<Props> = ({ index, onRemoveArea }) => {
   const haittaLoppuPvm = watchHankeAlueet[index]?.haittaLoppuPvm;
   const minEndDate = haittaAlkuPvm && new Date(haittaAlkuPvm);
 
+  const [areaToRemove, setAreaToRemove] = useState<number | null>(null);
+
   const areaDefaultName = useMemo(
     () => getAreaDefaultName(getValues(FORMFIELD.HANKEALUEET)),
     [getValues],
@@ -47,110 +50,130 @@ const Haitat: React.FC<Props> = ({ index, onRemoveArea }) => {
     }
   }, [haittaAlkuPvm, haittaLoppuPvm, index, setValue]);
 
+  function confirmRemoveArea() {
+    if (areaToRemove !== null) {
+      onRemoveArea(areaToRemove);
+      setAreaToRemove(null);
+    }
+  }
+
+  function closeAreaRemoveDialog() {
+    setAreaToRemove(null);
+  }
+
   return (
-    <Fieldset
-      heading={t('hankeForm:hankkeenAlueForm:haitatHeader')}
-      border
-      className={styles.haitatContainer}
-    >
-      <Box mb="var(--spacing-l)">
-        <p>{t('hankeForm:hankkeenAlueForm:haitatInstructions')}</p>
-      </Box>
+    <>
+      <Fieldset
+        heading={t('hankeForm:hankkeenAlueForm:haitatHeader')}
+        border
+        className={styles.haitatContainer}
+      >
+        <div className={`${styles.formRow} ${styles.formRowEven} ${styles.formRowReverse}`}>
+          <Button
+            variant="secondary"
+            theme="black"
+            iconLeft={<IconCross />}
+            onClick={() => setAreaToRemove(index)}
+          >
+            {t('hankeForm:hankkeenAlueForm:removeAreaButton')}
+          </Button>
+          <Spacer />
+          <TextInput
+            name={`${FORMFIELD.HANKEALUEET}.${index}.nimi`}
+            label={t('form:labels:areaName')}
+            helperText={t('form:helperTexts:areaName')}
+            defaultValue={areaDefaultName}
+            maxLength={100}
+          />
+        </div>
 
-      <div className={`${styles.formRow} ${styles.formRowEven} formWprShort`}>
-        <TextInput
-          name={`${FORMFIELD.HANKEALUEET}.${index}.nimi`}
-          label={t('form:labels:areaName')}
-          helperText={t('form:helperTexts:areaName')}
-          defaultValue={areaDefaultName}
-          maxLength={100}
-        />
-      </div>
+        <div className={`${styles.formRow} ${styles.formRowEven}`}>
+          <DatePicker
+            name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.HAITTA_ALKU_PVM}`}
+            label={t(`hankeForm:labels:${FORMFIELD.HAITTA_ALKU_PVM}`)}
+            locale={locale}
+            helperText={t('form:helperTexts:dateInForm')}
+          />
+          <DatePicker
+            name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.HAITTA_LOPPU_PVM}`}
+            label={t(`hankeForm:labels:${FORMFIELD.HAITTA_LOPPU_PVM}`)}
+            locale={locale}
+            minDate={minEndDate || undefined}
+            initialMonth={minEndDate || undefined}
+            helperText={t('form:helperTexts:dateInForm')}
+          />
+          <Spacer />
+        </div>
 
-      <div className={`${styles.formRow} ${styles.formRowEven}`}>
-        <DatePicker
-          name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.HAITTA_ALKU_PVM}`}
-          label={t(`hankeForm:labels:${FORMFIELD.HAITTA_ALKU_PVM}`)}
-          locale={locale}
-          helperText={t('form:helperTexts:dateInForm')}
-        />
-        <DatePicker
-          name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.HAITTA_LOPPU_PVM}`}
-          label={t(`hankeForm:labels:${FORMFIELD.HAITTA_LOPPU_PVM}`)}
-          locale={locale}
-          minDate={minEndDate || undefined}
-          initialMonth={minEndDate || undefined}
-          helperText={t('form:helperTexts:dateInForm')}
-        />
-        <Spacer />
-      </div>
+        <div className={`${styles.formRow} ${styles.formRowEven}`}>
+          <Dropdown
+            name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.MELUHAITTA}`}
+            id={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.MELUHAITTA}`}
+            options={$enum(HANKE_MELUHAITTA).map((value) => ({
+              value,
+              label: t(`hanke:${FORMFIELD.MELUHAITTA}:${value}`),
+            }))}
+            defaultValue={formValues[index][FORMFIELD.MELUHAITTA] || ''}
+            label={t(`hankeForm:labels:${FORMFIELD.MELUHAITTA}`)}
+          />
+          <Dropdown
+            name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.POLYHAITTA}`}
+            id={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.POLYHAITTA}`}
+            options={$enum(HANKE_POLYHAITTA).map((value) => ({
+              value,
+              label: t(`hanke:${FORMFIELD.POLYHAITTA}:${value}`),
+            }))}
+            defaultValue={formValues[index][FORMFIELD.POLYHAITTA] || ''}
+            label={t(`hankeForm:labels:${FORMFIELD.POLYHAITTA}`)}
+          />
+          <Dropdown
+            name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.TARINAHAITTA}`}
+            id={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.TARINAHAITTA}`}
+            options={$enum(HANKE_TARINAHAITTA).map((value) => ({
+              value,
+              label: t(`hanke:${FORMFIELD.TARINAHAITTA}:${value}`),
+            }))}
+            defaultValue={formValues[index][FORMFIELD.TARINAHAITTA] || ''}
+            label={t(`hankeForm:labels:${FORMFIELD.TARINAHAITTA}`)}
+          />
+        </div>
 
-      <div className={`${styles.formRow} ${styles.formRowEven}`}>
-        <Dropdown
-          name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.MELUHAITTA}`}
-          id={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.MELUHAITTA}`}
-          options={$enum(HANKE_MELUHAITTA).map((value) => ({
-            value,
-            label: t(`hanke:${FORMFIELD.MELUHAITTA}:${value}`),
-          }))}
-          defaultValue={formValues[index][FORMFIELD.MELUHAITTA] || ''}
-          label={t(`hankeForm:labels:${FORMFIELD.MELUHAITTA}`)}
-        />
-        <Dropdown
-          name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.POLYHAITTA}`}
-          id={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.POLYHAITTA}`}
-          options={$enum(HANKE_POLYHAITTA).map((value) => ({
-            value,
-            label: t(`hanke:${FORMFIELD.POLYHAITTA}:${value}`),
-          }))}
-          defaultValue={formValues[index][FORMFIELD.POLYHAITTA] || ''}
-          label={t(`hankeForm:labels:${FORMFIELD.POLYHAITTA}`)}
-        />
-        <Dropdown
-          name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.TARINAHAITTA}`}
-          id={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.TARINAHAITTA}`}
-          options={$enum(HANKE_TARINAHAITTA).map((value) => ({
-            value,
-            label: t(`hanke:${FORMFIELD.TARINAHAITTA}:${value}`),
-          }))}
-          defaultValue={formValues[index][FORMFIELD.TARINAHAITTA] || ''}
-          label={t(`hankeForm:labels:${FORMFIELD.TARINAHAITTA}`)}
-        />
-      </div>
-
-      <div className={`${styles.formRow} ${styles.formRowUnEven}`}>
-        <Dropdown
-          name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.KAISTAHAITTA}`}
-          id={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.KAISTAHAITTA}`}
-          options={$enum(HANKE_KAISTAHAITTA).map((value) => ({
-            value,
-            label: t(`hanke:${FORMFIELD.KAISTAHAITTA}:${value}`),
-          }))}
-          defaultValue={formValues[index][FORMFIELD.KAISTAHAITTA] || ''}
-          label={t(`hankeForm:labels:${FORMFIELD.KAISTAHAITTA}`)}
-        />
-        <Dropdown
-          name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.KAISTAPITUUSHAITTA}`}
-          id={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.KAISTAPITUUSHAITTA}`}
-          options={$enum(HANKE_KAISTAPITUUSHAITTA).map((value) => ({
-            value,
-            label: t(`hanke:${FORMFIELD.KAISTAPITUUSHAITTA}:${value}`),
-          }))}
-          defaultValue={formValues[index][FORMFIELD.KAISTAPITUUSHAITTA] || ''}
-          label={t(`hankeForm:labels:${FORMFIELD.KAISTAPITUUSHAITTA}`)}
-        />
-      </div>
-
-      <Flex justify="end">
-        <Button
-          variant="supplementary"
-          iconLeft={<IconTrash />}
-          onClick={() => onRemoveArea(index)}
-        >
-          {t('hankeForm:hankkeenAlueForm:removeAreaButton')}
-        </Button>
-      </Flex>
-    </Fieldset>
+        <div className={`${styles.formRow} ${styles.formRowUnEven}`}>
+          <Dropdown
+            name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.KAISTAHAITTA}`}
+            id={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.KAISTAHAITTA}`}
+            options={$enum(HANKE_KAISTAHAITTA).map((value) => ({
+              value,
+              label: t(`hanke:${FORMFIELD.KAISTAHAITTA}:${value}`),
+            }))}
+            defaultValue={formValues[index][FORMFIELD.KAISTAHAITTA] || ''}
+            label={t(`hankeForm:labels:${FORMFIELD.KAISTAHAITTA}`)}
+          />
+          <Dropdown
+            name={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.KAISTAPITUUSHAITTA}`}
+            id={`${FORMFIELD.HANKEALUEET}.${index}.${FORMFIELD.KAISTAPITUUSHAITTA}`}
+            options={$enum(HANKE_KAISTAPITUUSHAITTA).map((value) => ({
+              value,
+              label: t(`hanke:${FORMFIELD.KAISTAPITUUSHAITTA}:${value}`),
+            }))}
+            defaultValue={formValues[index][FORMFIELD.KAISTAPITUUSHAITTA] || ''}
+            label={t(`hankeForm:labels:${FORMFIELD.KAISTAPITUUSHAITTA}`)}
+          />
+        </div>
+      </Fieldset>
+      <ConfirmationDialog
+        title={t('hankeForm:labels:removeAreaTitle')}
+        description={t('hankeForm:labels:removeAreaDescription', {
+          areaName: getValues(`${FORMFIELD.HANKEALUEET}.${index}.nimi`) || '',
+        })}
+        isOpen={areaToRemove !== null}
+        close={closeAreaRemoveDialog}
+        mainAction={confirmRemoveArea}
+        mainBtnLabel={t('common:buttons:remove')}
+        mainBtnIcon={<IconTrash />}
+        variant="danger"
+      />
+    </>
   );
 };
 

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -556,7 +556,9 @@
       "organisaatio": "Organisaatio",
       "omaOrganisaatio": "Lisää oma organisaatio",
       "insertOmaOrganisaatio": "Syötä oma organisaatio",
-      "rights": "Käyttöoikeutesi hankkeelle"
+      "rights": "Käyttöoikeutesi hankkeelle",
+      "removeAreaTitle": "Poista alue",
+      "removeAreaDescription": "Haluatko varmasti poistaa hankealueen {{areaName}}?"
     },
     "missingFields": {
       "nimi": "$t(hankeForm:labels:nimi)",


### PR DESCRIPTION
# Description

Moved hanke area delete button to more visible place and added confirmation dialog for deletion.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2475

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

1. Go to hanke form areas page and draw hanke area
2. Check that the area delete button placement matches Figma design: https://www.figma.com/design/CSWoUcI2jslxfOgBYgjKuK/Haitaton-HDS-3.0.0?node-id=122-12883&t=PQfH4vB3bDPUu48G-4
3. Press area delete button
4. Confirmation dialog should open
5. Confirm delete in dialog
6. Area should be removed

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
