### PR TITLE
HAI-2521 When saving and quitting in application form navigate to application view

### DIFF
--- a/src/common/components/footer/Footer.module.scss
+++ b/src/common/components/footer/Footer.module.scss
@@ -1,0 +1,3 @@
+.footer {
+  position: relative;
+}

--- a/src/common/components/footer/Footer.tsx
+++ b/src/common/components/footer/Footer.tsx
@@ -2,8 +2,11 @@ import { Link } from 'react-router-dom';
 import { Footer, Logo, logoFi, logoSv } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { useLocalizedRoutes } from '../../hooks/useLocalizedRoutes';
+import styles from './Footer.module.scss';
 
-function HaitatonFooter({ backgroundColor = 'var(--color-summer)' }: { backgroundColor?: string }) {
+function HaitatonFooter({
+  backgroundColor = 'var(--color-summer)',
+}: Readonly<{ backgroundColor?: string }>) {
   const { t, i18n } = useTranslation();
   const { MANUAL, HAITATON_INFO, ACCESSIBILITY, PRIVACY_POLICY } = useLocalizedRoutes();
   const { HOME } = useLocalizedRoutes();
@@ -16,6 +19,7 @@ function HaitatonFooter({ backgroundColor = 'var(--color-summer)' }: { backgroun
         '--footer-background': backgroundColor,
         '--footer-divider-color': 'var(--color-black-90)',
       }}
+      className={styles.footer}
     >
       <Footer.Navigation ariaLabel={t('common:ariaLabels:footerNavigation')}>
         <Footer.Link as={Link} to={MANUAL.path} label={MANUAL.label} />

--- a/src/domain/application/hooks/useNavigateToApplicationView.ts
+++ b/src/domain/application/hooks/useNavigateToApplicationView.ts
@@ -2,11 +2,11 @@ import { useNavigate } from 'react-router-dom';
 import useLinkPath from '../../../common/hooks/useLinkPath';
 import { ROUTES } from '../../../common/types/route';
 
-export default function useNavigateToApplicationView(applicationId?: string) {
+export default function useNavigateToApplicationView() {
   const navigate = useNavigate();
   const getApplicationViewPath = useLinkPath(ROUTES.HAKEMUS);
 
-  function navigateToApplicationView() {
+  function navigateToApplicationView(applicationId?: string) {
     if (applicationId) {
       navigate(getApplicationViewPath({ id: applicationId }));
     }

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -30,7 +30,6 @@ import { isApplicationDraft, isContactIn, sendApplication } from '../application
 import { HankeData } from '../types/hanke';
 import { ApplicationCancel } from '../application/components/ApplicationCancel';
 import ApplicationSaveNotification from '../application/components/ApplicationSaveNotification';
-import { useNavigateToApplicationList } from '../hanke/hooks/useNavigateToApplicationList';
 import { useGlobalNotification } from '../../common/components/globalNotification/GlobalNotificationContext';
 import useApplicationSendNotification from '../application/hooks/useApplicationSendNotification';
 import useHanke from '../hanke/hooks/useHanke';
@@ -47,6 +46,7 @@ import useAttachments from '../application/hooks/useAttachments';
 import { APPLICATION_ID_STORAGE_KEY } from '../application/constants';
 import { usePermissionsForHanke } from '../hanke/hankeUsers/hooks/useUserRightsForHanke';
 import useSaveApplication from '../application/hooks/useSaveApplication';
+import useNavigateToApplicationView from '../application/hooks/useNavigateToApplicationView';
 
 type Props = {
   hankeData?: HankeData;
@@ -133,7 +133,7 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
     getValues('id'),
   );
 
-  const navigateToApplicationList = useNavigateToApplicationList(hanke?.hankeTunnus);
+  const navigateToApplicationView = useNavigateToApplicationView();
 
   const [attachmentsUploading, setAttachmentsUploading] = useState(false);
 
@@ -187,10 +187,10 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
     onError() {
       showSendError();
     },
-    async onSuccess() {
+    async onSuccess(data) {
       showSendSuccess();
       await queryClient.invalidateQueries('application', { refetchInactive: true });
-      navigateToApplicationList();
+      navigateToApplicationView(data.id?.toString());
     },
   });
 
@@ -235,7 +235,7 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
 
   function saveAndQuit() {
     function handleSuccess(data: Application<JohtoselvitysData>) {
-      navigateToApplicationList(data.hankeTunnus);
+      navigateToApplicationView(data.id?.toString());
       setNotification(true, {
         position: 'top-right',
         dismissible: true,

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -237,7 +237,7 @@ test('Cable report application form can be filled and saved and sent to Allu', a
 
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
   expect(screen.queryByText(/hakemus lähetetty/i)).toBeInTheDocument();
-  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2');
+  expect(window.location.pathname).toBe('/fi/hakemus/7');
 });
 
 test('Should show error message when saving fails', async () => {
@@ -320,7 +320,7 @@ test('Save and quit works', async () => {
   await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
 
   expect(screen.queryAllByText(/hakemus tallennettu/i).length).toBe(2);
-  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2');
+  expect(window.location.pathname).toBe('/fi/hakemus/9');
 });
 
 test('Should not save and quit if current form page is not valid', async () => {

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -28,7 +28,6 @@ import {
   KaivuilmoitusUpdateData,
 } from '../application/types/application';
 import { useGlobalNotification } from '../../common/components/globalNotification/GlobalNotificationContext';
-import { useNavigateToApplicationList } from '../hanke/hooks/useNavigateToApplicationList';
 import {
   convertApplicationDataToFormState,
   convertFormStateToKaivuilmoitusUpdateData,
@@ -39,6 +38,7 @@ import useAttachments from '../application/hooks/useAttachments';
 import ConfirmationDialog from '../../common/components/HDSConfirmationDialog/ConfirmationDialog';
 import { changeFormStep } from '../forms/utils';
 import Areas from './Areas';
+import useNavigateToApplicationView from '../application/hooks/useNavigateToApplicationView';
 
 type Props = {
   hankeData: HankeData;
@@ -48,7 +48,7 @@ type Props = {
 export default function KaivuilmoitusContainer({ hankeData, application }: Readonly<Props>) {
   const { t } = useTranslation();
   const { setNotification } = useGlobalNotification();
-  const navigateToApplicationList = useNavigateToApplicationList(hankeData.hankeTunnus);
+  const navigateToApplicationView = useNavigateToApplicationView();
   const [attachmentUploadErrors, setAttachmentUploadErrors] = useState<JSX.Element[]>([]);
   const { data: hankkeenHakemukset } = useApplicationsForHanke(hankeData.hankeTunnus);
   const johtoselvitysIds = hankkeenHakemukset?.applications
@@ -185,7 +185,7 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
 
   function saveAndQuit() {
     function handleSuccess(data: Application<KaivuilmoitusData>) {
-      navigateToApplicationList(data.hankeTunnus);
+      navigateToApplicationView(data.id?.toString());
       setNotification(true, {
         position: 'top-right',
         dismissible: true,

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -260,7 +260,7 @@ test('Should be able fill perustiedot and save form', async () => {
   await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
 
   expect(screen.queryAllByText(/hakemus tallennettu/i).length).toBe(2);
-  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2');
+  expect(window.location.pathname).toBe('/fi/hakemus/7');
 });
 
 test('Should not be able to save form if work name is missing', async () => {

--- a/src/pages/EditJohtoselvitysPage.tsx
+++ b/src/pages/EditJohtoselvitysPage.tsx
@@ -20,7 +20,7 @@ const EditJohtoselvitysPage: React.FC = () => {
   const { id } = useParams();
   const { EDIT_JOHTOSELVITYSHAKEMUS } = useLocalizedRoutes();
   const { t } = useTranslation();
-  const navigateToApplicationView = useNavigateToApplicationView(id);
+  const navigateToApplicationView = useNavigateToApplicationView();
   const [showApplicationSentDialog, setShowApplicationSentDialog] = useState(false);
 
   const applicationQueryResult = useApplication(Number(id));
@@ -60,7 +60,7 @@ const EditJohtoselvitysPage: React.FC = () => {
         isOpen={showApplicationSentDialog}
         title={t('hakemus:sentDialog:title')}
         description={t('hakemus:sentDialog:description')}
-        mainAction={navigateToApplicationView}
+        mainAction={() => navigateToApplicationView(id)}
         mainBtnLabel={t('hakemus:sentDialog:button')}
         variant="primary"
         showSecondaryButton={false}


### PR DESCRIPTION
# Description

Previously when saving and quitting, user was taken to application list. Changed it so that user is taken to application view. Made the same change also when sending cable report application.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2521

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Save and quit in both johtoselvitys and kaivuilmoitus form and check that you end up in correct application view.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
