### PR TITLE
HAI-2516 Send application button in application view

### DIFF
--- a/src/common/components/header/Header.test.tsx
+++ b/src/common/components/header/Header.test.tsx
@@ -5,7 +5,7 @@ import useUser from '../../../domain/auth/useUser';
 import i18next from '../../../locales/i18nForTests';
 import { UserEvent } from '@testing-library/user-event/dist/types/setup/setup';
 
-jest.setTimeout(10000);
+jest.setTimeout(30000);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockedUseUser = useUser as jest.Mock<any>;

--- a/src/domain/application/hooks/useApplicationSendNotification.tsx
+++ b/src/domain/application/hooks/useApplicationSendNotification.tsx
@@ -6,7 +6,9 @@ import { useGlobalNotification } from '../../../common/components/globalNotifica
 /**
  * Returns functions for showing success and error notifications for sending application
  */
-export default function useApplicationSendNotification() {
+export default function useApplicationSendNotification(
+  errorMessageKey: string = 'hakemus:notifications:sendErrorText',
+) {
   const { t } = useTranslation();
   const { setNotification } = useGlobalNotification();
 
@@ -25,7 +27,7 @@ export default function useApplicationSendNotification() {
 
   function showSendError() {
     const sendErrorMessage = (
-      <Trans i18nKey="hakemus:notifications:sendErrorText">
+      <Trans i18nKey={errorMessageKey}>
         <p>
           Hakemus on tallennettu luonnoksena, koska hakemuksen lähettäminen käsittelyyn epäonnistui.
           Yritä lähettämistä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen
@@ -40,7 +42,7 @@ export default function useApplicationSendNotification() {
       dismissible: true,
       label: t('hakemus:notifications:sendErrorLabel'),
       message: sendErrorMessage,
-      type: 'alert',
+      type: 'error',
       closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
     });
   }

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -13,7 +13,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { useMutation, useQueryClient } from 'react-query';
 import { merge } from 'lodash';
 import { useBeforeUnload } from 'react-router-dom';
-import { JohtoselvitysFormData, JohtoselvitysFormValues } from './types';
+import { JohtoselvitysFormValues } from './types';
 import { BasicInfo } from './BasicInfo';
 import Contacts from '../application/components/ApplicationContacts';
 import { Geometries } from './Geometries';
@@ -26,7 +26,7 @@ import {
   convertFormStateToJohtoselvitysUpdateData,
 } from './utils';
 import { changeFormStep, isPageValid } from '../forms/utils';
-import { isApplicationDraft, sendApplicationNew } from '../application/utils';
+import { isApplicationDraft, isContactIn, sendApplication } from '../application/utils';
 import { HankeData } from '../types/hanke';
 import { ApplicationCancel } from '../application/components/ApplicationCancel';
 import ApplicationSaveNotification from '../application/components/ApplicationSaveNotification';
@@ -46,28 +46,12 @@ import ConfirmationDialog from '../../common/components/HDSConfirmationDialog/Co
 import useAttachments from '../application/hooks/useAttachments';
 import { APPLICATION_ID_STORAGE_KEY } from '../application/constants';
 import { usePermissionsForHanke } from '../hanke/hankeUsers/hooks/useUserRightsForHanke';
-import { SignedInUser } from '../hanke/hankeUsers/hankeUser';
 import useSaveApplication from '../application/hooks/useSaveApplication';
 
 type Props = {
   hankeData?: HankeData;
   application?: Application<JohtoselvitysData>;
 };
-
-function isContactIn(signedInUser?: SignedInUser, application?: JohtoselvitysFormData) {
-  if (signedInUser && application) {
-    const found = [
-      application.customerWithContacts,
-      application.contractorWithContacts,
-      application.propertyDeveloperWithContacts,
-      application.representativeWithContacts,
-    ]
-      .flatMap((customer) => customer?.contacts)
-      .find((contact) => contact?.hankekayttajaId === signedInUser.hankeKayttajaId);
-    return found !== undefined;
-  }
-  return false;
-}
 
 const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
   hankeData,
@@ -199,7 +183,7 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
     },
   });
 
