### PR TITLE
HAI-2390 Fix for calculating haitta indexes when using touch screen

### DIFF
--- a/src/domain/hanke/edit/components/Haitat.tsx
+++ b/src/domain/hanke/edit/components/Haitat.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, Fieldset, IconCross, IconTrash } from 'hds-react';
 import { $enum } from 'ts-enum-util';
 import { Spacer } from '@chakra-ui/react';
+import { debounce } from 'lodash';
 import { FORMFIELD, HankeDataFormState } from '../types';
 import DatePicker from '../../../../common/components/datePicker/DatePicker';
 import Dropdown from '../../../../common/components/dropdown/Dropdown';
@@ -62,9 +63,13 @@ const Haitat: React.FC<Props> = ({ index, onRemoveArea, onChangeArea }) => {
     setAreaToRemove(null);
   }
 
-  function handleNuisancesChange() {
-    onChangeArea(watchHankeAlue);
-  }
+  const handleNuisancesChange = debounce(
+    () => {
+      onChangeArea(watchHankeAlue);
+    },
+    300,
+    { leading: true, trailing: false },
+  );
 
   return (
     <>


### PR DESCRIPTION
# Description

There was a problem when using touch screen and selecting nuisances for hanke area in dropdowns, where the app would stuck in infinite loop of calling the api. Fixed this by debouncing the onChange handler of the dropdowns.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2390

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Go to hanke form areas page and open Chrome dev tools and press Toggle device toolbar button to simulate touch controls
2. Add new hanke area and fill all of its information
3. When selecting last of the nuisances and nuisance indexes are calculated, check in network tab of dev tools that call to /haittaindeksit endpoint is done once and that the app does not freeze

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
