### PR TITLE
HAI-2384 Add tooltips for nuisance indexes in haittojenhallinta

### DIFF
--- a/src/domain/common/haittaIndexes/HaittaIndex.tsx
+++ b/src/domain/common/haittaIndexes/HaittaIndex.tsx
@@ -25,21 +25,21 @@ export default function HaittaIndex({
 
   return (
     <Flex flexDirection="column" alignItems="center">
-      <Flex alignItems="center" gap="var(--spacing-3-xs)">
-        {showLabel ? (
-          <Box as="p" fontSize="var(--fontsize-body-s)" gap="var(--spacing-2-xs)">
-            {t('hankeIndexes:haittaindeksi')}
-          </Box>
-        ) : null}
+      {showLabel ? (
+        <Box as="p" fontSize="var(--fontsize-body-s)" mb="var(--spacing-3-xs)">
+          {t('hankeIndexes:haittaindeksi')}
+        </Box>
+      ) : null}
+      <Flex alignItems="flex-start" gap="var(--spacing-3-xs)">
+        <HaittaIndexNumber
+          index={index}
+          testId={testId}
+          tooltipContent={tooltipContent}
+          showTooltip={showTooltip}
+          showColorByIndex={showColorByIndex}
+        />
         {tooltipContent ? <HaittaIndexTooltip>{tooltipContent}</HaittaIndexTooltip> : null}
       </Flex>
-      <HaittaIndexNumber
-        index={index}
-        testId={testId}
-        tooltipContent={tooltipContent}
-        showTooltip={showTooltip}
-        showColorByIndex={showColorByIndex}
-      />
     </Flex>
   );
 }

--- a/src/domain/common/haittaIndexes/HaittaIndexTooltip.module.scss
+++ b/src/domain/common/haittaIndexes/HaittaIndexTooltip.module.scss
@@ -1,3 +1,0 @@
-.tooltipButton {
-  width: 20px;
-}

--- a/src/domain/common/haittaIndexes/HaittaIndexTooltip.tsx
+++ b/src/domain/common/haittaIndexes/HaittaIndexTooltip.tsx
@@ -1,10 +1,13 @@
 import { Tooltip } from 'hds-react';
-import styles from './HaittaIndexTooltip.module.scss';
 
 type Props = {
   children: React.ReactNode;
 };
 
 export default function HaittaIndexTooltip({ children }: Readonly<Props>) {
-  return <Tooltip buttonClassName={styles.tooltipButton}>{children}</Tooltip>;
+  return (
+    <div onClick={(event) => event.stopPropagation()}>
+      <Tooltip>{children}</Tooltip>
+    </div>
+  );
 }

--- a/src/domain/common/haittaIndexes/HaittaIndexes.tsx
+++ b/src/domain/common/haittaIndexes/HaittaIndexes.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from 'react-i18next';
 import CustomAccordion from '../../../common/components/customAccordion/CustomAccordion';
 import { HaittaIndexData } from './types';
 import { HaittaSection } from './HaittaSection';
-import React from 'react';
 import { HaittaSubSection } from './HaittaSubSection';
 import HaittaIndex from './HaittaIndex';
+import HaittaTooltipContent from './HaittaTooltipContent';
 
 type Props = {
   heading: string;
@@ -35,6 +35,9 @@ export default function HaittaIndexes({
             heading={t('hankeIndexes:pyoraliikenne')}
             index={haittaIndexData?.pyoraliikenneindeksi}
             testId="test-pyoraliikenneindeksi"
+            tooltipContent={
+              <HaittaTooltipContent translationKey="hankeIndexes:tooltips:PYORALIIKENNE" />
+            }
           />
           <CustomAccordion
             heading={t('hankeIndexes:autoliikenne')}
@@ -42,6 +45,12 @@ export default function HaittaIndexes({
               <HaittaIndex
                 index={haittaIndexData?.autoliikenne?.indeksi}
                 testId="test-autoliikenneindeksi"
+                tooltipContent={
+                  <HaittaTooltipContent
+                    translationKey="hankeIndexes:tooltips:AUTOLIIKENNE"
+                    showHeading={false}
+                  />
+                }
               />
             }
             headingSize="s"
@@ -51,16 +60,25 @@ export default function HaittaIndexes({
               heading={t(`hankeForm:haittojenHallintaForm:carTrafficNuisanceType:katuluokka`)}
               index={haittaIndexData?.autoliikenne.katuluokka}
               testId="test-katuluokka"
+              tooltipContent={
+                <HaittaTooltipContent translationKey="hankeIndexes:tooltips:autoKatuluokka" />
+              }
             />
             <HaittaSubSection
               heading={t(`hankeForm:haittojenHallintaForm:carTrafficNuisanceType:liikennemaara`)}
               index={haittaIndexData?.autoliikenne.liikennemaara}
               testId="test-liikennemaara"
+              tooltipContent={
+                <HaittaTooltipContent translationKey="hankeIndexes:tooltips:autoliikenneMaara" />
+              }
             />
             <HaittaSubSection
               heading={t(`hankeForm:haittojenHallintaForm:carTrafficNuisanceType:kaistahaitta`)}
               index={haittaIndexData?.autoliikenne.kaistahaitta}
               testId="test-kaistahaitta"
+              tooltipContent={
+                <HaittaTooltipContent translationKey="hankeIndexes:tooltips:autoKaistaHaitta" />
+              }
             />
             <HaittaSubSection
               heading={t(
@@ -68,22 +86,34 @@ export default function HaittaIndexes({
               )}
               index={haittaIndexData?.autoliikenne.kaistapituushaitta}
               testId="test-kaistapituushaitta"
+              tooltipContent={
+                <HaittaTooltipContent translationKey="hankeIndexes:tooltips:autoKaistaPituusHaitta" />
+              }
             />
             <HaittaSubSection
               heading={t(`hankeForm:haittojenHallintaForm:carTrafficNuisanceType:haitanKesto`)}
               index={haittaIndexData?.autoliikenne.haitanKesto}
               testId="test-haitanKesto"
+              tooltipContent={
+                <HaittaTooltipContent translationKey="hankeIndexes:tooltips:autoHankkeenKesto" />
+              }
             />
           </CustomAccordion>
           <HaittaSection
             heading={t('hankeIndexes:linjaautoliikenne')}
             index={haittaIndexData?.linjaautoliikenneindeksi}
             testId="test-linjaautoliikenneindeksi"
+            tooltipContent={
+              <HaittaTooltipContent translationKey="hankeIndexes:tooltips:LINJAAUTOLIIKENNE" />
+            }
           />
           <HaittaSection
             heading={t('hankeIndexes:raitioliikenne')}
             index={haittaIndexData?.raitioliikenneindeksi}
             testId="test-raitioliikenneindeksi"
+            tooltipContent={
+              <HaittaTooltipContent translationKey="hankeIndexes:tooltips:RAITIOLIIKENNE" />
+            }
           />
         </>
       ) : (

--- a/src/domain/common/haittaIndexes/HaittaSection.tsx
+++ b/src/domain/common/haittaIndexes/HaittaSection.tsx
@@ -6,7 +6,14 @@ export function HaittaSection({
   index,
   testId,
   border = true,
-}: Readonly<{ heading: string; index?: number; testId?: string; border?: boolean }>) {
+  tooltipContent,
+}: Readonly<{
+  heading: string;
+  index?: number;
+  testId?: string;
+  border?: boolean;
+  tooltipContent?: React.ReactNode;
+}>) {
   return (
     <Grid
       templateColumns="1fr 24px"
@@ -22,7 +29,7 @@ export function HaittaSection({
         <p className="heading-xs">
           <strong>{heading}</strong>
         </p>
-        <HaittaIndex index={index} testId={testId} />
+        <HaittaIndex index={index} testId={testId} tooltipContent={tooltipContent} />
       </Flex>
     </Grid>
   );

--- a/src/domain/common/haittaIndexes/HaittaSubSection.tsx
+++ b/src/domain/common/haittaIndexes/HaittaSubSection.tsx
@@ -9,6 +9,7 @@ export function HaittaSubSection({
   showIndex = true,
   showColorByIndex,
   className,
+  tooltipContent,
 }: Readonly<{
   heading: string;
   index?: number;
@@ -16,6 +17,7 @@ export function HaittaSubSection({
   showIndex?: boolean;
   showColorByIndex?: boolean;
   className?: string;
+  tooltipContent?: React.ReactNode;
 }>) {
   return (
     <Grid
@@ -39,6 +41,7 @@ export function HaittaSubSection({
             showLabel={false}
             testId={testId}
             showColorByIndex={showColorByIndex}
+            tooltipContent={tooltipContent}
           />
         )}
       </Flex>

--- a/src/domain/common/haittaIndexes/HaittaTooltipContent.test.tsx
+++ b/src/domain/common/haittaIndexes/HaittaTooltipContent.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '../../../testUtils/render';
+import HaittaTooltipContent from './HaittaTooltipContent';
+
+test.each([
+  ['hankeIndexes:tooltips:PYORALIIKENNE'],
+  ['hankeIndexes:tooltips:AUTOLIIKENNE'],
+  ['hankeIndexes:tooltips:LINJAAUTOLIIKENNE'],
+  ['hankeIndexes:tooltips:RAITIOLIIKENNE'],
+  ['hankeIndexes:tooltips:MUUT'],
+])('Should show correct tooltip for %s', (translationKey) => {
+  const { container } = render(<HaittaTooltipContent translationKey={translationKey} />);
+  expect(container).toMatchSnapshot();
+});
+
+test('Should not show heading when showHeading is false', () => {
+  render(
+    <HaittaTooltipContent
+      translationKey="hankeIndexes:tooltips:PYORALIIKENNE"
+      showHeading={false}
+    />,
+  );
+  expect(screen.queryByText('Haittaindeksit:')).not.toBeInTheDocument();
+});

--- a/src/domain/common/haittaIndexes/HaittaTooltipContent.tsx
+++ b/src/domain/common/haittaIndexes/HaittaTooltipContent.tsx
@@ -1,0 +1,28 @@
+import { Trans, useTranslation } from 'react-i18next';
+import { Box } from '@chakra-ui/react';
+
+type Props = {
+  translationKey: string;
+  showHeading?: boolean;
+};
+
+export default function HaittaTooltipContent({
+  translationKey,
+  showHeading = true,
+}: Readonly<Props>) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      {showHeading && (
+        <Box as="h5" fontWeight="bold">
+          {t('hankeIndexes:haittaindeksit')}:
+        </Box>
+      )}
+      <Trans
+        i18nKey={translationKey}
+        components={{ ul: <Box as="ul" listStyleType="none" />, li: <li /> }}
+      />
+    </>
+  );
+}

--- a/src/domain/common/haittaIndexes/__snapshots__/HaittaTooltipContent.test.tsx.snap
+++ b/src/domain/common/haittaIndexes/__snapshots__/HaittaTooltipContent.test.tsx.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Should show correct tooltip for hankeIndexes:tooltips:AUTOLIIKENNE 1`] = `
+<div>
+  <h5
+    class="css-in3yi3"
+  >
+    Haittaindeksit
+    :
+  </h5>
+  Autoliikenteelle lasketaan painotettu haittaindeksi (0-5) siihen sisältyvien osa-alueiden mukaan.
+</div>
+`;
+
+exports[`Should show correct tooltip for hankeIndexes:tooltips:LINJAAUTOLIIKENNE 1`] = `
+<div>
+  <h5
+    class="css-in3yi3"
+  >
+    Haittaindeksit
+    :
+  </h5>
+  <ul
+    class="css-155za0w"
+  >
+    <li>
+      0: Ei linja-autojen paikallisliikennettä
+    </li>
+    <li>
+      2: Linja-autojen paikallisliikennettä muulloin, kuin ruuhka-aikana
+    </li>
+    <li>
+      3: Linja-autojen paikallisliikenteen linjojen vuoromäärä enintään 10 ruuhkatunnissa
+    </li>
+    <li>
+      4: Linja-autojen paikallisliikenteen runkolinja tai vuoromäärä enintään 20 ruuhkatunnissa
+    </li>
+    <li>
+      5: Kamppi-Rautatientori -alue, Mannerheimintie, Kaisaniemenkatu, Hämeentie tai linja-autojen paikallisliikenteen linjojen vuoromäärä yli 20 ruuhkatunnissa
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Should show correct tooltip for hankeIndexes:tooltips:MUUT 1`] = `
+<div>
+  <h5
+    class="css-in3yi3"
+  >
+    Haittaindeksit
+    :
+  </h5>
+  key 'tooltips.MUUT (fi)' returned an object instead of string.
+</div>
+`;
+
+exports[`Should show correct tooltip for hankeIndexes:tooltips:PYORALIIKENNE 1`] = `
+<div>
+  <h5
+    class="css-in3yi3"
+  >
+    Haittaindeksit
+    :
+  </h5>
+  <ul
+    class="css-155za0w"
+  >
+    <li>
+      0: Ei tunnistettua pyöräliikenteen reittiä
+    </li>
+    <li>
+      2: Muut pyöräliikenteen yhteydet
+    </li>
+    <li>
+      3: Muut pyöräliikenteen reitit (tai reitin/yhteyden luokitustieto puuttuu pyöräliikenteen tausta-aineistosta)
+    </li>
+    <li>
+      5: Pyöräliikenteen pääreitti tai pääreitin osana toimiva katu
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Should show correct tooltip for hankeIndexes:tooltips:RAITIOLIIKENNE 1`] = `
+<div>
+  <h5
+    class="css-in3yi3"
+  >
+    Haittaindeksit
+    :
+  </h5>
+  <ul
+    class="css-155za0w"
+  >
+    <li>
+      0: Ei tunnistettuja raitiotiekiskoja
+    </li>
+    <li>
+      3: Raitiotieverkon rataosa, joilla ei ole säännöllistä linjaliikennettä
+    </li>
+    <li>
+      5: Raitiotieverkon rataosa, jolla on säännöllistä linjaliikennettä
+    </li>
+  </ul>
+</div>
+`;

--- a/src/domain/hanke/edit/components/Haittojenhallintasuunnitelma.tsx
+++ b/src/domain/hanke/edit/components/Haittojenhallintasuunnitelma.tsx
@@ -22,6 +22,7 @@ import HaittaIndex from '../../../common/haittaIndexes/HaittaIndex';
 import { HaittaSubSection } from '../../../common/haittaIndexes/HaittaSubSection';
 import styles from './Haittojenhallintasuunnitelma.module.scss';
 import ProcedureTips from '../../../common/haittaIndexes/ProcedureTips';
+import HaittaTooltipContent from '../../../common/haittaIndexes/HaittaTooltipContent';
 
 function mapNuisanceEnumIndexToNuisanceIndex(index: number): number {
   if (index === 2) return 3;
@@ -31,15 +32,32 @@ function mapNuisanceEnumIndexToNuisanceIndex(index: number): number {
 
 function HaittaIndexHeading({
   index,
+  haittojenhallintaTyyppi,
+  showTooltipHeading = true,
   testId,
-}: Readonly<{ index: number | undefined; testId?: string }>) {
+}: Readonly<{
+  index: number | undefined;
+  haittojenhallintaTyyppi: string;
+  showTooltipHeading?: boolean;
+  testId?: string;
+}>) {
   const { t } = useTranslation();
   return (
     <HStack spacing="12px">
       <Box as="h4" className="heading-s">
         {t(`hankeIndexes:haittaindeksi`)}
       </Box>
-      <HaittaIndex index={index} showLabel={false} testId={testId} />
+      <HaittaIndex
+        index={index}
+        showLabel={false}
+        testId={testId}
+        tooltipContent={
+          <HaittaTooltipContent
+            translationKey={`hankeIndexes:tooltips:${haittojenhallintaTyyppi}`}
+            showHeading={showTooltipHeading}
+          />
+        }
+      />
     </HStack>
   );
 }
@@ -120,23 +138,39 @@ const Haittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke, index 
           </Box>
           {haitta === HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE ? (
             <CustomAccordion
-              heading={<HaittaIndexHeading index={indeksi} testId="test-AUTOLIIKENNE" />}
+              heading={
+                <HaittaIndexHeading
+                  index={indeksi}
+                  haittojenhallintaTyyppi={haitta}
+                  showTooltipHeading={false}
+                  testId="test-AUTOLIIKENNE"
+                />
+              }
               headingBorderBottom={false}
             >
               <HaittaSubSection
                 heading={t(`hankeForm:haittojenHallintaForm:carTrafficNuisanceType:katuluokka`)}
                 index={tormaystarkasteluTulos?.autoliikenne.katuluokka}
                 testId="test-katuluokka"
+                tooltipContent={
+                  <HaittaTooltipContent translationKey="hankeIndexes:tooltips:autoKatuluokka" />
+                }
               />
               <HaittaSubSection
                 heading={t(`hankeForm:haittojenHallintaForm:carTrafficNuisanceType:liikennemaara`)}
                 index={tormaystarkasteluTulos?.autoliikenne.liikennemaara}
                 testId="test-liikennemaara"
+                tooltipContent={
+                  <HaittaTooltipContent translationKey="hankeIndexes:tooltips:autoliikenneMaara" />
+                }
               />
               <HaittaSubSection
                 heading={t(`hankeForm:haittojenHallintaForm:carTrafficNuisanceType:kaistahaitta`)}
                 index={tormaystarkasteluTulos?.autoliikenne.kaistahaitta}
                 testId="test-kaistahaitta"
+                tooltipContent={
+                  <HaittaTooltipContent translationKey="hankeIndexes:tooltips:autoKaistaHaitta" />
+                }
               />
               <HaittaSubSection
                 heading={t(
@@ -144,15 +178,25 @@ const Haittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke, index 
                 )}
                 index={tormaystarkasteluTulos?.autoliikenne.kaistapituushaitta}
                 testId="test-kaistapituushaitta"
+                tooltipContent={
+                  <HaittaTooltipContent translationKey="hankeIndexes:tooltips:autoKaistaPituusHaitta" />
+                }
               />
               <HaittaSubSection
                 heading={t(`hankeForm:haittojenHallintaForm:carTrafficNuisanceType:haitanKesto`)}
                 index={tormaystarkasteluTulos?.autoliikenne.haitanKesto}
                 testId="test-haitanKesto"
+                tooltipContent={
+                  <HaittaTooltipContent translationKey="hankeIndexes:tooltips:autoHankkeenKesto" />
+                }
               />
             </CustomAccordion>
           ) : (
-            <HaittaIndexHeading index={indeksi} testId={`test-${haitta}`} />
+            <HaittaIndexHeading
+              index={indeksi}
+              haittojenhallintaTyyppi={haitta}
+              testId={`test-${haitta}`}
+            />
           )}
           <Box mt="var(--spacing-s)">
             <ProcedureTips haittojenhallintaTyyppi={haitta} haittaIndex={indeksi} />
@@ -178,6 +222,9 @@ const Haittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke, index 
           showColorByIndex={false}
           className={styles.muutHaittojenHallintaToimetSubSection}
           testId="test-meluHaitta"
+          tooltipContent={
+            <HaittaTooltipContent translationKey="hankeIndexes:tooltips:MUUT:meluHaitta" />
+          }
         />
         <HaittaSubSection
           heading={t(`hankeForm:labels:polyHaittaShort`)}
@@ -185,6 +232,9 @@ const Haittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke, index 
           showColorByIndex={false}
           className={styles.muutHaittojenHallintaToimetSubSection}
           testId="test-polyHaitta"
+          tooltipContent={
+            <HaittaTooltipContent translationKey="hankeIndexes:tooltips:MUUT:polyHaitta" />
+          }
         />
         <HaittaSubSection
           heading={t(`hankeForm:labels:tarinaHaittaShort`)}
@@ -192,6 +242,9 @@ const Haittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke, index 
           showColorByIndex={false}
           className={styles.muutHaittojenHallintaToimetSubSection}
           testId="test-tarinaHaitta"
+          tooltipContent={
+            <HaittaTooltipContent translationKey="hankeIndexes:tooltips:MUUT:tarinaHaitta" />
+          }
         />
         <HaittaSubSection
           heading={t(`hankeForm:labels:checkSurrounding`)}

--- a/src/domain/hanke/hankeView/HankeView.module.scss
+++ b/src/domain/hanke/hankeView/HankeView.module.scss
@@ -16,10 +16,6 @@
 .hankeAreaContainer {
   margin-bottom: var(--spacing-m);
 
-  .hankeAreaContent {
-    color: var(--color-black-60);
-  }
-
   .areaIndexes {
     margin-bottom: var(--spacing-s);
   }

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -77,7 +77,7 @@ const HankeAreaInfo: React.FC<AreaProps> = ({ area, index }) => {
       initiallyOpen
       className={styles.hankeAreaContainer}
     >
-      <div className={styles.hankeAreaContent}>
+      <div>
         <FormSummarySection>
           <SectionItemTitle>{t('hanke:alue:duration')}</SectionItemTitle>
           <SectionItemContent>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -472,7 +472,7 @@
       "VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA": "Vähentää kaistan yhdellä ajosuunnalla",
       "VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA": "Vähentää samanaikaisesti kaistan kahdella ajosuunnalla",
       "VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA": "Vähentää samanaikaisesti useita kaistoja kahdella ajosuunnalla",
-      "VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA": "Vähentää samanaikaisesti useita kaistoja liittymän eri suunnilla"
+      "VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA": "Vähentää samanaikaisesti useita kaistoja liittymien eri suunnilla"
     },
     "kaistaPituusHaitta": {
       "EI_VAIKUTA_KAISTAJARJESTELYIHIN": "Ei vaikuta",
@@ -1178,7 +1178,23 @@
       "EI_TARVETTA": "ei tarvetta",
       "MERKITTAVA": "merkittävä"
     },
-    "indexesNotCalculated": "Haittaindeksejä ei ole laskettu."
+    "indexesNotCalculated": "Haittaindeksejä ei ole laskettu.",
+    "tooltips": {
+      "PYORALIIKENNE": "<ul><li>0: Ei tunnistettua pyöräliikenteen reittiä</li><li>2: Muut pyöräliikenteen yhteydet</li><li>3: Muut pyöräliikenteen reitit (tai reitin/yhteyden luokitustieto puuttuu pyöräliikenteen tausta-aineistosta)</li><li>5: Pyöräliikenteen pääreitti tai pääreitin osana toimiva katu</li></ul>",
+      "AUTOLIIKENNE": "Autoliikenteelle lasketaan painotettu haittaindeksi (0-5) siihen sisältyvien osa-alueiden mukaan.",
+      "autoKatuluokka": "<ul><li>0: Ei tunnistettua katuluokkaa</li><li>1: Asuntokatu, huoltoväylä tai vähäliikenteinen katu</li><li>2: Kantakaupungin asuntokatu, huoltoväylä tai vähäliikenteinen katu</li><li>3: Paikallinen kokoojakatu</li><li>4: Alueellinen kokoojakatu</li><li>5: Pääkatu tai moottoriväylä</li></ul>",
+      "autoliikenneMaara": "<ul><li>0: Ei tunnistettua autoliikennettä</li><li>1: Alle 500 autoa arkivuorokaudessa</li><li>2: 500 - 1 499 autoa arkivuorokaudessa</li><li>3: 1 500 - 4 999 autoa arkivuorokaudessa</li><li>4: 5 000 - 9 999 autoa arkivuorokaudessa</li><li>5: 10 000 tai enemmän autoja arkivuorokaudessa</li></ul>",
+      "autoKaistaHaitta": "<ul><li>1: Ei vaikuta kaistajärjestelyihin</li><li>2: $t(hanke:kaistaHaitta:VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA)</li><li>3: $t(hanke:kaistaHaitta:VAHENTAA_SAMANAIKAISESTI_KAISTAN_KAHDELLA_AJOSUUNNALLA)</li><li>4: $t(hanke:kaistaHaitta:VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_KAHDELLA_AJOSUUNNALLA)</li><li>5: $t(hanke:kaistaHaitta:VAHENTAA_SAMANAIKAISESTI_USEITA_KAISTOJA_LIITTYMIEN_ERI_SUUNNILLA)</li></ul>",
+      "autoKaistaPituusHaitta": "<ul><li>1: Ei vaikuta kaistajärjestelyihin</li><li>2: Kaistavaikutusten pituus alle 10 m</li><li>3: Kaistavaikutusten pituus 10-99 m</li><li>4: Kaistavaikutusten pituus 100-499 m</li><li>5: Kaistavaikutusten pituus 500 m tai enemmän</li></ul>",
+      "autoHankkeenKesto": "<ul><li>1: Hankkeen kesto alle 2 viikkoa</li><li>3: Hankkeen kesto 2 viikkoa - 3 kuukautta</li><li>5: Hankkeen kesto yli 3 kuukautta</li></ul>",
+      "LINJAAUTOLIIKENNE": "<ul><li>0: Ei linja-autojen paikallisliikennettä</li><li>2: Linja-autojen paikallisliikennettä muulloin, kuin ruuhka-aikana</li><li>3: Linja-autojen paikallisliikenteen linjojen vuoromäärä enintään 10 ruuhkatunnissa</li><li>4: Linja-autojen paikallisliikenteen runkolinja tai vuoromäärä enintään 20 ruuhkatunnissa</li><li>5: Kamppi-Rautatientori -alue, Mannerheimintie, Kaisaniemenkatu, Hämeentie tai linja-autojen paikallisliikenteen linjojen vuoromäärä yli 20 ruuhkatunnissa</li></ul>",
+      "RAITIOLIIKENNE": "<ul><li>0: Ei tunnistettuja raitiotiekiskoja</li><li>3: Raitiotieverkon rataosa, joilla ei ole säännöllistä linjaliikennettä</li><li>5: Raitiotieverkon rataosa, jolla on säännöllistä linjaliikennettä</li></ul>",
+      "MUUT": {
+        "meluHaitta": "<ul><li>$t(hanke:meluHaitta:EI_MELUHAITTAA)</li><li>$t(hanke:meluHaitta:SATUNNAINEN_MELUHAITTA)</li><li>$t(hanke:meluHaitta:TOISTUVA_MELUHAITTA)</li><li>$t(hanke:meluHaitta:JATKUVA_MELUHAITTA)</li></ul>",
+        "polyHaitta": "<ul><li>$t(hanke:polyHaitta:EI_POLYHAITTAA)</li><li>$t(hanke:polyHaitta:SATUNNAINEN_POLYHAITTA)</li><li>$t(hanke:polyHaitta:TOISTUVA_POLYHAITTA)</li><li>$t(hanke:polyHaitta:JATKUVA_POLYHAITTA)</li></ul>",
+        "tarinaHaitta": "<ul><li>$t(hanke:tarinaHaitta:EI_TARINAHAITTAA)</li><li>$t(hanke:tarinaHaitta:SATUNNAINEN_TARINAHAITTA)</li><li>$t(hanke:tarinaHaitta:TOISTUVA_TARINAHAITTA)</li><li>$t(hanke:tarinaHaitta:JATKUVA_TARINAHAITTA)</li></ul>"
+      }
+    }
   },
   "homepage": {
     "pageTitle": "Tervetuloa Haitaton-palveluun",


### PR DESCRIPTION
# Description

Added tooltips for nuisance indexes for different liikennemuodot in hanke haittojenhallinta. Also added the tooltips to hanke areas page.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2384

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check in hanke haittojenhallinta page that nuisance index tooltips exist for each liikennemuoto and you can check that they are correct: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HAI/pages/8236367978/Asiakasryhm+luokittelut+0-5+ja+toimenpidevinkit+asiakasryhmitt+in

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
