### PR TITLE
HAI-1370 Fix validation of OVT-tunnus field in kaivuilmoitus

### DIFF
--- a/src/common/components/dropdown/DropdownMultiselect.tsx
+++ b/src/common/components/dropdown/DropdownMultiselect.tsx
@@ -21,6 +21,7 @@ type PropTypes<T> = {
   icon?: ReactNode;
   clearable?: boolean;
   placeholder?: string;
+  required?: boolean;
   mapValueToLabel: (value: T) => string;
   transformValue?: (value: T) => T;
 };
@@ -37,6 +38,7 @@ function DropdownMultiselect<T>({
   icon,
   clearable,
   placeholder,
+  required,
   mapValueToLabel,
   transformValue,
 }: Readonly<PropTypes<T>>) {
@@ -74,6 +76,7 @@ function DropdownMultiselect<T>({
             tooltipButtonLabel={tooltip?.tooltipButtonLabel}
             tooltipLabel={tooltip?.tooltipLabel}
             tooltipText={tooltip?.tooltipText}
+            required={required}
           />
         );
       }}

--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -153,6 +153,7 @@ const CustomerFields: React.FC<{
         mapHankeUserToValue={mapHankeUserToContact}
         mapValueToLabel={mapContactToLabel}
         transformValue={(value) => removeOrdererFromContact(value)}
+        required
         tooltip={{
           tooltipButtonLabel: t('hankeForm:toolTips:tipOpenLabel'),
           tooltipLabel: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),

--- a/src/domain/application/yupSchemas.ts
+++ b/src/domain/application/yupSchemas.ts
@@ -65,7 +65,11 @@ export const invoicingCustomerSchema = yup.object({
   }),
   email: yup.string().nullable().trim().email().max(100),
   phone: yup.string().nullable().phone().trim().max(20),
-  ovt: yup.string().min(12).nullable(),
+  ovt: yup
+    .string()
+    .nullable()
+    .transform((value: string, originalValue: string) => (originalValue === '' ? null : value))
+    .min(12),
   invoicingOperator: yup.string().nullable(),
   customerReference: yup.string().nullable(),
 });

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -872,6 +872,7 @@ describe('New contact person form and contact person dropdown', () => {
     await user.click(screen.getAllByRole('button', { name: /lisää uusi yhteyshenkilö/i })[0]);
     fillNewContactPersonForm(newUser);
     await user.click(screen.getByRole('button', { name: /tallenna ja lisää yhteyshenkilö/i }));
+    fireEvent.click(screen.getByRole('button', { name: /sulje ilmoitus/i }));
     await user.click(screen.getAllByRole('button', { name: /lisää uusi yhteyshenkilö/i })[0]);
     fillNewContactPersonForm(newUser);
     await user.click(screen.getByRole('button', { name: /tallenna ja lisää yhteyshenkilö/i }));

--- a/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
+++ b/src/domain/hanke/hankeUsers/ContactPersonSelect.tsx
@@ -10,6 +10,7 @@ function ContactPersonSelect<T>({
   name,
   hankeUsers,
   tooltip,
+  required,
   mapHankeUserToValue,
   mapValueToLabel,
   transformValue,
@@ -17,6 +18,7 @@ function ContactPersonSelect<T>({
   name: string;
   hankeUsers?: HankeUser[];
   tooltip?: TooltipProps;
+  required?: boolean;
   mapHankeUserToValue: (user: HankeUser) => T;
   mapValueToLabel: (value: T) => string;
   transformValue?: (value: T) => T;
@@ -38,6 +40,7 @@ function ContactPersonSelect<T>({
       mapValueToLabel={mapValueToLabel}
       transformValue={transformValue}
       defaultValue={[]}
+      required={required}
       options={
         hankeUsers?.map((hankeUser) => ({
           value: mapHankeUserToValue(hankeUser),

--- a/src/domain/kaivuilmoitus/Contacts.tsx
+++ b/src/domain/kaivuilmoitus/Contacts.tsx
@@ -14,16 +14,19 @@ export default function Contacts() {
   const { t } = useTranslation();
   const { watch, resetField, trigger } = useFormContext<KaivuilmoitusFormValues>();
 
-  const [selectedContactType, ovt, invoicingOperator, customerReference] = watch([
+  const [selectedContactType, ovt, invoicingOperator, streetName, postalCode, city] = watch([
     'applicationData.invoicingCustomer.type',
     'applicationData.invoicingCustomer.ovt',
     'applicationData.invoicingCustomer.invoicingOperator',
-    'applicationData.invoicingCustomer.customerReference',
+    'applicationData.invoicingCustomer.postalAddress.streetAddress.streetName',
+    'applicationData.invoicingCustomer.postalAddress.postalCode',
+    'applicationData.invoicingCustomer.postalAddress.city',
   ]);
 
   const ovtDisabled = selectedContactType === 'PERSON' || selectedContactType === 'OTHER';
 
-  const postalAddressRequired = !ovt || !invoicingOperator || !customerReference;
+  const postalAddressRequired = !ovt || !invoicingOperator;
+  const ovtRequired = !ovtDisabled && (!streetName || !postalCode || !city);
 
   useEffect(() => {
     if (selectedContactType === 'PERSON' || selectedContactType === 'OTHER') {
@@ -42,6 +45,15 @@ export default function Contacts() {
       ]);
     }
   }, [postalAddressRequired, trigger]);
+
+  useEffect(() => {
+    if (!ovtRequired) {
+      trigger([
+        'applicationData.invoicingCustomer.ovt',
+        'applicationData.invoicingCustomer.invoicingOperator',
+      ]);
+    }
+  }, [ovtRequired, trigger]);
 
   return (
     <>
@@ -85,16 +97,17 @@ export default function Contacts() {
             name="applicationData.invoicingCustomer.ovt"
             label={t('form:yhteystiedot:labels:ovt')}
             disabled={ovtDisabled}
+            required={ovtRequired}
           />
           <TextInput
             name="applicationData.invoicingCustomer.invoicingOperator"
             label={t('form:yhteystiedot:labels:invoicingOperator')}
             disabled={ovtDisabled}
+            required={ovtRequired}
           />
           <TextInput
             name="applicationData.invoicingCustomer.customerReference"
             label={t('form:yhteystiedot:labels:customerReference')}
-            disabled={ovtDisabled}
           />
         </ResponsiveGrid>
         <ResponsiveGrid>

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -220,6 +220,7 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
       'applicationData.propertyDeveloperWithContacts.customer.registryKey',
       'applicationData.representativeWithContacts.customer.registryKey',
       'applicationData.invoicingCustomer.registryKey',
+      'applicationData.invoicingCustomer.ovt',
     ],
   ];
 

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -525,7 +525,6 @@ test('Should disable OVT fields if invoicing customer type is not COMPANY or ASS
 
   expect(screen.getByTestId('applicationData.invoicingCustomer.ovt')).toBeDisabled();
   expect(screen.getByTestId('applicationData.invoicingCustomer.invoicingOperator')).toBeDisabled();
-  expect(screen.getByTestId('applicationData.invoicingCustomer.customerReference')).toBeDisabled();
 });
 
 test('Postal address fields should be required if OVT fields are empty', async () => {
@@ -548,9 +547,6 @@ test('Postal address fields should be required if OVT fields are empty', async (
   fireEvent.change(screen.getByTestId('applicationData.invoicingCustomer.invoicingOperator'), {
     target: { value: '12345' },
   });
-  fireEvent.change(screen.getByTestId('applicationData.invoicingCustomer.customerReference'), {
-    target: { value: '6789' },
-  });
 
   expect(
     screen.getByTestId('applicationData.invoicingCustomer.postalAddress.streetAddress.streetName'),
@@ -560,6 +556,37 @@ test('Postal address fields should be required if OVT fields are empty', async (
   ).not.toBeRequired();
   expect(
     screen.getByTestId('applicationData.invoicingCustomer.postalAddress.city'),
+  ).not.toBeRequired();
+});
+
+test('OVT fields should be required if postal address fields are empty', async () => {
+  const hankeData = hankkeet[1] as HankeData;
+  const { user } = render(<KaivuilmoitusContainer hankeData={hankeData} />);
+  await fillBasicInformation(user);
+  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+  expect(screen.getByTestId('applicationData.invoicingCustomer.ovt')).toBeRequired();
+  expect(screen.getByTestId('applicationData.invoicingCustomer.invoicingOperator')).toBeRequired();
+
+  fireEvent.change(
+    screen.getByTestId('applicationData.invoicingCustomer.postalAddress.streetAddress.streetName'),
+    {
+      target: { value: 'Katu 1' },
+    },
+  );
+  fireEvent.change(
+    screen.getByTestId('applicationData.invoicingCustomer.postalAddress.postalCode'),
+    {
+      target: { value: '00100' },
+    },
+  );
+  fireEvent.change(screen.getByTestId('applicationData.invoicingCustomer.postalAddress.city'), {
+    target: { value: 'Helsinki' },
+  });
+
+  expect(screen.getByTestId('applicationData.invoicingCustomer.ovt')).not.toBeRequired();
+  expect(
+    screen.getByTestId('applicationData.invoicingCustomer.invoicingOperator'),
   ).not.toBeRequired();
 });
 


### PR DESCRIPTION
# Description
There was a problem in contacts page that even if filling all required fields, it would appear that there is some missing information.

Changed validation for ovt field so that empty string is also valid so there is no error if user leaves the field empty.

Also changed yhteyshenklöt fields to be required.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1370

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

In kaivuilmoitus form contacts page, fill all required fields and move to next page. Stepper icon for contacts page should be completed and there should not be a warning icon.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
