### PR TITLE
HAI-1368 Fix showing hanke areas based on work dates in kaivuilmoitus

### DIFF
--- a/src/domain/johtoselvitys/Geometries.test.tsx
+++ b/src/domain/johtoselvitys/Geometries.test.tsx
@@ -43,7 +43,7 @@ test('Hanke areas are visible if work start and end dates are between hanke star
     '27.11.2024',
   );
 
-  expect(screen.getByTestId('countOfFilteredHankkeet')).toHaveTextContent('1');
+  expect(screen.getByTestId('countOfFilteredHankeAlueet')).toHaveTextContent('1');
 
   await user.type(screen.getByRole('textbox', { name: 'Työn arvioitu alkupäivä *' }), '28.11.2024');
   await user.type(
@@ -51,7 +51,7 @@ test('Hanke areas are visible if work start and end dates are between hanke star
     '29.11.2024',
   );
 
-  expect(screen.getByTestId('countOfFilteredHankkeet')).toHaveTextContent('0');
+  expect(screen.getByTestId('countOfFilteredHankeAlueet')).toHaveTextContent('0');
 });
 
 test('Hanke areas are not visible if hanke is generated', async () => {
@@ -64,5 +64,5 @@ test('Hanke areas are not visible if hanke is generated', async () => {
     '27.11.2024',
   );
 
-  expect(screen.queryByTestId('countOfFilteredHankkeet')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('countOfFilteredHankeAlueet')).not.toBeInTheDocument();
 });

--- a/src/domain/map/HankeMap.test.tsx
+++ b/src/domain/map/HankeMap.test.tsx
@@ -4,7 +4,7 @@ import HankeMap from './HankeMap';
 
 const startDateLabel = 'Ajanjakson alku';
 const endDateLabel = 'Ajanjakson loppu';
-const countOfFilteredHankkeet = 'countOfFilteredHankkeet';
+const countOfFilteredHankeAlueet = 'countOfFilteredHankeAlueet';
 
 describe('HankeMap', () => {
   test('Render test', async () => {
@@ -24,22 +24,22 @@ describe('HankeMap', () => {
     await screen.findByText('Ajanjakson alku');
 
     changeFilterDate(startDateLabel, renderedComponent, '1.1.2022');
-    expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('2');
+    expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('3');
     changeFilterDate(endDateLabel, renderedComponent, '1.1.2022');
-    expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('0');
+    expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('0');
     changeFilterDate(endDateLabel, renderedComponent, '12.12.2023');
-    expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('2');
+    expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('3');
     changeFilterDate(startDateLabel, renderedComponent, '28.2.2023');
-    expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('1');
+    expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('2');
     changeFilterDate(startDateLabel, renderedComponent, '1');
-    expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('2');
+    expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('3');
     changeFilterDate(startDateLabel, renderedComponent, '1.1');
-    expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('2');
+    expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('3');
     changeFilterDate(startDateLabel, renderedComponent, null);
-    expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('2');
+    expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('3');
     changeFilterDate(endDateLabel, renderedComponent, null);
-    expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('2');
+    expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('3');
     changeFilterDate(startDateLabel, renderedComponent, '1.1.2022');
-    expect(renderedComponent.getByTestId(countOfFilteredHankkeet)).toHaveTextContent('2');
+    expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('3');
   });
 });

--- a/src/domain/map/components/Layers/HankeLayer.tsx
+++ b/src/domain/map/components/Layers/HankeLayer.tsx
@@ -43,8 +43,8 @@ function HankeLayer({
             startDate: startDate && toStartOfDayUTCISO(new Date(startDate)),
             endDate,
           })({
-            startDate: alue.haittaAlkuPvm?.toString() || null,
-            endDate: alue.haittaLoppuPvm?.toString() || null,
+            startDate: alue.haittaAlkuPvm?.toString() ?? null,
+            endDate: alue.haittaLoppuPvm?.toString() ?? null,
           }),
         ),
       })),

--- a/src/domain/map/components/Layers/HankeLayer.tsx
+++ b/src/domain/map/components/Layers/HankeLayer.tsx
@@ -1,7 +1,7 @@
 import { useRef, useMemo, useContext } from 'react';
 import { Vector as VectorSource } from 'ol/source';
 import VectorLayer from '../../../../common/components/map/layers/VectorLayer';
-import { byAllHankeFilters } from '../../utils';
+import { hankeIsBetweenDates } from '../../utils';
 import { styleFunction } from '../../utils/geometryStyle';
 import CenterProjectOnMap from '../interations/CenterProjectOnMap';
 import HankkeetContext from '../../HankkeetProviderContext';
@@ -34,23 +34,29 @@ function HankeLayer({
   const hankeSource = useRef(new VectorSource());
   const hankkeet = hankeData || hankkeetFromContext;
 
-  const hankkeetFilteredByAll = useMemo(
+  const hankkeetFilteredByDates = useMemo(
     () =>
-      hankkeet.filter(
-        byAllHankeFilters({
-          startDate: startDate && toStartOfDayUTCISO(new Date(startDate)),
-          endDate,
-        }),
-      ),
+      hankkeet.map((hanke) => ({
+        ...hanke,
+        alueet: hanke.alueet.filter((alue) =>
+          hankeIsBetweenDates({
+            startDate: startDate && toStartOfDayUTCISO(new Date(startDate)),
+            endDate,
+          })({
+            startDate: alue.haittaAlkuPvm?.toString() || null,
+            endDate: alue.haittaLoppuPvm?.toString() || null,
+          }),
+        ),
+      })),
     [hankkeet, startDate, endDate],
   );
 
-  useHankeFeatures(hankeSource.current, hankkeetFilteredByAll);
+  useHankeFeatures(hankeSource.current, hankkeetFilteredByDates);
 
   return (
     <>
-      <div style={{ display: 'none' }} data-testid="countOfFilteredHankkeet">
-        {hankkeetFilteredByAll.length}
+      <div style={{ display: 'none' }} data-testid="countOfFilteredHankeAlueet">
+        {hankkeetFilteredByDates.flatMap((hanke) => hanke.alueet).length}
       </div>
       {centerOnMap && <CenterProjectOnMap source={hankeSource.current} />}
       {highlightFeatures && <HighlightFeatureOnMap source={hankeSource.current} />}


### PR DESCRIPTION
# Description

When setting work dates in kaivuilmoitus areas page, all hanke areas were shown if hanke start and end dates were within work dates. Changed it so that filtering is done based on hanke area dates so that only areas that are within the set dates are shown.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1368

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Have a hanke that has at least two areas that have no overlapping dates (for example 1.9.2024 - 2.9.2024 and 4.9.2024 - 6.9.2024)
2. Create new kaivuilmoitus and in the areas page set work dates so that not all hanke area dates are within those dates
3. Check that only hanke areas that are within the set work dates area shown

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
