### PR TITLE
HAI-1370 Fix for customer reference field in kaivuilmoitus form

### DIFF
--- a/src/domain/kaivuilmoitus/Contacts.tsx
+++ b/src/domain/kaivuilmoitus/Contacts.tsx
@@ -32,7 +32,6 @@ export default function Contacts() {
     if (selectedContactType === 'PERSON' || selectedContactType === 'OTHER') {
       resetField('applicationData.invoicingCustomer.ovt', { defaultValue: '' });
       resetField('applicationData.invoicingCustomer.invoicingOperator', { defaultValue: '' });
-      resetField('applicationData.invoicingCustomer.customerReference', { defaultValue: '' });
     }
   }, [selectedContactType, resetField]);
 


### PR DESCRIPTION
# Description

Made a change that customer reference field is not reset when changing invoicing customer type to be Person or Other.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1370

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Go to contacts page of kaivuilmoitus form and fill customer reference (asiakkaan viite) for invoicing customer
2. Navigate to another page of the form
3. Go back to contacts page and check that customer reference is still there

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
