### PR TITLE
HAI-1415: Trap focus to side panel for improved accessiblity

### DIFF
--- a/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
+++ b/src/domain/map/components/HankeSidebar/HankeSidebar.tsx
@@ -44,9 +44,6 @@ const HankeSidebar: React.FC<React.PropsWithChildren<Props>> = ({ hanke, isOpen,
       placement="left"
       isOpen={isOpen}
       size="md"
-      // https://github.com/chakra-ui/chakra-ui/issues/2893
-      // Temporary ixed with global css in app.scss
-      trapFocus={false}
       useInert={false}
       onClose={handleClose}
       blockScrollOnMount={false}


### PR DESCRIPTION
# Description

trapFocus property was disabled for side panel, which resulted the user having to tab all through the background elements before being able to access the panel content. This change makes opening the panel to also focus on the panel contents.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/jira/software/projects/HAI/boards/116?selectedIssue=HAI-1415

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Click an area on the map. The tab focus should not be inside the panel. Using VoiceOver, the user moving forward on the page will immediately access the panel contents.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: