### PR TITLE
HAI-2406 Fix incorrect page name in hanke draft state notification in hanke form summary page

### DIFF
--- a/src/domain/hanke/edit/components/HankeDraftStateNotification.tsx
+++ b/src/domain/hanke/edit/components/HankeDraftStateNotification.tsx
@@ -3,9 +3,17 @@ import { Notification } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@chakra-ui/react';
 import { uniq } from 'lodash';
+import { $enum } from 'ts-enum-util';
 import { HankeData } from '../../../types/hanke';
 import { useValidationErrors } from '../../../forms/hooks/useValidationErrors';
 import { Message, hankePublicSchema } from '../hankePublicSchema';
+import { HANKE_PAGES } from '../types';
+
+const pageOrder = $enum(HANKE_PAGES).getValues();
+
+function sortPages(a: string, b: string) {
+  return pageOrder.indexOf(a as HANKE_PAGES) - pageOrder.indexOf(b as HANKE_PAGES);
+}
 
 type Props = {
   /** Hanke data */
@@ -22,7 +30,7 @@ const HankeDraftStateNotification: React.FC<Readonly<Props>> = ({ hanke, classNa
   const hankePublicErrors = useValidationErrors(hankePublicSchema, hanke);
   const errorPages = uniq(
     hankePublicErrors.map((error) => (error.message as unknown as Message).values.page),
-  );
+  ).toSorted(sortPages);
 
   if (errorPages.length > 0) {
     return (

--- a/src/domain/hanke/edit/hankePublicSchema.ts
+++ b/src/domain/hanke/edit/hankePublicSchema.ts
@@ -9,18 +9,11 @@ import {
   HANKE_TARINAHAITTA_KEY,
   HANKE_VAIHE_KEY,
 } from '../../types/hanke';
-import { CONTACT_FORMFIELD, FORMFIELD } from './types';
+import { CONTACT_FORMFIELD, FORMFIELD, HANKE_PAGES } from './types';
 
 enum ERROR_KEYS {
   REQUIRED = 'required',
   MIN = 'min',
-}
-
-enum HANKE_PAGES {
-  PERUSTIEDOT = 'perustiedot',
-  ALUEET = 'alueet',
-  HAITTOJEN_HALLINTA = 'haittojenHallinta',
-  YHTEYSTIEDOT = 'yhteystiedot',
 }
 
 export type Message = {
@@ -69,11 +62,7 @@ const yhteystietoSchema = yup.object({
     .when('tyyppi', {
       is: (value: string) => value === CONTACT_TYYPPI.YRITYS || value === CONTACT_TYYPPI.YHTEISO,
       then: (schema) =>
-        schema.test(
-          'is-business-id',
-          getMessage(CONTACT_FORMFIELD.TUNNUS, HANKE_PAGES.YHTEYSTIEDOT),
-          isValidBusinessId,
-        ),
+        schema.test('is-business-id', getMessage(HANKE_PAGES.YHTEYSTIEDOT), isValidBusinessId),
       otherwise: (schema) => schema,
     }),
 });

--- a/src/domain/hanke/edit/types.ts
+++ b/src/domain/hanke/edit/types.ts
@@ -99,3 +99,10 @@ export type YhteyshenkiloWithoutName = Pick<
   Yhteyshenkilo,
   YHTEYSHENKILO_FORMFIELD.EMAIL | YHTEYSHENKILO_FORMFIELD.PUHELINNUMERO
 >;
+
+export enum HANKE_PAGES {
+  PERUSTIEDOT = 'perustiedot',
+  ALUEET = 'alueet',
+  HAITTOJEN_HALLINTA = 'haittojenHallinta',
+  YHTEYSTIEDOT = 'yhteystiedot',
+}


### PR DESCRIPTION
# Description

In hanke form summary page where all pages with missing information are listed, there was an entry tabit.ytunnus. Fixed that.

Also fixed incorrect order of pages which would occur in some cases.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2406

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create new hanke
2. Visit contacts page but don't fill anything there and go to summary page
3. Pages with missing information should be listed in the notification with nothing extra

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
