### PR TITLE
HAI-1367 Fixes for kaivuilmoitus form cable report and placement contract fields

### DIFF
--- a/src/common/components/inputCombobox/InputCombobox.tsx
+++ b/src/common/components/inputCombobox/InputCombobox.tsx
@@ -14,6 +14,7 @@ type Props = {
   className?: string;
   pattern?: RegExp;
   errorText?: string;
+  uppercase?: boolean;
 };
 
 /**
@@ -30,6 +31,7 @@ export default function InputCombobox({
   className,
   pattern,
   errorText,
+  uppercase,
 }: Readonly<Props>) {
   const { t } = useTranslation();
   const { setValue, getValues } = useFormContext();
@@ -49,14 +51,17 @@ export default function InputCombobox({
     // when user types to the text input and hits Enter
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Enter') {
-        const inputValue = (event.target as HTMLInputElement | null)?.value;
+        let inputValue = (event.target as HTMLInputElement | null)?.value;
+        if (uppercase) {
+          inputValue = inputValue?.toUpperCase();
+        }
         if (inputValue) {
           const inputValid = pattern?.test(inputValue) ?? true;
           if (inputValid) {
             setComboboxOptions((prevOptions) =>
-              uniqBy(prevOptions.concat({ label: inputValue }), 'label'),
+              uniqBy(prevOptions.concat({ label: inputValue! }), 'label'),
             );
-            setValue(name, getValues(name)?.concat(inputValue));
+            setValue(name, getValues(name)?.concat(inputValue), { shouldDirty: true });
           }
           setValid(inputValid);
         }
@@ -68,7 +73,7 @@ export default function InputCombobox({
     return function cleanup() {
       inputElement?.removeEventListener('keydown', handleKeyDown);
     };
-  }, [inputElement, rendered, getValues, setValue, name, pattern]);
+  }, [inputElement, rendered, getValues, setValue, name, pattern, uppercase]);
 
   return (
     <Controller

--- a/src/domain/kaivuilmoitus/BasicInfo.tsx
+++ b/src/domain/kaivuilmoitus/BasicInfo.tsx
@@ -148,7 +148,7 @@ export default function BasicInfo({ johtoselvitysIds }: Readonly<Props>) {
           label={t('hakemus:labels:cableReports')}
           helperText={t('hakemus:labels:cableReportsHelp')}
           className={styles.formRow}
-          pattern={/^JS\d{7}$/i}
+          pattern={/^[jJ][sS]\d{7}$/}
           errorText={t('hakemus:errors:cableReport')}
           placeholder="JSXXXXXXX"
           uppercase

--- a/src/domain/kaivuilmoitus/BasicInfo.tsx
+++ b/src/domain/kaivuilmoitus/BasicInfo.tsx
@@ -2,6 +2,7 @@ import { Box } from '@chakra-ui/react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useFormContext } from 'react-hook-form';
 import { Checkbox as HDSCheckbox, SelectionGroup } from 'hds-react';
+import { uniq } from 'lodash';
 import TextInput from '../../common/components/textInput/TextInput';
 import TextArea from '../../common/components/textArea/TextArea';
 import styles from './Kaivuilmoitus.module.scss';
@@ -21,6 +22,7 @@ export default function BasicInfo({ johtoselvitysIds }: Readonly<Props>) {
     trigger,
     watch,
     setValue,
+    getValues,
     formState: { errors },
   } = useFormContext<KaivuilmoitusFormValues>();
 
@@ -46,7 +48,11 @@ export default function BasicInfo({ johtoselvitysIds }: Readonly<Props>) {
   }
 
   function handlePlacementContractsChange(updatedContracts: string[]) {
-    setValue('applicationData.placementContracts', updatedContracts);
+    setValue(
+      'applicationData.placementContracts',
+      updatedContracts.map((value) => value.toUpperCase()),
+      { shouldDirty: true },
+    );
   }
 
   return (
@@ -138,12 +144,14 @@ export default function BasicInfo({ johtoselvitysIds }: Readonly<Props>) {
         <InputCombobox
           id="applicationData.cableReports"
           name="applicationData.cableReports"
-          options={johtoselvitysIds}
+          options={uniq(johtoselvitysIds.concat(getValues('applicationData.cableReports') ?? []))}
           label={t('hakemus:labels:cableReports')}
           helperText={t('hakemus:labels:cableReportsHelp')}
           className={styles.formRow}
-          pattern={/^JS\d{7}$/}
+          pattern={/^JS\d{7}$/i}
           errorText={t('hakemus:errors:cableReport')}
+          placeholder="JSXXXXXXX"
+          uppercase
         />
       )}
 
@@ -156,7 +164,7 @@ export default function BasicInfo({ johtoselvitysIds }: Readonly<Props>) {
         label={t('hakemus:labels:placementContracts')}
         tags={placementContracts ?? []}
         tagDeleteButtonAriaLabel={getTagDeleteButtonAriaLabel}
-        pattern="^SL\d{7}$"
+        pattern="^[sS][lL]\d{7}$"
         placeholder="SLXXXXXXX"
         helperText={t('hakemus:labels:placementContractsHelp')}
         errorText={t('hakemus:errors:placementContract')}

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -769,7 +769,7 @@
       "applicationAdditionalInfo": "Lisätietoja hakemuksesta",
       "applicationInfo": "Hakemuksen tiedot",
       "cableReports": "Tehtyjen johtoselvitysten tunnukset",
-      "cableReportsHelp": "Valitse listasta tai kirjoita muu tunnus",
+      "cableReportsHelp": "Valitse listasta tai kirjoita muu tunnus ja paina Enter lisätäksesi",
       "placementContractsTitle": "Sijoitussopimukset",
       "placementContracts": "Sijoitussopimustunnus",
       "placementContractsHelp": "Anna sijoitussopimustunnus ja paina Lisää",


### PR DESCRIPTION
# Description

Changed entering existing cable report identifiers and placement contracts to be case insensitive.

Added placeholder text and better helper text to cable report field.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1367

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Try entering cable report identifiers (for example JS0000001 and js0000002) and check that both are accepted
2. Try same for placement contracts (for example SL0000001 and sl0000002)

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
