### PR TITLE
HAI-2585 Move 'Add new contact person' button

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -118,7 +118,6 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
     },
     async onSuccess() {
       showSendSuccess();
-      setIsSendButtonDisabled(false);
       await queryClient.invalidateQueries('application', { refetchInactive: true });
     },
   });
@@ -193,7 +192,7 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
                 theme="coat"
                 iconLeft={<IconEnvelope aria-hidden="true" />}
                 onClick={onSendApplication}
-                isLoading={applicationSendMutation.isLoading || isSendButtonDisabled}
+                isLoading={applicationSendMutation.isLoading}
                 loadingText={t('common:buttons:sendingText')}
                 disabled={disableSendButton || isSendButtonDisabled}
               >

--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -17,9 +17,9 @@ import TextInput from '../../../common/components/textInput/TextInput';
 import useLocale from '../../../common/hooks/useLocale';
 import Dropdown from '../../../common/components/dropdown/Dropdown';
 import FormContact from '../../forms/components/FormContact';
-import ContactPersonSelect from '../../hanke/hankeUsers/ContactPersonSelect';
 import { HankeUser } from '../../hanke/hankeUsers/hankeUser';
 import { useHankeUsers } from '../../hanke/hankeUsers/hooks/useHankeUsers';
+import { mapHankeUserToContact } from '../../hanke/hankeUsers/utils';
 
 function getEmptyCustomerWithContacts(): CustomerWithContacts {
   return {
@@ -35,26 +35,10 @@ function getEmptyCustomerWithContacts(): CustomerWithContacts {
   };
 }
 
-function mapHankeUserToContact({
-  id,
-  etunimi,
-  sukunimi,
-  puhelinnumero,
-  sahkoposti,
-}: HankeUser): Contact {
-  return {
-    hankekayttajaId: id,
-    firstName: etunimi,
-    lastName: sukunimi,
-    phone: puhelinnumero,
-    email: sahkoposti,
-  };
-}
-
 const CustomerFields: React.FC<{
   customerType: CustomerType;
   hankeUsers?: HankeUser[];
-}> = ({ customerType, hankeUsers }) => {
+}> = ({ customerType }) => {
   const { t } = useTranslation();
   const { watch, setValue } = useFormContext<Application>();
 
@@ -80,16 +64,6 @@ const CustomerFields: React.FC<{
       });
     }
   }, [registryKey, customerType, setValue]);
-
-  function mapContactToLabel(contact: Contact) {
-    return `${contact.firstName} ${contact.lastName} (${contact.email})`;
-  }
-
-  function removeOrdererFromContact(contact: Contact): Contact {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { orderer, ...rest } = contact;
-    return rest;
-  }
 
   return (
     <Fieldset
@@ -147,19 +121,6 @@ const CustomerFields: React.FC<{
           autoComplete="tel"
         />
       </ResponsiveGrid>
-      <ContactPersonSelect
-        name={`applicationData.${customerType}.contacts`}
-        hankeUsers={hankeUsers}
-        mapHankeUserToValue={mapHankeUserToContact}
-        mapValueToLabel={mapContactToLabel}
-        transformValue={(value) => removeOrdererFromContact(value)}
-        required
-        tooltip={{
-          tooltipButtonLabel: t('hankeForm:toolTips:tipOpenLabel'),
-          tooltipLabel: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
-          tooltipText: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
-        }}
-      />
     </Fieldset>
   );
 };
@@ -203,7 +164,17 @@ export default function ApplicationContacts() {
       previousContacts.concat(mapHankeUserToContact(contactPerson)),
       { shouldDirty: true, shouldValidate: true },
     );
