### PR TITLE
HAI-2578 Make it possible to send kaivuilmoitus to Allu

### DIFF
--- a/src/domain/application/hooks/useSendApplication.ts
+++ b/src/domain/application/hooks/useSendApplication.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from 'react-query';
+import { sendApplication } from '../utils';
+import useApplicationSendNotification from './useApplicationSendNotification';
+import { Application } from '../types/application';
+
+type Options = {
+  onSuccess: (data: Application) => void;
+};
+
+export default function useSendApplication(options?: Options) {
+  const { onSuccess } = options || {};
+  const queryClient = useQueryClient();
+  const { showSendSuccess, showSendError } = useApplicationSendNotification();
+
+  return useMutation(sendApplication, {
+    onError() {
+      showSendError();
+    },
+    async onSuccess(data) {
+      showSendSuccess();
+      await queryClient.invalidateQueries(['application', data.id], { refetchInactive: true });
+      onSuccess && onSuccess(data);
+    },
+  });
+}

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -209,7 +209,7 @@ test('Should render correct number of applications if they exist', async () => {
 
   await user.click(screen.getByRole('tab', { name: /hakemukset/i }));
 
-  expect(screen.getAllByTestId('application-card')).toHaveLength(4);
+  expect(screen.getAllByTestId('application-card')).toHaveLength(5);
 });
 
 test('Should show information if no applications exist', async () => {

--- a/src/domain/homepage/Homepage.test.tsx
+++ b/src/domain/homepage/Homepage.test.tsx
@@ -111,7 +111,7 @@ describe('Create johtoselvitys from dialog', () => {
     fillInformation();
     await user.click(screen.getByRole('button', { name: /luo hakemus/i }));
 
-    expect(window.location.pathname).toBe('/fi/johtoselvityshakemus/7/muokkaa');
+    expect(window.location.pathname).toBe('/fi/johtoselvityshakemus/8/muokkaa');
   });
 
   test('Should show validation errors and not create johtoselvitys if information is missing', async () => {

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -231,7 +231,7 @@ test('Cable report application form can be filled and saved and sent to Allu', a
 
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
   expect(await screen.findByText(/hakemus lähetetty/i)).toBeInTheDocument();
-  expect(window.location.pathname).toBe('/fi/hakemus/7');
+  expect(window.location.pathname).toBe('/fi/hakemus/8');
 });
 
 test('Should show error message when saving fails', async () => {
@@ -317,7 +317,7 @@ test('Save and quit works', async () => {
   await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
 
   expect(await screen.findAllByText(/hakemus tallennettu/i)).toHaveLength(2);
-  expect(window.location.pathname).toBe('/fi/hakemus/9');
+  expect(window.location.pathname).toBe('/fi/hakemus/10');
 });
 
 test('Should not save and quit if current form page is not valid', async () => {
@@ -594,7 +594,6 @@ test('Should be able to upload attachments', async () => {
     new File(['test-b'], 'test-file-b.pdf', { type: 'application/pdf' }),
   ]);
 
-  await screen.findAllByText('Tallennetaan tiedostoja', undefined, { timeout: 5000 });
   await waitForElementToBeRemoved(() => screen.queryAllByText(/Tallennetaan tiedostoja/i), {
     timeout: 10000,
   });

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -107,7 +107,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
   const {
     getValues,
     setValue,
-    reset,
     trigger,
     watch,
     handleSubmit,
@@ -129,7 +128,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
   } = useSaveApplication<KaivuilmoitusData, KaivuilmoitusCreateData, KaivuilmoitusUpdateData>({
     onCreateSuccess({ id }) {
       setValue('id', id);
-      reset({}, { keepValues: true });
     },
     onUpdateSuccess({
       applicationData: {
@@ -163,7 +161,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
           representativeWithContacts.customer.yhteystietoId,
         );
       }
-      reset({}, { keepValues: true });
     },
   });
 

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -259,7 +259,7 @@ test('Should be able fill perustiedot and save form', async () => {
   await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
 
   expect(screen.queryAllByText(/hakemus tallennettu/i).length).toBe(2);
-  expect(window.location.pathname).toBe('/fi/hakemus/7');
+  expect(window.location.pathname).toBe('/fi/hakemus/8');
 });
 
 test('Should not be able to save form if work name is missing', async () => {

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -20,6 +20,7 @@ import {
 import { ContactType, Customer, InvoicingCustomer } from '../application/types/application';
 import { cloneDeep } from 'lodash';
 import { fillNewContactPersonForm } from '../forms/components/testUtils';
+import { SignedInUser } from '../hanke/hankeUsers/hankeUser';
 
 afterEach(cleanup);
 
@@ -808,4 +809,64 @@ test('Should highlight selected work area', async () => {
   await user.click(workAreaTwo);
   expect(workAreaOne).not.toHaveClass('selected');
   expect(workAreaTwo).toHaveClass('selected');
+});
+
+test('Should be able to send application', async () => {
+  const hankeData = hankkeet[1] as HankeData;
+  const application = cloneDeep(applications[6] as Application<KaivuilmoitusData>);
+  const { user } = render(
+    <KaivuilmoitusContainer hankeData={hankeData} application={application} />,
+  );
+  await user.click(await screen.findByRole('button', { name: /yhteenveto/i }));
+  await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
+
+  expect(await screen.findByText(/hakemus lähetetty/i)).toBeInTheDocument();
+});
+
+test('Should show error message when sending fails', async () => {
+  server.use(
+    rest.post('/api/hakemukset/:id/laheta', async (req, res, ctx) => {
+      return res(ctx.status(500), ctx.json({ errorMessage: 'Failed for testing purposes' }));
+    }),
+  );
+
+  const hankeData = hankkeet[1] as HankeData;
+  const application = cloneDeep(applications[6] as Application<KaivuilmoitusData>);
+  const { user } = render(
+    <KaivuilmoitusContainer hankeData={hankeData} application={application} />,
+  );
+  await user.click(await screen.findByRole('button', { name: /yhteenveto/i }));
+  await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
+
+  expect(await screen.findByText(/lähettäminen epäonnistui/i)).toBeInTheDocument();
+});
+
+test('Should show and disable send button and show notification when user is not a contact person', async () => {
+  server.use(
+    rest.get('/api/hankkeet/:hankeTunnus/whoami', async (_, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.json<SignedInUser>({
+          hankeKayttajaId: 'not-a-contact-person-id',
+          kayttooikeustaso: 'KATSELUOIKEUS',
+          kayttooikeudet: ['VIEW'],
+        }),
+      );
+    }),
+  );
+
+  const hankeData = hankkeet[1] as HankeData;
+  const application = cloneDeep(applications[6] as Application<KaivuilmoitusData>);
+  const { user } = render(
+    <KaivuilmoitusContainer hankeData={hankeData} application={application} />,
+  );
+  await user.click(await screen.findByRole('button', { name: /yhteenveto/i }));
+
+  expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /lähetä hakemus/i })).toBeDisabled();
+  expect(
+    screen.queryAllByText(
+      'Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö.',
+    ),
+  ).toHaveLength(2);
 });

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -521,6 +521,145 @@ const hakemukset: Application[] = [
       rockExcavation: true,
     },
   } as Application<JohtoselvitysData>,
+  {
+    id: 7,
+    alluStatus: null,
+    applicationType: 'EXCAVATION_NOTIFICATION',
+    hankeTunnus: 'HAI22-2',
+    applicationIdentifier: null,
+    applicationData: {
+      applicationType: 'EXCAVATION_NOTIFICATION',
+      name: 'Aidasmäentien toiset kaivuut',
+      startTime: new Date('2023-01-12T00:00:00Z'),
+      endTime: new Date('2024-11-12T00:00:00Z'),
+      workDescription: 'Kaivetaan Aidasmäentiellä',
+      constructionWork: true,
+      maintenanceWork: false,
+      emergencyWork: false,
+      propertyConnectivity: false,
+      rockExcavation: false,
+      cableReportDone: false,
+      requiredCompetence: true,
+      cableReports: ['JS2300002'],
+      placementContracts: ['SL1234567'],
+      areas: [
+        {
+          name: 'Hankealue 2',
+          hankealueId: 2,
+          tyoalueet: [
+            {
+              geometry: {
+                type: 'Polygon',
+                crs: {
+                  type: 'name',
+                  properties: {
+                    name: 'urn:ogc:def:crs:EPSG::3879',
+                  },
+                },
+                coordinates: [
+                  [
+                    [25498585.50387858, 6679353.862125141],
+                    [25498588.30930639, 6679372.671835153],
+                    [25498578.30073113, 6679371.404998987],
+                    [25498577.10224065, 6679355.728613365],
+                    [25498585.50387858, 6679353.862125141],
+                  ],
+                ],
+              },
+              area: 158.4294946899533,
+            },
+            {
+              geometry: {
+                type: 'Polygon',
+                crs: {
+                  type: 'name',
+                  properties: {
+                    name: 'urn:ogc:def:crs:EPSG::3879',
+                  },
+                },
+                coordinates: [
+                  [
+                    [25498581.440262634, 6679345.526261961],
+                    [25498582.233686976, 6679350.99321805],
+                    [25498576.766730886, 6679351.786642391],
+                    [25498575.973306544, 6679346.319686302],
+                    [25498581.440262634, 6679345.526261961],
+                  ],
+                ],
+              },
+              area: 30.345726208334995,
+            },
+          ],
+          katuosoite: 'Aidasmäentie 5',
+          tyonTarkoitukset: ['VESI'],
+          meluhaitta: 'TOISTUVA_MELUHAITTA',
+          polyhaitta: 'JATKUVA_POLYHAITTA',
+          tarinahaitta: 'SATUNNAINEN_TARINAHAITTA',
+          kaistahaitta: 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA',
+          kaistahaittojenPituus: 'PITUUS_10_99_METRIA',
+          lisatiedot: '',
+        },
+      ],
+      customerWithContacts: {
+        customer: {
+          type: 'COMPANY',
+          name: 'Yritys Oy',
+          country: 'FI',
+          email: 'yritys@test.com',
+          phone: '0000000000',
+          registryKey: '1164243-9',
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            email: 'matti.meikalainen@test.com',
+            firstName: 'Matti',
+            lastName: 'Meikäläinen',
+            orderer: true,
+            phone: '0401234567',
+          },
+        ],
+      },
+      contractorWithContacts: {
+        customer: {
+          type: 'COMPANY',
+          name: 'Yritys 2 Oy',
+          country: 'FI',
+          email: 'yritys2@test.com',
+          phone: '040123456',
+          registryKey: null,
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afb1',
+            email: 'tauno@test.com',
+            firstName: 'Tauno',
+            lastName: 'Testinen',
+            orderer: false,
+            phone: '0401234567',
+          },
+        ],
+      },
+      representativeWithContacts: null,
+      propertyDeveloperWithContacts: null,
+      invoicingCustomer: {
+        type: 'COMPANY',
+        name: 'Laskutus Oy',
+        registryKey: '1234567-1',
+        postalAddress: {
+          streetAddress: { streetName: 'Laskutuskuja 1' },
+          postalCode: '00100',
+          city: 'Helsinki',
+        },
+      },
+    },
+  } as Application<KaivuilmoitusData>,
 ];
 
 export default hakemukset;

--- a/src/domain/mocks/data/users-data.json
+++ b/src/domain/mocks/data/users-data.json
@@ -72,7 +72,7 @@
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb2",
-    "sahkoposti": "marja.meikalainen@test.com",
+    "sahkoposti": "marja@test.com",
     "etunimi": "Marja",
     "sukunimi": "Marjanen",
     "puhelinnumero": "0401234567",

--- a/src/domain/mocks/data/users-data.json
+++ b/src/domain/mocks/data/users-data.json
@@ -72,7 +72,7 @@
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afb2",
-    "sahkoposti": "marja@test.com",
+    "sahkoposti": "marja.meikalainen@test.com",
     "etunimi": "Marja",
     "sukunimi": "Marjanen",
     "puhelinnumero": "0401234567",


### PR DESCRIPTION
# Description

Added send application button to summary page of kaivuilmoitus form that is visible if all required fields are filled. Made the same change to application page send button visibility.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2578

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new kaivuilmoitus and fill all required fields
2. Check in the summary page and in the application view that the "Lähetä hakemus" button is visible (you can also check that it's not visible if some required information is missing)
3. Click the send button and check that sending is successful

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
