### PR TITLE
HAI-2573 Fix hanke muu taho validation

### DIFF
--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -355,12 +355,14 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
                     label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.ROOLI}`)}
                     placeholder={t('form:yhteystiedot:placeholders:otherPartyRole')}
                     helperText={t('form:yhteystiedot:helperTexts:otherPartyRole')}
+                    required
                   />
                 </ResponsiveGrid>
                 <ResponsiveGrid>
                   <TextInput
                     name={`${fieldPath}.${CONTACT_FORMFIELD.NIMI}`}
                     label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.NIMI}`)}
+                    required
                   />
                   <TextInput
                     name={`${fieldPath}.${CONTACT_FORMFIELD.ORGANISAATIO}`}
@@ -373,6 +375,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
                   <TextInput
                     name={`${fieldPath}.${CONTACT_FORMFIELD.EMAIL}`}
                     label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.EMAIL}`)}
+                    required
                   />
                   <TextInput
                     name={`${fieldPath}.${CONTACT_FORMFIELD.PUHELINNUMERO}`}

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -56,8 +56,7 @@ const yhteystietoSchema = yup.object({
 const muuYhteystietoSchema = yhteystietoSchema
   .omit([CONTACT_FORMFIELD.TYYPPI, CONTACT_FORMFIELD.TUNNUS])
   .shape({
-    [CONTACT_FORMFIELD.NIMI]: yup.string().defined().max(100),
-    [CONTACT_FORMFIELD.ROOLI]: yup.string().defined(),
+    [CONTACT_FORMFIELD.ROOLI]: yup.string().required().meta({ pageName: HANKE_PAGES.YHTEYSTIEDOT }),
     [CONTACT_FORMFIELD.ORGANISAATIO]: yup.string().defined(),
     [CONTACT_FORMFIELD.OSASTO]: yup.string().defined(),
   });

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -616,6 +616,7 @@
         "ytunnus": "$t(form:yhteystiedot:titles:rakennuttajat): $t(form:yhteystiedot:labels:ytunnus)"
       },
       "muut": {
+        "rooli": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:rooli)",
         "nimi": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:nimi)",
         "email": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:email)",
         "ytunnus": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:ytunnus)"


### PR DESCRIPTION
# Description

Marked hanke muu taho role, name and email to be required and added required validation for role to yup schema.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2573

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Add muu taho for hanke
2. Check that role, name and email fields are required
3. Visit role, name and email fields
4. Check that there are validation errors below the fields and also in the top notification about missing fields

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
