### PR TITLE
HAI-1424: Change Buttons inside NavLink to divs for the sake of accessibility

### DIFF
--- a/src/common/components/app/app.scss
+++ b/src/common/components/app/app.scss
@@ -1,5 +1,8 @@
 @import '~hds-core/lib/base.css';
 @import '~hds-core/lib/icons/icon.css';
+@import '~hds-core/lib/icons/map.css';
+@import '~hds-core/lib/icons/layers.css';
+@import '~hds-core/lib/components/button/button.css';
 
 @font-face {
   font-family: HelsinkiGrotesk;

--- a/src/domain/mapAndList/MapAndListContainer.tsx
+++ b/src/domain/mapAndList/MapAndListContainer.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { Flex } from '@chakra-ui/react';
-import { Button } from 'hds-react';
-import { IconMap, IconLayers } from 'hds-react/icons';
 import { useTranslation } from 'react-i18next';
 import { Outlet, NavLink } from 'react-router-dom';
 import { useLocalizedRoutes } from '../../common/hooks/useLocalizedRoutes';
@@ -25,24 +23,31 @@ const MapAndListContainer: React.FC<React.PropsWithChildren<unknown>> = () => {
         <div>
           <NavLink to={PUBLIC_HANKKEET_MAP.path}>
             {({ isActive }) => (
-              <Button
-                theme="black"
-                variant={isActive ? 'primary' : 'secondary'}
-                iconRight={<IconMap />}
+              <div
+                className={
+                  'hds-button hds-button--theme-black ' +
+                  (isActive ? 'hds-button--primary' : 'hds-button--secondary')
+                }
               >
-                {t('publicHankkeet:buttons:map')}
-              </Button>
+                <span className="hds-button__label">{t('publicHankkeet:buttons:map')}</span>
+                <span className="hds-icon hds-icon--map hds-icon--size-s" aria-hidden="true"></span>
+              </div>
             )}
           </NavLink>
           <NavLink to={PUBLIC_HANKKEET_LIST.path}>
             {({ isActive }) => (
-              <Button
-                theme="black"
-                variant={isActive ? 'primary' : 'secondary'}
-                iconRight={<IconLayers />}
+              <div
+                className={
+                  'hds-button hds-button--theme-black ' +
+                  (isActive ? 'hds-button--primary' : 'hds-button--secondary')
+                }
               >
-                {t('publicHankkeet:buttons:list')}
-              </Button>
+                <span className="hds-button__label">{t('publicHankkeet:buttons:list')}</span>
+                <span
+                  className="hds-icon hds-icon--layers hds-icon--size-s"
+                  aria-hidden="true"
+                ></span>
+              </div>
             )}
           </NavLink>
         </div>


### PR DESCRIPTION
# Description

The tabs in Map and List Container were implemented as Buttons inside NavLink, which resulted screen reader to read both the link and the button. This changes the buttons to divs, so the screen reader works correctly.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1424

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Use VoiceOver or other screen reader software to switch between links and map views. It should work correctly.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
