### PR TITLE
HAI-2465 Haittojenhallintasuunnitelma area color based on nuisance index

### DIFF
--- a/src/domain/hanke/edit/components/Haittojenhallintasuunnitelma.tsx
+++ b/src/domain/hanke/edit/components/Haittojenhallintasuunnitelma.tsx
@@ -110,11 +110,7 @@ const Haittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke, index 
             {t(`hankeForm:haittojenHallintaForm:nuisanceType:${haitta}`)}
           </Box>
           <Box mt="var(--spacing-m)" mb="var(--spacing-m)">
-            <HankealueMap
-              hankealue={hankealue}
-              tyyppi={haitta as HAITTOJENHALLINTATYYPPI}
-              center={addressCoordinate}
-            />
+            <HankealueMap hankealue={hankealue} index={indeksi} center={addressCoordinate} />
           </Box>
           {haitta === HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE ? (
             <CustomAccordion

--- a/src/domain/hanke/edit/components/Haittojenhallintasuunnitelma.tsx
+++ b/src/domain/hanke/edit/components/Haittojenhallintasuunnitelma.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Box, HStack } from '@chakra-ui/react';
 import { $enum } from 'ts-enum-util';
@@ -14,7 +14,6 @@ import TextArea from '../../../../common/components/textArea/TextArea';
 import { sortedLiikenneHaittojenhallintatyyppi } from '../utils';
 import useFieldArrayWithStateUpdate from '../../../../common/hooks/useFieldArrayWithStateUpdate';
 import HankealueMap from '../../../map/components/HankkeenHaittojenhallintasuunnitelma/HankealueMap';
-import VectorSource from 'ol/source/Vector';
 import useAddressCoordinate from '../../../map/hooks/useAddressCoordinate';
 import { HaittaIndexData } from '../../../common/haittaIndexes/types';
 import CustomAccordion from '../../../../common/components/customAccordion/CustomAccordion';
@@ -57,7 +56,6 @@ const Haittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke, index 
   const hankealue = hankealueet[index];
   const tormaystarkasteluTulos = hankealue.tormaystarkasteluTulos as HaittaIndexData;
   const haittojenhallintatyypit = sortedLiikenneHaittojenhallintatyyppi(tormaystarkasteluTulos);
-  const [drawSource] = useState<VectorSource>(new VectorSource());
   const addressCoordinate = useAddressCoordinate(hanke.tyomaaKatuosoite);
   const meluhaittaIndex = mapNuisanceEnumIndexToNuisanceIndex(
     $enum(HANKE_MELUHAITTA).indexOfKey(hankealue.meluHaitta!),
@@ -116,7 +114,6 @@ const Haittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke, index 
               hankealue={hankealue}
               tyyppi={haitta as HAITTOJENHALLINTATYYPPI}
               center={addressCoordinate}
-              drawSource={drawSource}
             />
           </Box>
           {haitta === HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE ? (

--- a/src/domain/hanke/edit/components/Haittojenhallintasuunnitelma.tsx
+++ b/src/domain/hanke/edit/components/Haittojenhallintasuunnitelma.tsx
@@ -114,6 +114,7 @@ const Haittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke, index 
           <Box mt="var(--spacing-m)" mb="var(--spacing-m)">
             <HankealueMap
               hankealue={hankealue}
+              tyyppi={haitta as HAITTOJENHALLINTATYYPPI}
               center={addressCoordinate}
               drawSource={drawSource}
             />

--- a/src/domain/kaivuilmoitus/validationSchema.ts
+++ b/src/domain/kaivuilmoitus/validationSchema.ts
@@ -14,7 +14,7 @@ import {
   HANKE_POLYHAITTA_KEY,
   HANKE_TARINAHAITTA_KEY,
   HANKE_TYOMAATYYPPI_KEY,
-} from './../types/hanke';
+} from '../types/hanke';
 import { HaittaIndexData } from '../common/haittaIndexes/types';
 
 const tyoalueSchema = yup.object({

--- a/src/domain/map/components/HankkeenHaittojenhallintasuunnitelma/HankealueMap.tsx
+++ b/src/domain/map/components/HankkeenHaittojenhallintasuunnitelma/HankealueMap.tsx
@@ -3,7 +3,7 @@ import VectorSource from 'ol/source/Vector';
 import Map from '../../../../common/components/map/Map';
 import Kantakartta from '../Layers/Kantakartta';
 import OverviewMapControl from '../../../../common/components/map/controls/OverviewMapControl';
-import { HAITTOJENHALLINTATYYPPI, HankeAlue } from '../../../types/hanke';
+import { HankeAlue } from '../../../types/hanke';
 import styles from './HankealueMap.module.scss';
 import VectorLayer from '../../../../common/components/map/layers/VectorLayer';
 import FitSource from '../interations/FitSource';
@@ -20,7 +20,7 @@ import { styleFunction } from '../../utils/geometryStyle';
 
 type Props = {
   hankealue: HankeAlue;
-  tyyppi: HAITTOJENHALLINTATYYPPI;
+  index: number;
   center?: Coordinate;
   drawSource?: VectorSource;
   zoom?: number;
@@ -28,7 +28,7 @@ type Props = {
 
 const HankealueMap: React.FC<Props> = ({
   hankealue,
-  tyyppi,
+  index,
   center,
   drawSource: existingDrawSource,
   zoom = 9,
@@ -36,7 +36,7 @@ const HankealueMap: React.FC<Props> = ({
   const { mapTileLayers, toggleMapTileLayer } = useMapDataLayers();
   const ortoLayerOpacity = mapTileLayers.kantakartta.visible ? 0.5 : 1;
   const drawSource = existingDrawSource || new VectorSource();
-  useHankealueFeature(drawSource, hankealue, tyyppi);
+  useHankealueFeature(drawSource, hankealue, index);
 
   return (
     <>

--- a/src/domain/map/components/HankkeenHaittojenhallintasuunnitelma/HankealueMap.tsx
+++ b/src/domain/map/components/HankkeenHaittojenhallintasuunnitelma/HankealueMap.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import VectorSource from 'ol/source/Vector';
 import Map from '../../../../common/components/map/Map';
 import Kantakartta from '../Layers/Kantakartta';
@@ -17,26 +17,6 @@ import { MapTileLayerId } from '../../types';
 import { Coordinate } from 'ol/coordinate';
 import { useMapDataLayers } from '../../hooks/useMapLayers';
 import { styleFunction } from '../../utils/geometryStyle';
-import { HaittaIndexData } from '../../../common/haittaIndexes/types';
-
-const liikennehaittaindeksi = (
-  tulos: HaittaIndexData | null | undefined,
-  tyyppi: HAITTOJENHALLINTATYYPPI,
-) => {
-  if (!tulos) return null;
-  switch (tyyppi) {
-    case HAITTOJENHALLINTATYYPPI.PYORALIIKENNE:
-      return tulos.pyoraliikenneindeksi;
-    case HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE:
-      return tulos.autoliikenne.indeksi;
-    case HAITTOJENHALLINTATYYPPI.RAITIOLIIKENNE:
-      return tulos.raitioliikenneindeksi;
-    case HAITTOJENHALLINTATYYPPI.LINJAAUTOLIIKENNE:
-      return tulos.linjaautoliikenneindeksi;
-    default:
-      return null;
-  }
-};
 
 type Props = {
   hankealue: HankeAlue;
@@ -55,9 +35,8 @@ const HankealueMap: React.FC<Props> = ({
 }) => {
   const { mapTileLayers, toggleMapTileLayer } = useMapDataLayers();
   const ortoLayerOpacity = mapTileLayers.kantakartta.visible ? 0.5 : 1;
-  const [drawSource] = useState<VectorSource>(existingDrawSource || new VectorSource());
-  const indeksi = liikennehaittaindeksi(hankealue.tormaystarkasteluTulos, tyyppi);
-  useHankealueFeature(drawSource, hankealue, indeksi);
+  const drawSource = existingDrawSource || new VectorSource();
+  useHankealueFeature(drawSource, hankealue, tyyppi);
 
   return (
     <>

--- a/src/domain/map/components/HankkeenHaittojenhallintasuunnitelma/HankealueMap.tsx
+++ b/src/domain/map/components/HankkeenHaittojenhallintasuunnitelma/HankealueMap.tsx
@@ -3,7 +3,7 @@ import VectorSource from 'ol/source/Vector';
 import Map from '../../../../common/components/map/Map';
 import Kantakartta from '../Layers/Kantakartta';
 import OverviewMapControl from '../../../../common/components/map/controls/OverviewMapControl';
-import { HankeAlue } from '../../../types/hanke';
+import { HAITTOJENHALLINTATYYPPI, HankeAlue } from '../../../types/hanke';
 import styles from './HankealueMap.module.scss';
 import VectorLayer from '../../../../common/components/map/layers/VectorLayer';
 import FitSource from '../interations/FitSource';
@@ -17,9 +17,30 @@ import { MapTileLayerId } from '../../types';
 import { Coordinate } from 'ol/coordinate';
 import { useMapDataLayers } from '../../hooks/useMapLayers';
 import { styleFunction } from '../../utils/geometryStyle';
+import { HaittaIndexData } from '../../../common/haittaIndexes/types';
+
+const liikennehaittaindeksi = (
+  tulos: HaittaIndexData | null | undefined,
+  tyyppi: HAITTOJENHALLINTATYYPPI,
+) => {
+  if (!tulos) return null;
+  switch (tyyppi) {
+    case HAITTOJENHALLINTATYYPPI.PYORALIIKENNE:
+      return tulos.pyoraliikenneindeksi;
+    case HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE:
+      return tulos.autoliikenne.indeksi;
+    case HAITTOJENHALLINTATYYPPI.RAITIOLIIKENNE:
+      return tulos.raitioliikenneindeksi;
+    case HAITTOJENHALLINTATYYPPI.LINJAAUTOLIIKENNE:
+      return tulos.linjaautoliikenneindeksi;
+    default:
+      return null;
+  }
+};
 
 type Props = {
   hankealue: HankeAlue;
+  tyyppi: HAITTOJENHALLINTATYYPPI;
   center?: Coordinate;
   drawSource?: VectorSource;
   zoom?: number;
@@ -27,6 +48,7 @@ type Props = {
 
 const HankealueMap: React.FC<Props> = ({
   hankealue,
+  tyyppi,
   center,
   drawSource: existingDrawSource,
   zoom = 9,
@@ -34,7 +56,8 @@ const HankealueMap: React.FC<Props> = ({
   const { mapTileLayers, toggleMapTileLayer } = useMapDataLayers();
   const ortoLayerOpacity = mapTileLayers.kantakartta.visible ? 0.5 : 1;
   const [drawSource] = useState<VectorSource>(existingDrawSource || new VectorSource());
-  useHankealueFeature(drawSource, hankealue);
+  const indeksi = liikennehaittaindeksi(hankealue.tormaystarkasteluTulos, tyyppi);
+  useHankealueFeature(drawSource, hankealue, indeksi);
 
   return (
     <>

--- a/src/domain/map/hooks/useHankealueFeature.ts
+++ b/src/domain/map/hooks/useHankealueFeature.ts
@@ -3,7 +3,8 @@ import { Vector } from 'ol/source';
 import GeoJSON from 'ol/format/GeoJSON';
 import { Feature } from 'ol';
 import { Geometry } from 'ol/geom';
-import { HankeAlue } from '../../types/hanke';
+import { HAITTOJENHALLINTATYYPPI, HankeAlue } from '../../types/hanke';
+import { HaittaIndexData } from '../../common/haittaIndexes/types';
 
 /**
  * Add feature from hanke area to map
@@ -12,28 +13,40 @@ import { HankeAlue } from '../../types/hanke';
 export default function useHankealueFeature(
   source: Vector,
   hankealue: HankeAlue,
-  indeksi: number | null,
+  tyyppi: HAITTOJENHALLINTATYYPPI | undefined | null,
 ) {
-  console.log(indeksi);
   useEffect(() => {
     source.clear();
+
+    const indeksi = (tulos: HaittaIndexData | null | undefined) => {
+      if (!tulos) return null;
+      switch (tyyppi) {
+        case HAITTOJENHALLINTATYYPPI.PYORALIIKENNE:
+          return tulos.pyoraliikenneindeksi;
+        case HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE:
+          return tulos.autoliikenne.indeksi;
+        case HAITTOJENHALLINTATYYPPI.RAITIOLIIKENNE:
+          return tulos.raitioliikenneindeksi;
+        case HAITTOJENHALLINTATYYPPI.LINJAAUTOLIIKENNE:
+          return tulos.linjaautoliikenneindeksi;
+        default:
+          return null;
+      }
+    };
+
     if (hankealue.geometriat) {
       const feature = new GeoJSON().readFeatures(
         hankealue.geometriat.featureCollection,
       )[0] as Feature<Geometry>;
       feature.setProperties(
         {
-          // this does not work as it should:
-          liikennehaittaindeksi: indeksi,
-          // this works as it should:
-          //liikennehaittaindeksi: 3,
+          liikennehaittaindeksi: indeksi(hankealue.tormaystarkasteluTulos),
           areaName: hankealue.nimi,
         },
         true,
       );
-      console.log('feature', feature);
       source.addFeature(feature);
       source.dispatchEvent('featuresAdded');
     }
-  }, [source, hankealue, indeksi]);
+  }, [source, hankealue, tyyppi]);
 }

--- a/src/domain/map/hooks/useHankealueFeature.ts
+++ b/src/domain/map/hooks/useHankealueFeature.ts
@@ -3,36 +3,15 @@ import { Vector } from 'ol/source';
 import GeoJSON from 'ol/format/GeoJSON';
 import { Feature } from 'ol';
 import { Geometry } from 'ol/geom';
-import { HAITTOJENHALLINTATYYPPI, HankeAlue } from '../../types/hanke';
-import { HaittaIndexData } from '../../common/haittaIndexes/types';
+import { HankeAlue } from '../../types/hanke';
 
 /**
  * Add feature from hanke area to map
  * and add liikennehaittaindeksi as property
  */
-export default function useHankealueFeature(
-  source: Vector,
-  hankealue: HankeAlue,
-  tyyppi: HAITTOJENHALLINTATYYPPI | undefined | null,
-) {
+export default function useHankealueFeature(source: Vector, hankealue: HankeAlue, indeksi: number) {
   useEffect(() => {
     source.clear();
-
-    const indeksi = (tulos: HaittaIndexData | null | undefined) => {
-      if (!tulos) return null;
-      switch (tyyppi) {
-        case HAITTOJENHALLINTATYYPPI.PYORALIIKENNE:
-          return tulos.pyoraliikenneindeksi;
-        case HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE:
-          return tulos.autoliikenne.indeksi;
-        case HAITTOJENHALLINTATYYPPI.RAITIOLIIKENNE:
-          return tulos.raitioliikenneindeksi;
-        case HAITTOJENHALLINTATYYPPI.LINJAAUTOLIIKENNE:
-          return tulos.linjaautoliikenneindeksi;
-        default:
-          return null;
-      }
-    };
 
     if (hankealue.geometriat) {
       const feature = new GeoJSON().readFeatures(
@@ -40,7 +19,7 @@ export default function useHankealueFeature(
       )[0] as Feature<Geometry>;
       feature.setProperties(
         {
-          liikennehaittaindeksi: indeksi(hankealue.tormaystarkasteluTulos),
+          liikennehaittaindeksi: indeksi,
           areaName: hankealue.nimi,
         },
         true,
@@ -48,5 +27,5 @@ export default function useHankealueFeature(
       source.addFeature(feature);
       source.dispatchEvent('featuresAdded');
     }
-  }, [source, hankealue, tyyppi]);
+  }, [source, hankealue, indeksi]);
 }

--- a/src/domain/map/hooks/useHankealueFeature.ts
+++ b/src/domain/map/hooks/useHankealueFeature.ts
@@ -9,7 +9,12 @@ import { HankeAlue } from '../../types/hanke';
  * Add feature from hanke area to map
  * and add liikennehaittaindeksi as property
  */
-export default function useHankealueFeature(source: Vector, hankealue: HankeAlue) {
+export default function useHankealueFeature(
+  source: Vector,
+  hankealue: HankeAlue,
+  indeksi: number | null,
+) {
+  console.log(indeksi);
   useEffect(() => {
     source.clear();
     if (hankealue.geometriat) {
@@ -18,15 +23,17 @@ export default function useHankealueFeature(source: Vector, hankealue: HankeAlue
       )[0] as Feature<Geometry>;
       feature.setProperties(
         {
-          liikennehaittaindeksi: hankealue.tormaystarkasteluTulos
-            ? hankealue.tormaystarkasteluTulos.liikennehaittaindeksi.indeksi
-            : null,
+          // this does not work as it should:
+          liikennehaittaindeksi: indeksi,
+          // this works as it should:
+          //liikennehaittaindeksi: 3,
           areaName: hankealue.nimi,
         },
         true,
       );
+      console.log('feature', feature);
       source.addFeature(feature);
       source.dispatchEvent('featuresAdded');
     }
-  }, [source, hankealue]);
+  }, [source, hankealue, indeksi]);
 }


### PR DESCRIPTION
# Description

Color of the areas in haittojenhallintasuunnitelma are based on nuisance index.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2465

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Create or open a hanke, add some areas to it and see that the area colors are correct in haittojenhallintasuunnitelma.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