-  const applicationSendMutation = useMutation(sendApplicationNew, {
+  const applicationSendMutation = useMutation(sendApplication, {
     onError() {
       showSendError();
     },
@@ -474,7 +458,12 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
                 </Button>
               )}
               {disableSendButton && (
-                <Notification size="small" style={{ marginTop: 'var(--spacing-xs)' }} type="info">
+                <Notification
+                  size="small"
+                  style={{ marginTop: 'var(--spacing-xs)' }}
+                  type="info"
+                  label={t('hakemus:notifications:sendApplicationDisabled')}
+                >
                   {t('hakemus:notifications:sendApplicationDisabled')}
                 </Notification>
               )}

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -437,10 +437,10 @@ test('Should show and disable send button and show notification when user is not
   expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).toBeInTheDocument();
   expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).toBeDisabled();
   expect(
-    screen.queryByText(
+    screen.queryAllByText(
       'Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö.',
     ),
-  ).toBeInTheDocument();
+  ).toHaveLength(2);
 });
 
 test('Should show and enable button when application is edited in draft state and user is a contact person', async () => {

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -22,7 +22,7 @@ import { cloneDeep } from 'lodash';
 
 afterEach(cleanup);
 
-jest.setTimeout(40000);
+jest.setTimeout(60000);
 
 async function fillBasicInformation(
   user: UserEvent,

--- a/src/domain/map/components/AddressSearch/AddressSearch.test.tsx
+++ b/src/domain/map/components/AddressSearch/AddressSearch.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen, waitFor } from '../../../../testUtils/render';
 import AddressSearch from './AddressSearch';
 
+jest.setTimeout(30000);
+
 test('Address can be selected from suggestions', async () => {
   const handleAddressSelect = jest.fn();
   const { user } = render(<AddressSearch onAddressSelect={handleAddressSelect} />);

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -5,7 +5,7 @@ import {
   KaivuilmoitusData,
 } from '../../application/types/application';
 
-const hakemukset: Application<JohtoselvitysData | KaivuilmoitusData>[] = [
+const hakemukset: Application[] = [
   {
     id: 1,
     alluStatus: null,

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -11,6 +11,7 @@ import {
 import hakemuksetData from './hakemukset-data';
 import { isApplicationPending } from '../../application/utils';
 import ApiError from '../apiError';
+import { cloneDeep } from 'lodash';
 
 let hakemukset: Application[] = [...hakemuksetData];
 
@@ -120,6 +121,7 @@ export async function sendHakemus(id: number) {
   if (!hakemus) {
     throw new ApiError(`No application with id ${id}`, 404);
   }
-  hakemus.alluStatus = 'PENDING';
-  return hakemus;
+  const updatedHakemus = cloneDeep(hakemus);
+  updatedHakemus.alluStatus = 'PENDING';
+  return updatedHakemus;
 }

--- a/src/domain/mocks/data/users.ts
+++ b/src/domain/mocks/data/users.ts
@@ -33,11 +33,7 @@ export async function readAll(hankeTunnus: string): Promise<HankeUser[]> {
 }
 
 export async function readCurrent(): Promise<HankeUser | undefined> {
-  const currentUser = users
-    .map(mapToHankeUser)
-    .find((user) => user.sahkoposti === 'matti.meikalainen@test.com');
-  console.log('currentUser', currentUser);
-  return currentUser;
+  return users.map(mapToHankeUser).find((user) => user.sahkoposti === 'matti.meikalainen@test.com');
 }
 
 async function readFromHanke(hankeTunnus: string, id: string): Promise<HankeUser | undefined> {

--- a/src/domain/mocks/data/users.ts
+++ b/src/domain/mocks/data/users.ts
@@ -33,7 +33,11 @@ export async function readAll(hankeTunnus: string): Promise<HankeUser[]> {
 }
 
 export async function readCurrent(): Promise<HankeUser | undefined> {
-  return users.map(mapToHankeUser).find((user) => user.sahkoposti === 'testi@test.com');
+  const currentUser = users
+    .map(mapToHankeUser)
+    .find((user) => user.sahkoposti === 'matti.meikalainen@test.com');
+  console.log('currentUser', currentUser);
+  return currentUser;
 }
 
 async function readFromHanke(hankeTunnus: string, id: string): Promise<HankeUser | undefined> {

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -28,7 +28,6 @@ export const handlers = [
   // Private hankkeet endpoints miss handling of user at this point
   rest.get(`${apiUrl}/hankkeet/:hankeTunnus`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
-    console.log(`GET ${apiUrl}/hankkeet/${hankeTunnus}`);
     const hanke = await hankkeetDB.read(hankeTunnus as string);
     if (!hanke) {
       return res(
@@ -43,14 +42,12 @@ export const handlers = [
   }),
 
   rest.get(`${apiUrl}/hankkeet`, async (_, res, ctx) => {
-    console.log(`GET ${apiUrl}/hankkeet`);
     const hankkeet = await hankkeetDB.readAll();
     return res(ctx.status(200), ctx.json(hankkeet));
   }),
 
   rest.post(`${apiUrl}/hankkeet`, async (req, res, ctx) => {
     const reqBody: HankeDataDraft = await req.json();
-    console.log(`POST ${apiUrl}/hankkeet`, reqBody);
     const hanke = await hankkeetDB.create(reqBody);
     return res(ctx.status(200), ctx.json(hanke));
   }),
@@ -58,7 +55,6 @@ export const handlers = [
   rest.put(`${apiUrl}/hankkeet/:hankeTunnus`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
     const reqBody: HankeDataDraft = await req.json();
-    console.log(`PUT ${apiUrl}/hankkeet/${hankeTunnus}`, reqBody);
     try {
       const hanke = await hankkeetDB.update(hankeTunnus as string, reqBody);
       return res(ctx.status(200), ctx.json(hanke));
@@ -75,7 +71,6 @@ export const handlers = [
 
   rest.delete(`${apiUrl}/hankkeet/:hankeTunnus`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
-    console.log(`DELETE ${apiUrl}/hankkeet/${hankeTunnus}/hakemukset`);
     try {
       const hanke = await hankkeetDB.remove(hankeTunnus as string);
       return res(ctx.status(200), ctx.json(hanke));
@@ -93,26 +88,22 @@ export const handlers = [
 
   rest.get(`${apiUrl}/hankkeet/:hankeTunnus/hakemukset`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
-    console.log(`GET ${apiUrl}/hankkeet/${hankeTunnus}/hakemukset`);
     const hakemukset = await hakemuksetDB.readAllForHanke(hankeTunnus as string);
     return res(ctx.status(200), ctx.json({ applications: hakemukset }));
   }),
 
   rest.get(`${apiUrl}/public-hankkeet`, async (_, res, ctx) => {
-    console.log(`GET ${apiUrl}/public-hankkeet`);
     const hankkeet = await hankkeetDB.readAll();
     return res(ctx.status(200), ctx.json(hankkeet));
   }),
 
   rest.get(`${apiUrl}/hakemukset`, async (_, res, ctx) => {
-    console.log(`GET ${apiUrl}/hakemukset`);
     const hakemukset = await hakemuksetDB.readAll();
     return res(ctx.status(200), ctx.json(hakemukset));
   }),
 
   rest.get(`${apiUrl}/hakemukset/:id`, async (req, res, ctx) => {
     const { id } = req.params;
-    console.log(`GET ${apiUrl}/hakemukset/${id}`);
     const hakemus = await hakemuksetDB.read(Number(id as string));
     if (!hakemus) {
       return res(
@@ -127,14 +118,12 @@ export const handlers = [
 
   rest.post(`${apiUrl}/hakemukset`, async (req, res, ctx) => {
     const reqBody: JohtoselvitysCreateData | KaivuilmoitusCreateData = await req.json();
-    console.log(`POST ${apiUrl}/hakemukset`, reqBody);
     const hakemus = await hakemuksetDB.create(reqBody);
     return res(ctx.status(200), ctx.json(hakemus));
   }),
 
   rest.post(`${apiUrl}/hakemukset/johtoselvitys`, async (req, res, ctx) => {
     const reqBody: JohtoselvitysFormValues = await req.json();
-    console.log(`POST ${apiUrl}/hakemukset/johtoselvitys`, reqBody);
     const hanke = await hankkeetDB.create({
       nimi: reqBody.applicationData.name,
       alkuPvm: '',
@@ -150,10 +139,9 @@ export const handlers = [
   }),
 
   rest.post(`${apiUrl}/johtoselvityshakemus`, async (req, res, ctx) => {
-    const reqBody: NewJohtoselvitysData = await req.json();
-    console.log(`POST ${apiUrl}/johtoselvityshakemus`, reqBody);
+    const { nimi }: NewJohtoselvitysData = await req.json();
     const hanke = await hankkeetDB.create({
-      nimi: reqBody.nimi,
+      nimi: nimi,
       alkuPvm: null,
       loppuPvm: null,
       vaihe: null,
@@ -162,7 +150,7 @@ export const handlers = [
     });
     const hakemus = await hakemuksetDB.createJohtoselvitys({
       applicationData: {
-        name: reqBody.nimi,
+        name: nimi,
         ...defaultJohtoselvitysData,
       },
       id: null,
@@ -182,7 +170,6 @@ export const handlers = [
   rest.put(`${apiUrl}/hakemukset/:id`, async (req, res, ctx) => {
     const { id } = req.params;
     const reqBody: JohtoselvitysUpdateData = await req.json();
-    console.log(`PUT ${apiUrl}/hakemukset/${id}`, reqBody);
     try {
       const hakemus = await hakemuksetDB.update(Number(id as string), reqBody);
       return res(ctx.status(200), ctx.json(hakemus));
@@ -197,27 +184,8 @@ export const handlers = [
     }
   }),
 
-  rest.post(`${apiUrl}/hakemukset/:id/send-application`, async (req, res, ctx) => {
-    const { id } = req.params;
-    console.log(`POST ${apiUrl}/hakemukset/${id}/send-application`);
-    const hakemus = await hakemuksetDB.read(Number(id));
-
-    if (!hakemus) {
-      return res(
-        ctx.status(404),
-        ctx.json({
-          errorMessage: 'Hakemus not found',
-          errorCode: 'HAI1001',
-        }),
-      );
-    }
-
-    return res(ctx.status(200), ctx.json(hakemus));
-  }),
-
   rest.post(`${apiUrl}/hakemukset/:id/laheta`, async (req, res, ctx) => {
     const { id } = req.params;
-    console.log(`POST ${apiUrl}/hakemukset/${id}/laheta`);
     const hakemus = await hakemuksetDB.sendHakemus(Number(id));
 
     if (!hakemus) {
@@ -235,7 +203,6 @@ export const handlers = [
 
   rest.delete(`${apiUrl}/hakemukset/:id`, async (req, res, ctx) => {
     const { id } = req.params;
-    console.log(`DELETE ${apiUrl}/hakemukset/${id}`);
     try {
       await hakemuksetDB.remove(Number(id));
       return res(ctx.status(200), ctx.json(null));
@@ -253,7 +220,6 @@ export const handlers = [
 
   rest.get(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
-    console.log(`GET ${apiUrl}/hankkeet/${hankeTunnus}/kayttajat`);
     const users = await usersDB.readAll(hankeTunnus as string);
     return res(ctx.status(200), ctx.json({ kayttajat: users }));
   }),
@@ -261,7 +227,6 @@ export const handlers = [
   rest.post(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
     const user: Yhteyshenkilo = await req.json();
-    console.log(`POST ${apiUrl}/hankkeet/${hankeTunnus}/kayttajat`, user);
     const createdUser = await usersDB.create(hankeTunnus as string, user);
     return res(ctx.status(200), ctx.json(createdUser));
   }),
@@ -269,7 +234,6 @@ export const handlers = [
   rest.put(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
     const { kayttajat } = await req.json();
-    console.log(`PUT ${apiUrl}/hankkeet/${hankeTunnus}/kayttajat`, kayttajat);
     await usersDB.updatePermissions(hankeTunnus as string, kayttajat);
     return res(ctx.status(204));
   }),
@@ -277,7 +241,6 @@ export const handlers = [
   rest.put(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat/self`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
     const reqBody: YhteyshenkiloWithoutName = await req.json();
-    console.log(`PUT ${apiUrl}/hankkeet/${hankeTunnus}/kayttajat/self`, reqBody);
     const user = await usersDB.update(
       hankeTunnus as string,
       '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -289,7 +252,6 @@ export const handlers = [
   rest.put(`${apiUrl}/hankkeet/:hankeTunnus/kayttajat/:userId`, async (req, res, ctx) => {
     const { hankeTunnus, userId } = req.params;
     const reqBody: Yhteyshenkilo | YhteyshenkiloWithoutName = await req.json();
-    console.log(`PUT ${apiUrl}/hankkeet/${hankeTunnus}/kayttajat/${userId}`, reqBody);
     try {
       const updatedUser = await usersDB.update(hankeTunnus as string, userId as string, reqBody);
       return res(ctx.status(200), ctx.json(updatedUser));
@@ -307,7 +269,7 @@ export const handlers = [
 
   rest.get(`${apiUrl}/hankkeet/:hankeTunnus/whoami`, async (req, res, ctx) => {
     const { hankeTunnus } = req.params;
-    console.log(`GET ${apiUrl}/hankkeet/${hankeTunnus}/whoami`);
+
     if (hankeTunnus === 'SMTGEN2_1') {
       return res(
         ctx.status(200),
@@ -337,20 +299,17 @@ export const handlers = [
         'DELETE_USER',
       ],
     };
-    console.log('user', user);
 
     return res(ctx.status(200), ctx.json<SignedInUser>(user));
   }),
 
   rest.get(`${apiUrl}/kayttajat/:id`, async (req, res, ctx) => {
     const { id } = req.params;
-    console.log(`GET ${apiUrl}/kayttajat/${id}`);
     const user = await usersDB.read(id as string);
     return res(ctx.status(200), ctx.json(user));
   }),
 
   rest.post(`${apiUrl}/kayttajat`, async (_, res, ctx) => {
-    console.log(`POST ${apiUrl}/kayttajat`);
     return res(
       ctx.status(200),
       ctx.json<IdentificationResponse>({
@@ -363,14 +322,12 @@ export const handlers = [
 
   rest.post(`${apiUrl}/kayttajat/:kayttajaId/kutsu`, async (req, res, ctx) => {
     const { kayttajaId } = req.params;
-    console.log(`POST ${apiUrl}/kayttajat/${kayttajaId}/kutsu`);
     const user = await usersDB.resendInvitation(kayttajaId as string);
     return res(ctx.delay(), ctx.json(user), ctx.status(200));
   }),
 
   rest.get(`${apiUrl}/kayttajat/:id/deleteInfo`, async (req, res, ctx) => {
     const { id } = req.params;
-    console.log(`GET ${apiUrl}/kayttajat/${id}/deleteInfo`);
     if (id === '3fa85f64-5717-4562-b3fc-2c963f66afa7') {
       return res(
         ctx.delay(),
@@ -437,7 +394,6 @@ export const handlers = [
 
   rest.delete(`${apiUrl}/kayttajat/:id`, async (req, res, ctx) => {
     const { id } = req.params;
-    console.log(`DELETE ${apiUrl}/kayttajat/${id}`);
     try {
       await usersDB.remove(id as string);
       return res(ctx.status(204));
@@ -454,31 +410,22 @@ export const handlers = [
   }),
 
   rest.get(`${apiUrl}/hakemukset/:id/liitteet`, async (req, res, ctx) => {
-    const { id } = req.params;
-    console.log(`GET ${apiUrl}/hakemukset/${id}/liitteet`);
     return res(ctx.status(200), ctx.json([]));
   }),
 
   rest.post(`${apiUrl}/hakemukset/:id/liitteet`, async (req, res, ctx) => {
-    const { id } = req.params;
-    console.log(`POST ${apiUrl}/hakemukset/${id}/liitteet`);
     return res(ctx.delay(), ctx.status(200));
   }),
 
   rest.delete(`${apiUrl}/hakemukset/:id/liitteet/:attachmentId`, async (req, res, ctx) => {
-    const { id, attachmentId } = req.params;
-    console.log(`DELETE ${apiUrl}/hakemukset/${id}/liitteet/${attachmentId}`);
     return res(ctx.status(200));
   }),
 
-  rest.get(`${apiUrl}/hankkeet/:hankeTunnus/liitteet`, async (req, res, ctx) => {
-    const { hankeTunnus } = req.params;
-    console.log(`GET ${apiUrl}/hankkeet/${hankeTunnus}/liitteet`);
+  rest.get(`${apiUrl}/hankkeet/:hankeTunnus/liitteet`, async (_, res, ctx) => {
     return res(ctx.status(200), ctx.json([]));
   }),
 
   rest.get(`${apiUrl}/profiili/verified-name`, async (_, res, ctx) => {
-    console.log(`GET ${apiUrl}/profiili/verified-name`);
     return res(
       ctx.status(200),
       ctx.json({ firstName: 'Testi Tauno Tahvo', lastName: 'Testinen', givenName: 'Testi' }),

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -5,13 +5,7 @@ import * as hankkeetDB from './data/hankkeet';
 import * as hakemuksetDB from './data/hakemukset';
 import * as usersDB from './data/users';
 import ApiError from './apiError';
-import {
-  AccessRightLevel,
-  DeleteInfo,
-  IdentificationResponse,
-  SignedInUser,
-  SignedInUserByHanke,
-} from '../hanke/hankeUsers/hankeUser';
+import { DeleteInfo, IdentificationResponse, SignedInUser } from '../hanke/hankeUsers/hankeUser';
 import { Yhteyshenkilo, YhteyshenkiloWithoutName } from '../hanke/edit/types';
 import {
   JohtoselvitysCreateData,
@@ -20,7 +14,6 @@ import {
   NewJohtoselvitysData,
 } from '../application/types/application';
 import { defaultJohtoselvitysData } from './data/defaultJohtoselvitysData';
-import { signedInUsers, userDataByHanke } from './signedInUser';
 
 const apiUrl = '/api';
 
@@ -282,25 +275,27 @@ export const handlers = [
     }
 
     const currentUser = await usersDB.readCurrent();
-    const user = signedInUsers.find((u) => u.hankeKayttajaId === currentUser?.id) ?? {
-      hankeKayttajaId: currentUser?.id ?? '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-      kayttooikeustaso: 'KAIKKI_OIKEUDET',
-      kayttooikeudet: [
-        'VIEW',
-        'MODIFY_VIEW_PERMISSIONS',
-        'EDIT',
-        'MODIFY_EDIT_PERMISSIONS',
-        'DELETE',
-        'MODIFY_DELETE_PERMISSIONS',
-        'EDIT_APPLICATIONS',
-        'MODIFY_APPLICATION_PERMISSIONS',
-        'RESEND_INVITATION',
-        'MODIFY_USER',
-        'DELETE_USER',
-      ],
-    };
 
-    return res(ctx.status(200), ctx.json<SignedInUser>(user));
+    return res(
+      ctx.status(200),
+      ctx.json<SignedInUser>({
+        hankeKayttajaId: currentUser?.id ?? '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+        kayttooikeustaso: 'KAIKKI_OIKEUDET',
+        kayttooikeudet: [
+          'VIEW',
+          'MODIFY_VIEW_PERMISSIONS',
+          'EDIT',
+          'MODIFY_EDIT_PERMISSIONS',
+          'DELETE',
+          'MODIFY_DELETE_PERMISSIONS',
+          'EDIT_APPLICATIONS',
+          'MODIFY_APPLICATION_PERMISSIONS',
+          'RESEND_INVITATION',
+          'MODIFY_USER',
+          'DELETE_USER',
+        ],
+      }),
+    );
   }),
 
   rest.get(`${apiUrl}/kayttajat/:id`, async (req, res, ctx) => {
@@ -409,15 +404,15 @@ export const handlers = [
     }
   }),
 
-  rest.get(`${apiUrl}/hakemukset/:id/liitteet`, async (req, res, ctx) => {
+  rest.get(`${apiUrl}/hakemukset/:id/liitteet`, async (_, res, ctx) => {
     return res(ctx.status(200), ctx.json([]));
   }),
 
-  rest.post(`${apiUrl}/hakemukset/:id/liitteet`, async (req, res, ctx) => {
+  rest.post(`${apiUrl}/hakemukset/:id/liitteet`, async (_, res, ctx) => {
     return res(ctx.delay(), ctx.status(200));
   }),
 
-  rest.delete(`${apiUrl}/hakemukset/:id/liitteet/:attachmentId`, async (req, res, ctx) => {
+  rest.delete(`${apiUrl}/hakemukset/:id/liitteet/:attachmentId`, async (_, res, ctx) => {
     return res(ctx.status(200));
   }),
 
@@ -429,14 +424,6 @@ export const handlers = [
     return res(
       ctx.status(200),
       ctx.json({ firstName: 'Testi Tauno Tahvo', lastName: 'Testinen', givenName: 'Testi' }),
-    );
-  }),
-
-  rest.get(`${apiUrl}/my-permissions`, async (_, res, ctx) => {
-    console.log(`GET ${apiUrl}/my-permissions`);
-    return res(
-      ctx.status(200),
-      ctx.json<SignedInUserByHanke>(userDataByHanke(['HAI22-2'], AccessRightLevel.HAKEMUSASIOINTI)),
     );
   }),
 ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -787,6 +787,7 @@
       "sendErrorLabel": "Lähettäminen epäonnistui",
       "sendSuccessText": "Hakemus on lähetetty käsiteltäväksi.",
       "sendErrorText": "<0>Hakemus on tallennettu luonnoksena, koska hakemuksen lähettäminen käsittelyyn epäonnistui. Yritä lähettämistä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi.</1></0>",
+      "sendErrorTextNoSave": "<0>Hakemuksen lähettäminen käsittelyyn epäonnistui. Yritä lähettämistä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi.</1></0>",
       "cancelSuccessLabel": "Hakemus peruttiin",
       "cancelSuccessText": "Hakemus peruttiin onnistuneesti",
       "noApplications": "Hankkeella ei ole lisättyjä hakemuksia",


### PR DESCRIPTION
# Description

Application can be sent in application view just like in the application form. Same rules apply to the new button in application view as in the form:
* Button is shown, if the user has right permissions
* Button is disabled, if the user is not a contact person on application

Also, changed the error notification in case of the sending fails to be error instead of alert. Also, show the info icon in the notification when the button is disabled (the user is not a contact person on application).

Additionally, cleanep up the code a bit (unused `req` parameterts renamed to `_`, not-used `testi@test.com` changed to `matti.meikalainen@test.com` which is an existing test user, removed/renamed old pre-kortisto functions etc)

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2516

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

* Create a new cable report application or go the application page of an existing one
* Depending on user's permissions and whether he/she is a contact person the button status (visible/enabled) should be correct
* The actual sending works the same way as in the application form

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
