### PR TITLE
HAI-2406 Add default values for contact types in hanke form

### DIFF
--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -251,8 +251,10 @@ describe('HankeForm', () => {
     const { user } = await setupYhteystiedotPage(<HankeFormContainer hankeTunnus="HAI22-1" />);
 
     // Hanke owner (accordion open by default)
+    // Yritys should be default contact type
+    expect(screen.getByText(/yritys/i)).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /tyyppi/i }));
-    await user.click(screen.getByText(/yritys/i));
+    await user.click(screen.getByText(/yhteisö/i));
 
     fireEvent.change(screen.getByTestId('omistajat.0.nimi'), {
       target: { value: 'Omistaja Yritys' },

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -30,7 +30,7 @@ import { Box } from '@chakra-ui/react';
 function getEmptyContact(): Omit<HankeYhteystieto, 'id'> {
   return {
     nimi: '',
-    tyyppi: null,
+    tyyppi: CONTACT_TYYPPI.YRITYS,
     ytunnus: '',
     email: '',
     puhelinnumero: '',
@@ -80,7 +80,7 @@ const ContactFields: React.FC<
         <Dropdown
           id={`${contactType}.${index}.${CONTACT_FORMFIELD.TYYPPI}`}
           name={`${contactType}.${index}.${CONTACT_FORMFIELD.TYYPPI}`}
-          defaultValue={null}
+          defaultValue={CONTACT_TYYPPI.YRITYS}
           label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.TYYPPI}`)}
           options={$enum(CONTACT_TYYPPI).map((value) => {
             return {


### PR DESCRIPTION
# Description

Added default value of Yritys for contact type dropdowns in hanke form contacts page.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2406

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Check that contact type of yhteyshenkilöt has default value of Yritys.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
