### PR TITLE
HAI-2514 validate user email for duplicates

### DIFF
--- a/src/common/utils/yup.ts
+++ b/src/common/utils/yup.ts
@@ -1,6 +1,7 @@
 import * as yup from 'yup';
 import { formatToFinnishDate } from './date';
 import isValidBusinessId from '../../common/utils/isValidBusinessId';
+import { HankeUser } from '../../domain/hanke/hankeUsers/hankeUser';
 
 // https://github.com/jquense/yup/blob/master/src/locale.ts
 yup.setLocale({
@@ -42,5 +43,28 @@ yup.addMethod(
     return this.test('is-business-id', message, isValidBusinessId);
   },
 );
+
+yup.addMethod(yup.string, 'uniqueEmail', function isUniqueEmail() {
+  return this.test('uniqueEmail', 'Email already exists', function (value) {
+    const context = this.options.context;
+    if (!context) {
+      return true;
+    }
+    const { hankeUsers, currentUser, errorMessageKey } = context as {
+      hankeUsers: HankeUser[];
+      currentUser?: HankeUser;
+      errorMessageKey: string;
+    };
+    if (!hankeUsers) {
+      return true;
+    }
+    const isUnique =
+      !hankeUsers.some((user) => user.sahkoposti === value) || currentUser?.sahkoposti === value;
+    return (
+      isUnique ||
+      this.createError({ path: this.path, message: { key: errorMessageKey, values: {} } })
+    );
+  });
+});
 
 export default yup;

--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -222,6 +222,7 @@ export default function ApplicationContacts() {
       <FormContact<CustomerType>
         contactType="customerWithContacts"
         hankeTunnus={hankeTunnus!}
+        hankeUsers={hankeUsers}
         onContactPersonAdded={(user) =>
           addYhteyshenkiloForYhteystieto('customerWithContacts', user)
         }
@@ -239,6 +240,7 @@ export default function ApplicationContacts() {
         <FormContact<CustomerType>
           contactType="contractorWithContacts"
           hankeTunnus={hankeTunnus!}
+          hankeUsers={hankeUsers}
           onContactPersonAdded={(user) =>
             addYhteyshenkiloForYhteystieto('contractorWithContacts', user)
           }
@@ -258,6 +260,7 @@ export default function ApplicationContacts() {
           <FormContact<CustomerType>
             contactType="propertyDeveloperWithContacts"
             hankeTunnus={hankeTunnus!}
+            hankeUsers={hankeUsers}
             onRemove={handleRemovePropertyDeveloper}
             onContactPersonAdded={(user) =>
               addYhteyshenkiloForYhteystieto('propertyDeveloperWithContacts', user)
@@ -289,6 +292,7 @@ export default function ApplicationContacts() {
           <FormContact<CustomerType>
             contactType="representativeWithContacts"
             hankeTunnus={hankeTunnus!}
+            hankeUsers={hankeUsers}
             onRemove={handleRemoveRepresentative}
             onContactPersonAdded={(user) =>
               addYhteyshenkiloForYhteystieto('representativeWithContacts', user)

--- a/src/domain/forms/components/FormContact.tsx
+++ b/src/domain/forms/components/FormContact.tsx
@@ -11,6 +11,7 @@ import Transition from '../../../common/components/transition/Transition';
 interface Props<T> {
   contactType: T;
   hankeTunnus: string;
+  hankeUsers: HankeUser[] | undefined;
   index?: number;
   canBeRemoved?: boolean;
   onRemove?: UseFieldArrayRemove;
@@ -21,6 +22,7 @@ interface Props<T> {
 const FormContact = <T,>({
   contactType,
   hankeTunnus,
+  hankeUsers,
   index,
   canBeRemoved = true,
   onRemove,
@@ -79,6 +81,7 @@ const FormContact = <T,>({
       >
         <NewContactPersonForm
           hankeTunnus={hankeTunnus}
+          hankeUsers={hankeUsers}
           onContactPersonAdded={onContactPersonAdded}
           onClose={closeNewContactForm}
         />

--- a/src/domain/forms/components/NewContactPersonForm.tsx
+++ b/src/domain/forms/components/NewContactPersonForm.tsx
@@ -30,7 +30,7 @@ function NewContactPersonForm({
   const formContext = useForm<Yhteyshenkilo>({
     mode: 'onTouched',
     resolver: yupResolver(yhteyshenkiloSchema),
-    context: { hankeUsers },
+    context: { hankeUsers: hankeUsers, errorMessageKey: 'emailAlreadyUsedInContacts' },
   });
   const { getValues, trigger } = formContext;
   const { mutate } = useMutation(createHankeUser);

--- a/src/domain/forms/components/NewContactPersonForm.tsx
+++ b/src/domain/forms/components/NewContactPersonForm.tsx
@@ -15,15 +15,22 @@ export type ContactPersonAddedNotification = 'success' | 'error' | null;
 
 type Props = {
   hankeTunnus: string;
+  hankeUsers: HankeUser[] | undefined;
   onContactPersonAdded?: (newHankeUser: HankeUser) => void;
   onClose: (notification: ContactPersonAddedNotification) => void;
 };
 
-function NewContactPersonForm({ hankeTunnus, onContactPersonAdded, onClose }: Readonly<Props>) {
+function NewContactPersonForm({
+  hankeTunnus,
+  hankeUsers,
+  onContactPersonAdded,
+  onClose,
+}: Readonly<Props>) {
   const { t } = useTranslation();
   const formContext = useForm<Yhteyshenkilo>({
     mode: 'onTouched',
     resolver: yupResolver(yhteyshenkiloSchema),
+    context: { hankeUsers },
   });
   const { getValues, trigger } = formContext;
   const { mutate } = useMutation(createHankeUser);

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -819,6 +819,29 @@ describe('New contact person form and contact person dropdown', () => {
     expect(screen.queryByText('Yhteyshenkilö tallennettu')).not.toBeInTheDocument();
   });
 
+  test('Should not be able to create new user and show validation error if the new user has an existing email address', async () => {
+    const newUser = {
+      etunimi: 'Martti',
+      sukunimi: 'Mielikäinen',
+      sahkoposti: 'martti.mielikainen@test.com',
+      puhelinnumero: '0000000000',
+    };
+    const { user } = await setupYhteystiedotPage(<HankeFormContainer hankeTunnus="HAI22-1" />);
+    await user.click(screen.getAllByRole('button', { name: /lisää uusi yhteyshenkilö/i })[0]);
+    fillNewContactPersonForm(newUser);
+    await user.click(screen.getByRole('button', { name: /tallenna ja lisää yhteyshenkilö/i }));
+    await user.click(screen.getAllByRole('button', { name: /lisää uusi yhteyshenkilö/i })[0]);
+    fillNewContactPersonForm(newUser);
+    await user.click(screen.getByRole('button', { name: /tallenna ja lisää yhteyshenkilö/i }));
+
+    expect(
+      screen.getByText(
+        'Valitsemasi sähköpostiosoite löytyy jo hankkeen käyttäjähallinnasta. Lisää yhteyshenkilö pudotusvalikosta.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Yhteyshenkilö tallennettu')).not.toBeInTheDocument();
+  });
+
   test('Should show error notification if creating new user fails', async () => {
     server.use(
       rest.post('/api/hankkeet/:hankeTunnus/kayttajat', async (req, res, ctx) => {

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -206,6 +206,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.OMISTAJAT}
               hankeTunnus={hanke.hankeTunnus!}
+              hankeUsers={hankeUsers}
               index={index}
               canBeRemoved={omistajat.length > 1}
               onRemove={removeOmistaja}
@@ -249,6 +250,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.RAKENNUTTAJAT}
               hankeTunnus={hanke.hankeTunnus!}
+              hankeUsers={hankeUsers}
               index={index}
               onRemove={removeRakennuttaja}
               onContactPersonAdded={(user) =>
@@ -291,6 +293,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.TOTEUTTAJAT}
               hankeTunnus={hanke.hankeTunnus!}
+              hankeUsers={hankeUsers}
               index={index}
               onRemove={removeToteuttaja}
               onContactPersonAdded={(user) =>
@@ -335,6 +338,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.MUUTTAHOT}
               hankeTunnus={hanke.hankeTunnus!}
+              hankeUsers={hankeUsers}
               index={index}
               onRemove={removeMuuTaho}
               onContactPersonAdded={(user) =>

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -23,7 +23,7 @@ import { HaittaIndexData } from '../../common/haittaIndexes/types';
 export const yhteyshenkiloSchema = yup.object({
   [YHTEYSHENKILO_FORMFIELD.ETUNIMI]: yup.string().max(50).required(),
   [YHTEYSHENKILO_FORMFIELD.SUKUNIMI]: yup.string().max(50).required(),
-  [YHTEYSHENKILO_FORMFIELD.EMAIL]: yup.string().email().max(100).required(),
+  [YHTEYSHENKILO_FORMFIELD.EMAIL]: yup.string().email().max(100).uniqueEmail().required(),
   [YHTEYSHENKILO_FORMFIELD.PUHELINNUMERO]: yup.string().phone().max(20).required(),
 });
 

--- a/src/domain/hanke/hankeUsers/EditUserView.test.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.test.tsx
@@ -145,7 +145,7 @@ test('Should be able to edit own information', async () => {
     <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus={hankeTunnus} />,
   );
   await waitForLoadingToFinish();
-  const sahkoposti = 'matti@test.com';
+  const sahkoposti = 'matti.meikalainen@test.com';
   const puhelinnumero = '0000000000';
   fillUserInformation({ sahkoposti, puhelinnumero });
   await user.click(screen.getByRole('button', { name: /tallenna muutokset/i }));
@@ -171,6 +171,23 @@ test('Should not be able to save changes if form is not valid', async () => {
 
   expect(screen.getByText('Sähköposti on virheellinen')).toBeInTheDocument();
   expect(screen.getByText('Kenttä on pakollinen')).toBeInTheDocument();
+  expect(updateSelf).not.toHaveBeenCalled();
+
+  updateSelf.mockRestore();
+});
+
+test('Should not be able to save changes if email address is already in use', async () => {
+  const updateSelf = jest.spyOn(hankeUsersApi, 'updateSelf');
+  const { user } = render(
+    <EditUserContainer id="3fa85f64-5717-4562-b3fc-2c963f66afa6" hankeTunnus="HAI22-2" />,
+  );
+  await waitForLoadingToFinish();
+  fillUserInformation({ sahkoposti: 'teppo@test.com', puhelinnumero: '123456' });
+  await user.click(screen.getByRole('button', { name: /tallenna muutokset/i }));
+
+  expect(
+    screen.getByText('Valitsemasi sähköpostiosoite löytyy jo toiselta käyttäjältä.'),
+  ).toBeInTheDocument();
   expect(updateSelf).not.toHaveBeenCalled();
 
   updateSelf.mockRestore();

--- a/src/domain/hanke/hankeUsers/EditUserView.tsx
+++ b/src/domain/hanke/hankeUsers/EditUserView.tsx
@@ -98,6 +98,11 @@ function EditUserView({
       kayttooikeustaso,
     },
     resolver: yupResolver(editUserSchema),
+    context: {
+      hankeUsers: hankeUsers,
+      currentUser: user,
+      errorMessageKey: 'emailAlreadyUsedInUserManagement',
+    },
   });
   const { handleSubmit } = formContext;
 

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -718,7 +718,7 @@ test('Should be able to create new user and new user is added to dropdown', asyn
   const newUser = {
     etunimi: 'Marja',
     sukunimi: 'Meikäkäinen',
-    sahkoposti: 'marja@test.com',
+    sahkoposti: 'marja.meikalainen@test.com',
     puhelinnumero: '0000000000',
   };
   const testApplication = applications[0] as Application<JohtoselvitysData>;
@@ -732,6 +732,27 @@ test('Should be able to create new user and new user is added to dropdown', asyn
   expect(screen.getByText('Yhteyshenkilö tallennettu')).toBeInTheDocument();
   expect(
     screen.getByText(`${newUser.etunimi} ${newUser.sukunimi} (${newUser.sahkoposti})`),
+  ).toBeInTheDocument();
+});
+
+test('Should show validation error if the new user has an existing email address', async () => {
+  const newUser = {
+    etunimi: 'Marja',
+    sukunimi: 'Meikäkäinen',
+    sahkoposti: 'matti.meikalainen@test.com',
+    puhelinnumero: '0000000000',
+  };
+  const testApplication = applications[0] as Application<JohtoselvitysData>;
+  const { user } = render(<JohtoselvitysContainer application={testApplication} />);
+  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+  expect(screen.queryByText('Vaihe 3/5: Yhteystiedot')).toBeInTheDocument();
+  await user.click(screen.getAllByRole('button', { name: /lisää uusi yhteyshenkilö/i })[0]);
+  fillNewContactPersonForm(newUser);
+  await user.click(screen.getByRole('button', { name: /tallenna ja lisää yhteyshenkilö/i }));
+  expect(
+    screen.getByText(
+      /valitsemasi sähköpostiosoite löytyy jo hankkeen käyttäjähallinnasta. lisää yhteyshenkilö pudotusvalikosta./i,
+    ),
   ).toBeInTheDocument();
 });
 
@@ -775,8 +796,8 @@ test('Should remove validation error if yhteyshenkilo is created for yhteystieto
   await user.click(screen.getAllByRole('button', { name: /lisää uusi yhteyshenkilö/i })[0]);
   fillNewContactPersonForm({
     etunimi: 'Matti',
-    sukunimi: 'Meikäläinen',
-    sahkoposti: 'matti@test.com',
+    sukunimi: 'Kymäläinen',
+    sahkoposti: 'matti.kymalainen@test.com',
     puhelinnumero: '0000000000',
   });
   await user.click(screen.getByRole('button', { name: /tallenna ja lisää yhteyshenkilö/i }));

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../testUtils/helperFunctions';
 import { ContactType, Customer, InvoicingCustomer } from '../application/types/application';
 import { cloneDeep } from 'lodash';
+import { fillNewContactPersonForm } from '../forms/components/testUtils';
 
 afterEach(cleanup);
 
@@ -485,6 +486,31 @@ test('Should be able to fill form pages and show filled information in summary p
   expect(screen.getByText('muu.png')).toBeInTheDocument();
   expect(
     screen.getByText('Lorem ipsum dolor sit amet, consectetur adipiscing elit.'),
+  ).toBeInTheDocument();
+});
+
+test('Should show validation error if the new user has an existing email address', async () => {
+  const hankeData = hankkeet[1] as HankeData;
+  const newUser = {
+    etunimi: 'Marja',
+    sukunimi: 'Meikäkäinen',
+    sahkoposti: 'marja.meikalainen@test.com',
+    puhelinnumero: '0000000000',
+  };
+  const { user } = render(<KaivuilmoitusContainer hankeData={hankeData} />);
+  await fillBasicInformation(user);
+  await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+  await user.click(screen.getAllByRole('button', { name: /lisää uusi yhteyshenkilö/i })[0]);
+  fillNewContactPersonForm(newUser);
+  await user.click(screen.getByRole('button', { name: /tallenna ja lisää yhteyshenkilö/i }));
+  await user.click(screen.getAllByRole('button', { name: /lisää uusi yhteyshenkilö/i })[0]);
+  fillNewContactPersonForm(newUser);
+  await user.click(screen.getByRole('button', { name: /tallenna ja lisää yhteyshenkilö/i }));
+  expect(
+    screen.getByText(
+      /valitsemasi sähköpostiosoite löytyy jo hankkeen käyttäjähallinnasta. lisää yhteyshenkilö pudotusvalikosta./i,
+    ),
   ).toBeInTheDocument();
 });
 

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -99,7 +99,8 @@
       "dateMin": "Ensimmäinen mahdollinen päivä on {{min}}",
       "dateMax": "Viimeinen mahdollinen päivä on {{max}}",
       "yhteyshenkilotMin": "Vähintään yksi yhteyshenkilö tulee olla asetettuna",
-      "emailNotUnique": "Valitsemasi sähköpostiosoite löytyy jo hankkeen käyttäjähallinnasta. Lisää yhteyshenkilö pudotusvalikosta."
+      "emailAlreadyUsedInContacts": "Valitsemasi sähköpostiosoite löytyy jo hankkeen käyttäjähallinnasta. Lisää yhteyshenkilö pudotusvalikosta.",
+      "emailAlreadyUsedInUserManagement": "Valitsemasi sähköpostiosoite löytyy jo toiselta käyttäjältä."
     },
     "errors": {
       "areaRequired": "Vähintään yksi alue vaaditaan",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -98,7 +98,8 @@
       "stringMax": "Kentän pituus oltava enintään {{max}} merkkiä",
       "dateMin": "Ensimmäinen mahdollinen päivä on {{min}}",
       "dateMax": "Viimeinen mahdollinen päivä on {{max}}",
-      "yhteyshenkilotMin": "Vähintään yksi yhteyshenkilö tulee olla asetettuna"
+      "yhteyshenkilotMin": "Vähintään yksi yhteyshenkilö tulee olla asetettuna",
+      "emailNotUnique": "Valitsemasi sähköpostiosoite löytyy jo hankkeen käyttäjähallinnasta. Lisää yhteyshenkilö pudotusvalikosta."
     },
     "errors": {
       "areaRequired": "Vähintään yksi alue vaaditaan",

--- a/src/types/yup-extensions.d.ts
+++ b/src/types/yup-extensions.d.ts
@@ -4,6 +4,7 @@ declare module 'yup' {
   interface StringSchema {
     phone(message?: Message): this;
     businessId(message?: Message): this;
+    uniqueEmail(): this;
   }
   interface CustomSchemaMetadata {
     pageName?: string | string[];


### PR DESCRIPTION
# Description

In Hanke and Hakemus forms, when adding a new contact person, its email is validated against existing users and if the email is in use an error message is shown.
Also, in user management, one cannot change the user's email to be same as someone else's.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2514

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

* In project or application form, add a new contact person with an existing email address. There should be an error message shown.
* In user management, try to change user's email to be the same as someone else's. There should be an error message shown.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
