### PR TITLE
HAI-2522 Show user role in project only if the user has a role

### DIFF
--- a/src/domain/hanke/hankeUsers/EditUserView.test.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.test.tsx
@@ -48,6 +48,22 @@ test('Should show correct page title', async () => {
   ).toBeInTheDocument();
 });
 
+test('Should show user role if the user has one in the project', async () => {
+  render(<EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />);
+  await waitForLoadingToFinish();
+
+  expect(screen.getByText('Rooli hankkeessa:')).toBeInTheDocument();
+  expect(screen.getByText('Rakennuttaja, Muu')).toBeInTheDocument();
+});
+
+test('Should not show user role if the user has no role in the project', async () => {
+  render(<EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66af5" hankeTunnus="HAI22-2" />);
+  await waitForLoadingToFinish();
+
+  expect(screen.queryByText('Rooli hankkeessa:')).not.toBeInTheDocument();
+  expect(screen.queryByText('Rakennuttaja, Muu')).not.toBeInTheDocument();
+});
+
 test('For identified user should show status text of user identified and should not be able to edit name', async () => {
   render(<EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />);
   await waitForLoadingToFinish();

--- a/src/domain/hanke/hankeUsers/EditUserView.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.tsx
@@ -269,12 +269,14 @@ function EditUserView({
           <MainHeading spacingBottom="m">
             {t('hankeUsers:userEditTitle')}: {userFullName}
           </MainHeading>
-          <Text tag="p" styleAs="body-s" spacingBottom="s">
-            <Box as="strong" marginRight="var(--spacing-s)">
-              {t('hankeUsers:role')}:
-            </Box>
-            {userRoles}
-          </Text>
+          {roolit.length > 0 && (
+            <Text tag="p" styleAs="body-s" spacingBottom="s">
+              <Box as="strong" marginRight="var(--spacing-s)">
+                {t('hankeUsers:role')}:
+              </Box>
+              {userRoles}
+            </Text>
+          )}
           <Flex gap="var(--spacing-2-xs)" color="var(--color-black-60)">
             {tunnistautunut ? (
               <>


### PR DESCRIPTION
# Description

In user management page, show the user role/roles only if the user has any role in the project.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2522

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

* Go to user management page for a user that has a role in the project (= the user is a contact person of any contact type Omistaja/Rakennuttaja/Toteuttaja/Muu). The role and label "Rooli hankkeessa:" should be shown.
* Do the same for a user that has no role in the project - not even the label should be shown

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

