### PR TITLE
HAI-1411: Add tooltip next to index number for accessiblity

### DIFF
--- a/src/domain/common/haittaIndexes/HaittaIndex.tsx
+++ b/src/domain/common/haittaIndexes/HaittaIndex.tsx
@@ -7,9 +7,15 @@ type Props = {
   index?: number;
   tooltipContent?: React.ReactNode;
   testId?: string;
+  showTooltip?: boolean;
 };
 
-export default function HaittaIndex({ index, tooltipContent, testId }: Readonly<Props>) {
+export default function HaittaIndex({
+  index,
+  tooltipContent,
+  testId,
+  showTooltip = false,
+}: Readonly<Props>) {
   const { t } = useTranslation();
 
   return (
@@ -20,7 +26,12 @@ export default function HaittaIndex({ index, tooltipContent, testId }: Readonly<
         </Box>
         {tooltipContent ? <HaittaIndexTooltip>{tooltipContent}</HaittaIndexTooltip> : null}
       </Flex>
-      <HaittaIndexNumber index={index} testId={testId} />
+      <HaittaIndexNumber
+        index={index}
+        testId={testId}
+        tooltipContent={tooltipContent}
+        showTooltip={showTooltip}
+      />
     </Flex>
   );
 }

--- a/src/domain/common/haittaIndexes/HaittaIndexNumber.tsx
+++ b/src/domain/common/haittaIndexes/HaittaIndexNumber.tsx
@@ -7,30 +7,48 @@ import {
   getColorByStatus,
   TormaysIndex,
 } from '../utils/liikennehaittaindeksi';
+import HaittaIndexTooltip from './HaittaIndexTooltip';
 
-type Props = { index?: TormaysIndex; testId?: string };
+type Props = {
+  index?: TormaysIndex;
+  testId?: string;
+  tooltipContent?: React.ReactNode;
+  showTooltip?: boolean;
+};
 
-const HaittaIndexNumber: React.FC<Props> = ({ index, testId }) => {
+const HaittaIndexNumber: React.FC<Props> = ({
+  index,
+  testId,
+  tooltipContent,
+  showTooltip = false,
+}) => {
   const { t } = useTranslation();
 
   const status = getStatusByIndex(index);
 
   return (
-    <Box
-      backgroundColor={getColorByStatus(status)}
-      color={
-        status === LIIKENNEHAITTA_STATUS.YELLOW || status === LIIKENNEHAITTA_STATUS.GREY
-          ? 'black'
-          : 'white'
-      }
-      width="40px"
-      fontSize="var(--fontsize-body-m)"
-      textAlign="center"
-      py="3px"
-      data-testid={testId}
-    >
-      <VisuallyHidden>{t('common:haittaIndex:haittaIndexNumber')}</VisuallyHidden>
-      {index === undefined ? '-' : index}
+    <Box display="flex" alignItems="center" flexDirection="row" gap="8px">
+      <Box
+        backgroundColor={getColorByStatus(status)}
+        color={
+          status === LIIKENNEHAITTA_STATUS.YELLOW || status === LIIKENNEHAITTA_STATUS.GREY
+            ? 'black'
+            : 'white'
+        }
+        width="40px"
+        fontSize="var(--fontsize-body-m)"
+        textAlign="center"
+        py="3px"
+        data-testid={testId}
+      >
+        <VisuallyHidden>{t('common:haittaIndex:haittaIndexSelite')}</VisuallyHidden>
+        {index === undefined ? '-' : index}
+      </Box>
+      <div aria-hidden>
+        {showTooltip && tooltipContent ? (
+          <HaittaIndexTooltip>{tooltipContent}</HaittaIndexTooltip>
+        ) : null}
+      </div>
     </Box>
   );
 };

--- a/src/domain/hanke/hankeIndexes/CompressedAreaIndex.tsx
+++ b/src/domain/hanke/hankeIndexes/CompressedAreaIndex.tsx
@@ -42,6 +42,8 @@ const CompressedAreaIndex: React.FC<Props> = ({ area, haittaIndex, index, classN
       <HaittaIndexNumber
         index={haittaIndex}
         testId="hankeIndexes:compressed:liikennehaittaindeksi"
+        tooltipContent={t('common:haittaIndex:haittaIndexSelite')}
+        showTooltip
       />
     </Flex>
   );

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -81,7 +81,8 @@
     },
     "haittaIndex": {
       "fillHaitat": "Täytä alueen haitta-arviot nähdäksesi haittaindeksit",
-      "haittaIndexNumber": "Haittaindeksiluku:"
+      "haittaIndexNumber": "Haittaindeksiluku:",
+      "haittaIndexSelite": "Aluekohtainen haittaindeksi (0–5)"
     }
   },
   "form": {


### PR DESCRIPTION
# Description

Add tooltip that describes the scale (1–5) next to index number for accessiblity in hanke page

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2587

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Go to hanke page which has an area with nuisance index. There is a tooltip next to the index number. The screen reader should read the description before the index number, and ignore the tooltip.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location