### PR TITLE
HAI-1368 Fixes for kaivuilmoitus areas page

### DIFF
--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -213,14 +213,12 @@ export default function Areas({ hankeData }: Readonly<Props>) {
           showDrawControls={Boolean(workTimesSet)}
           onAddArea={handleAddArea}
         >
-          {startTime && endTime ? (
-            <HankeLayer
-              hankeData={hankeData && [hankeData]}
-              startDate={startTime?.toString()}
-              endDate={endTime?.toString()}
-              fitSource
-            />
-          ) : null}
+          <HankeLayer
+            hankeData={hankeData && [hankeData]}
+            startDate={startTime?.toString()}
+            endDate={endTime?.toString()}
+            fitSource
+          />
         </ApplicationMap>
 
         {!workTimesSet && (

--- a/src/domain/kaivuilmoitus/validationSchema.ts
+++ b/src/domain/kaivuilmoitus/validationSchema.ts
@@ -37,42 +37,55 @@ const kaivuilmoitusAlueSchema = yup.object({
   lisatiedot: yup.string(),
 });
 
-const applicationDataSchema = yup.object({
-  applicationType: applicationTypeSchema,
-  name: yup.string().trim().required(),
-  workDescription: yup.string().trim().required(),
-  rockExcavation: yup.boolean().nullable().required(),
-  constructionWork: yup
-    .boolean()
-    .defined()
-    .when(['maintenanceWork', 'emergencyWork'], {
-      is: false,
-      then: (schema) => schema.isTrue(),
-    }),
-  maintenanceWork: yup.boolean().defined(),
-  emergencyWork: yup.boolean().defined(),
-  cableReportDone: yup.boolean().required(),
-  requiredCompetence: yup.boolean().required(),
-  contractorWithContacts: customerWithContactsSchema,
-  customerWithContacts: customerWithContactsSchema,
-  propertyDeveloperWithContacts: customerWithContactsSchema.nullable(),
-  representativeWithContacts: customerWithContactsSchema.nullable(),
-  invoicingCustomer: invoicingCustomerSchema,
-  startTime: yup.date().nullable().required(),
-  endTime: yup
-    .date()
-    .when('startTime', (startTime: Date[], schema: yup.DateSchema) => {
-      try {
-        return startTime ? schema.min(startTime) : schema;
-      } catch (error) {
-        return schema;
-      }
-    })
-    .nullable()
-    .required(),
-  areas: yup.array(kaivuilmoitusAlueSchema).min(1).required(),
-  additionalInfo: yup.string().max(2000).nullable(),
-});
+const applicationDataSchema = yup.object().shape(
+  {
+    applicationType: applicationTypeSchema,
+    name: yup.string().trim().required(),
+    workDescription: yup.string().trim().required(),
+    rockExcavation: yup.boolean().nullable().required(),
+    constructionWork: yup
+      .boolean()
+      .defined()
+      .when(['maintenanceWork', 'emergencyWork'], {
+        is: false,
+        then: (schema) => schema.isTrue(),
+      }),
+    maintenanceWork: yup.boolean().defined(),
+    emergencyWork: yup.boolean().defined(),
+    cableReportDone: yup.boolean().required(),
+    requiredCompetence: yup.boolean().required(),
+    contractorWithContacts: customerWithContactsSchema,
+    customerWithContacts: customerWithContactsSchema,
+    propertyDeveloperWithContacts: customerWithContactsSchema.nullable(),
+    representativeWithContacts: customerWithContactsSchema.nullable(),
+    invoicingCustomer: invoicingCustomerSchema,
+    startTime: yup
+      .date()
+      .when('endTime', (endTime: Date[], schema: yup.DateSchema) => {
+        try {
+          return endTime ? schema.max(endTime[0]) : schema;
+        } catch (error) {
+          return schema;
+        }
+      })
+      .nullable()
+      .required(),
+    endTime: yup
+      .date()
+      .when('startTime', (startTime: Date[], schema: yup.DateSchema) => {
+        try {
+          return startTime ? schema.min(startTime) : schema;
+        } catch (error) {
+          return schema;
+        }
+      })
+      .nullable()
+      .required(),
+    areas: yup.array(kaivuilmoitusAlueSchema).min(1).required(),
+    additionalInfo: yup.string().max(2000).nullable(),
+  },
+  [['startTime', 'endTime']],
+);
 
 export const validationSchema: yup.ObjectSchema<KaivuilmoitusFormValues> = yup.object({
   id: yup.number().defined().nullable(),


### PR DESCRIPTION
# Description

Made a change that hanke areas are displayed immediately when navigating to areas page even before drawing work areas.

Added validation that work start time cannot be after work end time.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1368

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create new kaivuilmoitus
2. Go to areas page and check that hanke areas are visible from the start
3. Set work start and end times and then set start time to be after end time
4. Check that there is validation error about start time

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
