### PR TITLE
HAI-2519 Show user access rights on application page

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -17,6 +17,7 @@ test('Correct information about application should be displayed', async () => {
   expect(screen.getAllByText('Mannerheimintien kairaukset').length).toBe(2);
   expect(screen.queryByText('JS2300003')).toBeInTheDocument();
   expect(screen.queryByText('Odottaa käsittelyä')).toBeInTheDocument();
+  expect(screen.queryByText('Kaikki oikeudet')).toBeInTheDocument();
 });
 
 test('Link back to related hanke should work', async () => {

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -159,7 +159,9 @@ function ApplicationView({ application, hanke, onEditApplication }: Readonly<Pro
             {hanke && <Link href={hankeViewPath}>{hankeLinkText}</Link>}
           </SectionItemContent>
           <SectionItemTitle>{t('hankePortfolio:labels:oikeudet')}:</SectionItemTitle>
-          <SectionItemContent />
+          <SectionItemContent>
+            {t(`hankeUsers:accessRightLevels:${signedInUser?.kayttooikeustaso}`)}
+          </SectionItemContent>
         </FormSummarySection>
 
         <InformationViewHeaderButtons>

--- a/src/domain/application/applicationView/ApplicationViewContainer.tsx
+++ b/src/domain/application/applicationView/ApplicationViewContainer.tsx
@@ -9,6 +9,7 @@ import useHanke from '../../hanke/hooks/useHanke';
 import { useApplication } from '../hooks/useApplication';
 import useLinkPath from '../../../common/hooks/useLinkPath';
 import { HAKEMUS_ROUTES } from '../../../common/types/route';
+import { usePermissionsForHanke } from '../../hanke/hankeUsers/hooks/useUserRightsForHanke';
 
 type Props = {
   id: number;
@@ -18,6 +19,7 @@ function ApplicationViewContainer({ id }: Readonly<Props>) {
   const { t } = useTranslation();
   const { data: application, isLoading, isError, error } = useApplication(id);
   const { data: hanke } = useHanke(application?.hankeTunnus);
+  const { data: signedInUser } = usePermissionsForHanke(application?.hankeTunnus ?? undefined);
   const navigate = useNavigate();
   const getEditApplicationPath = useLinkPath(
     HAKEMUS_ROUTES[application?.applicationType ?? 'CABLE_REPORT'],
@@ -50,7 +52,12 @@ function ApplicationViewContainer({ id }: Readonly<Props>) {
   }
 
   return (
-    <ApplicationView application={application} hanke={hanke} onEditApplication={editApplication} />
+    <ApplicationView
+      application={application}
+      hanke={hanke}
+      signedInUser={signedInUser}
+      onEditApplication={editApplication}
+    />
   );
 }
 


### PR DESCRIPTION
# Description

Show user access rights on application page.

Implementation is copied from HankeView/HankeViewContainer.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2519

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Create a new or open an existing application. User access rights should be shown on the page.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