-    queryClient.invalidateQueries(['hankeUsers', hankeTunnus]);
+    void queryClient.invalidateQueries(['hankeUsers', hankeTunnus]);
+  }
+
+  function mapContactToLabel(contact: Contact) {
+    return `${contact.firstName} ${contact.lastName} (${contact.email})`;
+  }
+
+  function removeOrdererFromContact(contact: Contact): Contact {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { orderer, ...rest } = contact;
+    return rest;
   }
 
   return (
@@ -220,13 +191,23 @@ export default function ApplicationContacts() {
       </Text>
 
       {/* Työstä vastaava */}
-      <FormContact<CustomerType>
+      <FormContact<CustomerType, Contact>
+        name={`applicationData.customerWithContacts.contacts`}
         contactType="customerWithContacts"
         hankeTunnus={hankeTunnus!}
         hankeUsers={hankeUsers}
+        mapHankeUserToValue={mapHankeUserToContact}
+        mapValueToLabel={mapContactToLabel}
+        transformValue={(value) => removeOrdererFromContact(value)}
         onContactPersonAdded={(user) =>
           addYhteyshenkiloForYhteystieto('customerWithContacts', user)
         }
+        required
+        tooltip={{
+          tooltipButtonLabel: t('hankeForm:toolTips:tipOpenLabel'),
+          tooltipLabel: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
+          tooltipText: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
+        }}
       >
         <CustomerFields customerType="customerWithContacts" hankeUsers={hankeUsers} />
       </FormContact>
@@ -238,13 +219,23 @@ export default function ApplicationContacts() {
         headingLevel={3}
         initiallyOpen
       >
-        <FormContact<CustomerType>
+        <FormContact<CustomerType, Contact>
+          name={`applicationData.contractorWithContacts.contacts`}
           contactType="contractorWithContacts"
           hankeTunnus={hankeTunnus!}
           hankeUsers={hankeUsers}
+          mapHankeUserToValue={mapHankeUserToContact}
+          mapValueToLabel={mapContactToLabel}
+          transformValue={(value) => removeOrdererFromContact(value)}
           onContactPersonAdded={(user) =>
             addYhteyshenkiloForYhteystieto('contractorWithContacts', user)
           }
+          required
+          tooltip={{
+            tooltipButtonLabel: t('hankeForm:toolTips:tipOpenLabel'),
+            tooltipLabel: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
+            tooltipText: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
+          }}
         >
           <CustomerFields customerType="contractorWithContacts" hankeUsers={hankeUsers} />
         </FormContact>
@@ -258,14 +249,24 @@ export default function ApplicationContacts() {
         initiallyOpen={isPropertyDeveloper}
       >
         {isPropertyDeveloper && (
-          <FormContact<CustomerType>
+          <FormContact<CustomerType, Contact>
+            name={`applicationData.propertyDeveloperWithContacts.contacts`}
             contactType="propertyDeveloperWithContacts"
             hankeTunnus={hankeTunnus!}
             hankeUsers={hankeUsers}
+            mapHankeUserToValue={mapHankeUserToContact}
+            mapValueToLabel={mapContactToLabel}
+            transformValue={(value) => removeOrdererFromContact(value)}
             onRemove={handleRemovePropertyDeveloper}
             onContactPersonAdded={(user) =>
               addYhteyshenkiloForYhteystieto('propertyDeveloperWithContacts', user)
             }
+            required
+            tooltip={{
+              tooltipButtonLabel: t('hankeForm:toolTips:tipOpenLabel'),
+              tooltipLabel: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
+              tooltipText: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
+            }}
           >
             <CustomerFields customerType="propertyDeveloperWithContacts" hankeUsers={hankeUsers} />
           </FormContact>
@@ -290,14 +291,24 @@ export default function ApplicationContacts() {
         initiallyOpen={isRepresentative}
       >
         {isRepresentative && (
-          <FormContact<CustomerType>
+          <FormContact<CustomerType, Contact>
+            name={`applicationData.representativeWithContacts.contacts`}
             contactType="representativeWithContacts"
             hankeTunnus={hankeTunnus!}
             hankeUsers={hankeUsers}
+            mapHankeUserToValue={mapHankeUserToContact}
+            mapValueToLabel={mapContactToLabel}
+            transformValue={(value) => removeOrdererFromContact(value)}
             onRemove={handleRemoveRepresentative}
             onContactPersonAdded={(user) =>
               addYhteyshenkiloForYhteystieto('representativeWithContacts', user)
             }
+            required
+            tooltip={{
+              tooltipButtonLabel: t('hankeForm:toolTips:tipOpenLabel'),
+              tooltipLabel: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
+              tooltipText: t('form:yhteystiedot:tooltips:hakemusYhteyshenkilo'),
+            }}
           >
             <CustomerFields customerType="representativeWithContacts" hankeUsers={hankeUsers} />
           </FormContact>

--- a/src/domain/forms/components/FormContact.tsx
+++ b/src/domain/forms/components/FormContact.tsx
@@ -1,39 +1,59 @@
 import React, { useState } from 'react';
-import { Flex } from '@chakra-ui/react';
-import { Button, IconAngleDown, IconAngleUp, IconCross, Notification } from 'hds-react';
+import { Box, Flex } from '@chakra-ui/react';
+import { Button, IconCross, IconPlusCircle, Notification } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { UseFieldArrayRemove } from 'react-hook-form';
 import NewContactPersonForm, { ContactPersonAddedNotification } from './NewContactPersonForm';
 import { HankeUser } from '../../hanke/hankeUsers/hankeUser';
 import styles from './FormContact.module.scss';
 import Transition from '../../../common/components/transition/Transition';
+import ResponsiveGrid from '../../../common/components/grid/ResponsiveGrid';
+import ContactPersonSelect from '../../hanke/hankeUsers/ContactPersonSelect';
 
-interface Props<T> {
+/**
+ * Form component for adding and removing contact persons (yhteyshenkilö) for a contact (yhteystieto)
+ */
+interface Props<T, R> {
+  name: string;
   contactType: T;
   hankeTunnus: string;
   hankeUsers: HankeUser[] | undefined;
+  mapHankeUserToValue: ({ id, etunimi, sukunimi, sahkoposti, puhelinnumero }: HankeUser) => R;
+  mapValueToLabel: (value: R) => string;
+  transformValue?: (value: R) => R;
   index?: number;
   canBeRemoved?: boolean;
   onRemove?: UseFieldArrayRemove;
   onContactPersonAdded?: (newHankeUser: HankeUser) => void;
+  required?: boolean;
+  tooltip?: {
+    tooltipButtonLabel: string;
+    tooltipLabel: string;
+    tooltipText: string;
+  };
   children: React.ReactNode;
 }
 
-const FormContact = <T,>({
+const FormContact = <T, R>({
+  name,
   contactType,
   hankeTunnus,
   hankeUsers,
+  mapHankeUserToValue,
+  mapValueToLabel,
+  transformValue,
   index,
   canBeRemoved = true,
   onRemove,
   onContactPersonAdded,
+  required,
+  tooltip,
   children,
-}: Readonly<Props<T>>) => {
+}: Readonly<Props<T, R>>) => {
   const { t } = useTranslation();
   const [showNewContactPersonForm, setShowNewContactPersonForm] = useState(false);
   const [showContactPersonAddedNotification, setShowContactPersonAddedNotification] =
     useState<ContactPersonAddedNotification>(null);
-  const addContactPersonIcon = !showNewContactPersonForm ? <IconAngleDown /> : <IconAngleUp />;
 
   function toggleNewContactForm() {
     setShowNewContactPersonForm((formOpen) => !formOpen);
@@ -64,14 +84,31 @@ const FormContact = <T,>({
 
       {children}
 
-      <Button
-        variant="supplementary"
-        iconLeft={addContactPersonIcon}
-        onClick={toggleNewContactForm}
-        style={{ marginBottom: 'var(--spacing-s)' }}
-      >
-        {t(`form:yhteystiedot:buttons:addNewContactPerson`)}
-      </Button>
+      <Box maxWidth="var(--width-form-3-col)">
+        <ResponsiveGrid maxColumns={3}>
+          <Box style={{ gridColumn: 'span 2' }}>
+            <ContactPersonSelect<R>
+              name={name}
+              hankeUsers={hankeUsers}
+              mapHankeUserToValue={mapHankeUserToValue}
+              mapValueToLabel={mapValueToLabel}
+              transformValue={transformValue}
+              required={required}
+              tooltip={tooltip}
+            />
+          </Box>
+          <Box display="flex" alignItems="center" justifyContent="start" mb="var(--spacing-m)">
+            <Button
+              variant="secondary"
+              iconLeft={<IconPlusCircle aria-hidden />}
+              onClick={toggleNewContactForm}
+              disabled={showNewContactPersonForm}
+            >
+              {t(`form:yhteystiedot:buttons:addNewContactPerson`)}
+            </Button>
+          </Box>
+        </ResponsiveGrid>
+      </Box>
 
       <Transition
         showChildren={showNewContactPersonForm}

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -22,7 +22,6 @@ import FormContact from '../../forms/components/FormContact';
 import { useHankeUsers } from '../hankeUsers/hooks/useHankeUsers';
 import { HankeUser } from '../hankeUsers/hankeUser';
 import { useQueryClient } from 'react-query';
-import ContactPersonSelect from '../hankeUsers/ContactPersonSelect';
 import { mapHankeUserToHankeYhteyshenkilo } from '../hankeUsers/utils';
 import { Box } from '@chakra-ui/react';
 
@@ -59,7 +58,7 @@ const ContactFields: React.FC<
     index: number;
     hankeUsers?: HankeUser[];
   }>
-> = ({ contactType, index, hankeUsers }) => {
+> = ({ contactType, index }) => {
   const { t } = useTranslation();
   const { watch, setValue } = useFormContext();
   const selectedContactType = watch(`${contactType}.${index}.tyyppi`);
@@ -114,12 +113,6 @@ const ContactFields: React.FC<
           label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.PUHELINNUMERO}`)}
         />
       </ResponsiveGrid>
-      <ContactPersonSelect
-        name={`${contactType}.${index}.${CONTACT_FORMFIELD.YHTEYSHENKILOT}`}
-        hankeUsers={hankeUsers}
-        mapHankeUserToValue={mapHankeUserToHankeYhteyshenkilo}
-        mapValueToLabel={mapHankeYhteyshenkiloToLabel}
-      />
     </Box>
   );
 };
@@ -184,7 +177,7 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
       ),
     );
 
-    queryClient.invalidateQueries(['hankeUsers', hanke.hankeTunnus]);
+    void queryClient.invalidateQueries(['hankeUsers', hanke.hankeTunnus]);
   }
 
   return (
@@ -202,11 +195,14 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
       >
         {omistajat.map((item, index) => {
           return (
-            <FormContact<HankeContactTypeKey>
+            <FormContact<HankeContactTypeKey, HankeYhteyshenkilo>
+              name={`${HANKE_CONTACT_TYPE.OMISTAJAT}.${index}.${CONTACT_FORMFIELD.YHTEYSHENKILOT}`}
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.OMISTAJAT}
               hankeTunnus={hanke.hankeTunnus!}
               hankeUsers={hankeUsers}
+              mapHankeUserToValue={mapHankeUserToHankeYhteyshenkilo}
+              mapValueToLabel={mapHankeYhteyshenkiloToLabel}
               index={index}
               canBeRemoved={omistajat.length > 1}
               onRemove={removeOmistaja}
@@ -246,11 +242,14 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
       >
         {rakennuttajat.map((item, index) => {
           return (
-            <FormContact<HankeContactTypeKey>
+            <FormContact<HankeContactTypeKey, HankeYhteyshenkilo>
+              name={`${HANKE_CONTACT_TYPE.RAKENNUTTAJAT}.${index}.${CONTACT_FORMFIELD.YHTEYSHENKILOT}`}
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.RAKENNUTTAJAT}
               hankeTunnus={hanke.hankeTunnus!}
               hankeUsers={hankeUsers}
+              mapHankeUserToValue={mapHankeUserToHankeYhteyshenkilo}
+              mapValueToLabel={mapHankeYhteyshenkiloToLabel}
               index={index}
               onRemove={removeRakennuttaja}
               onContactPersonAdded={(user) =>
@@ -289,11 +288,14 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
       >
         {toteuttajat.map((item, index) => {
           return (
-            <FormContact<HankeContactTypeKey>
+            <FormContact<HankeContactTypeKey, HankeYhteyshenkilo>
+              name={`${HANKE_CONTACT_TYPE.TOTEUTTAJAT}.${index}.${CONTACT_FORMFIELD.YHTEYSHENKILOT}`}
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.TOTEUTTAJAT}
               hankeTunnus={hanke.hankeTunnus!}
               hankeUsers={hankeUsers}
+              mapHankeUserToValue={mapHankeUserToHankeYhteyshenkilo}
+              mapValueToLabel={mapHankeYhteyshenkiloToLabel}
               index={index}
               onRemove={removeToteuttaja}
               onContactPersonAdded={(user) =>
@@ -334,11 +336,14 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
           const fieldPath = `${FORMFIELD.MUUTTAHOT}.${index}`;
 
           return (
-            <FormContact<HankeContactTypeKey>
+            <FormContact<HankeContactTypeKey, HankeYhteyshenkilo>
+              name={`${HANKE_CONTACT_TYPE.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.YHTEYSHENKILOT}`}
               key={item.id}
               contactType={HANKE_CONTACT_TYPE.MUUTTAHOT}
               hankeTunnus={hanke.hankeTunnus!}
               hankeUsers={hankeUsers}
+              mapHankeUserToValue={mapHankeUserToHankeYhteyshenkilo}
+              mapValueToLabel={mapHankeYhteyshenkiloToLabel}
               index={index}
               onRemove={removeMuuTaho}
               onContactPersonAdded={(user) =>
@@ -382,12 +387,6 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
                     label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.PUHELINNUMERO}`)}
                   />
                 </ResponsiveGrid>
-                <ContactPersonSelect
-                  name={`${fieldPath}.${CONTACT_FORMFIELD.YHTEYSHENKILOT}`}
-                  hankeUsers={hankeUsers}
-                  mapHankeUserToValue={mapHankeUserToHankeYhteyshenkilo}
-                  mapValueToLabel={mapHankeYhteyshenkiloToLabel}
-                />
               </Fieldset>
             </FormContact>
           );

--- a/src/domain/hanke/hankeUsers/utils.ts
+++ b/src/domain/hanke/hankeUsers/utils.ts
@@ -1,5 +1,6 @@
 import { HankeUser, SignedInUser } from './hankeUser';
 import { HankeYhteyshenkilo } from '../../types/hanke';
+import { Contact } from '../../application/types/application';
 
 export function mapHankeUserToHankeYhteyshenkilo({
   id,
@@ -14,6 +15,22 @@ export function mapHankeUserToHankeYhteyshenkilo({
     sukunimi,
     sahkoposti,
     puhelinnumero,
+  };
+}
+
+export function mapHankeUserToContact({
+  id,
+  etunimi,
+  sukunimi,
+  sahkoposti,
+  puhelinnumero,
+}: HankeUser): Contact {
+  return {
+    hankekayttajaId: id,
+    firstName: etunimi,
+    lastName: sukunimi,
+    email: sahkoposti,
+    phone: puhelinnumero,
   };
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -217,7 +217,7 @@
       },
       "helperTexts": {
         "otherPartyRole": "Party’s role in the project",
-        "yhteyshenkilo": " You can search an added person by typing or using the drop-down menu, or you can add a new contact below."
+        "yhteyshenkilo": "You can search an added person by typing or using the drop-down menu, or you can add a new contact."
       },
       "contactType": {
         "YKSITYISHENKILO": "Private individual",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -230,7 +230,7 @@
       },
       "helperTexts": {
         "otherPartyRole": "Tahon rooli hankkeessa",
-        "yhteyshenkilo": " Voit etsiä jo lisättyä henkilöä kirjoittamalla tai valitsemalla pudotusvalikosta, tai lisätä uuden yhteyshenkilön alta."
+        "yhteyshenkilo": "Voit etsiä jo lisättyä henkilöä kirjoittamalla tai valitsemalla pudotusvalikosta, tai lisätä uuden yhteyshenkilön."
       },
       "contactType": {
         "YKSITYISHENKILO": "Yksityishenkilö",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -217,7 +217,7 @@
       },
       "helperTexts": {
         "otherPartyRole": "Partens roll i projektet",
-        "yhteyshenkilo": " Du kan söka personer som redan lagts till genom att skriva eller välja ut en rullgardinsmeny eller lägga till via ny kontaktperson."
+        "yhteyshenkilo": "Du kan söka personer som redan lagts till genom att skriva eller välja ut en rullgardinsmeny eller lägga till via ny kontaktperson."
       },
       "contactType": {
         "YKSITYISHENKILO": "Privatperson",


### PR DESCRIPTION
# Description

Move 'Add new contact person' button to be aside of the contact person dropdown list.
Also, adjusted the Send button functionality a bit in application form: after successful send the button is not enabled but the loading status is removed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2585

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Check Hanke, Johtoselvitys and Kaivuilmoitus form for adding new contact persons. The button location should be according to Figma specification and the adding should work as before with right tooltips (on application forms only) etc.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
