### PR TITLE
Support arrays and numbers in locales excel export and import

### DIFF
--- a/scripts/translate-common.ts
+++ b/scripts/translate-common.ts
@@ -4,8 +4,10 @@ import _ from 'lodash';
 import sv from '../src/locales/sv.json';
 import en from '../src/locales/en.json';
 
-export type LocaleMap = { [key: string]: string | LocaleMap };
-export type ResultMap = { [key: string]: { path: string; fi: string; sv: string; en: string } };
+export type LocaleMap = { [key: string]: any };
+export type ResultMap = {
+  [key: string]: { path: string; fi: string | number; sv: string | number; en: string | number };
+};
 
 export function traverse(path: string[], source: LocaleMap, result: ResultMap) {
   for (const key in source) {
@@ -17,6 +19,38 @@ export function traverse(path: string[], source: LocaleMap, result: ResultMap) {
         sv: _.get(sv, mpath),
         en: _.get(en, mpath),
       };
+    } else if (_.isNumber(source[key])) {
+      const mpath = _.join(path, '.') + '.' + key;
+      result[mpath] = {
+        path: mpath,
+        fi: source[key] as number,
+        sv: source[key] as number,
+        en: source[key] as number,
+      };
+    } else if (_.isArray(source[key])) {
+      (source[key] as Array<any>).forEach((item, index) => {
+        if (_.isString(item)) {
+          const mpath = _.join(path, '.') + '.' + key + '.' + index.toString();
+          result[mpath] = {
+            path: mpath,
+            fi: item as string,
+            sv: _.get(sv, mpath),
+            en: _.get(en, mpath),
+          };
+        } else if (_.isNumber(item)) {
+          const mpath = _.join(path, '.') + '.' + key + '.' + index.toString();
+          result[mpath] = {
+            path: mpath,
+            fi: item,
+            sv: item,
+            en: item,
+          };
+        } else if (_.isObject(item)) {
+          traverse([...path, key, index.toString()], item, result);
+        } else {
+          throw new Error('Unkown type of ');
+        }
+      });
     } else if (_.isObject(source[key])) {
       traverse([...path, key], source[key] as LocaleMap, result);
     } else {

--- a/scripts/translate-common.ts
+++ b/scripts/translate-common.ts
@@ -9,53 +9,33 @@ export type ResultMap = {
   [key: string]: { path: string; fi: string | number; sv: string | number; en: string | number };
 };
 
-export function traverse(path: string[], source: LocaleMap, result: ResultMap) {
-  for (const key in source) {
-    if (_.isString(source[key])) {
-      const mpath = _.join(path, '.') + '.' + key;
-      result[mpath] = {
-        path: mpath,
-        fi: source[key] as string,
-        sv: _.get(sv, mpath),
-        en: _.get(en, mpath),
-      };
-    } else if (_.isNumber(source[key])) {
-      const mpath = _.join(path, '.') + '.' + key;
-      result[mpath] = {
-        path: mpath,
-        fi: source[key] as number,
-        sv: source[key] as number,
-        en: source[key] as number,
-      };
-    } else if (_.isArray(source[key])) {
-      (source[key] as Array<any>).forEach((item, index) => {
-        if (_.isString(item)) {
-          const mpath = _.join(path, '.') + '.' + key + '.' + index.toString();
-          result[mpath] = {
-            path: mpath,
-            fi: item as string,
-            sv: _.get(sv, mpath),
-            en: _.get(en, mpath),
-          };
-        } else if (_.isNumber(item)) {
-          const mpath = _.join(path, '.') + '.' + key + '.' + index.toString();
-          result[mpath] = {
-            path: mpath,
-            fi: item,
-            sv: item,
-            en: item,
-          };
-        } else if (_.isObject(item)) {
-          traverse([...path, key, index.toString()], item, result);
-        } else {
-          throw new Error('Unkown type of ');
-        }
-      });
-    } else if (_.isObject(source[key])) {
-      traverse([...path, key], source[key] as LocaleMap, result);
-    } else {
-      throw new Error('Unkown type of ');
+export function traverse(path: string[], source: any, result: ResultMap) {
+  if (_.isString(source)) {
+    const mpath = _.join(path, '.');
+    result[mpath] = {
+      path: mpath,
+      fi: source as string,
+      sv: _.get(sv, mpath),
+      en: _.get(en, mpath),
+    };
+  } else if (_.isNumber(source)) {
+    const mpath = _.join(path, '.');
+    result[mpath] = {
+      path: mpath,
+      fi: source as number,
+      sv: source as number,
+      en: source as number,
+    };
+  } else if (_.isArray(source)) {
+    (source as Array<any>).forEach((item, index) => {
+      traverse([...path, index.toString()], item, result);
+    });
+  } else if (_.isObject(source)) {
+    for (const key in source) {
+      traverse([...path, key], (source as LocaleMap)[key], result);
     }
+  } else {
+    throw new Error('Unknown type of ');
   }
 }
 

--- a/scripts/translate-excel-to-json.ts
+++ b/scripts/translate-excel-to-json.ts
@@ -18,9 +18,9 @@ function read_locales() {
 }
 
 function write_locales(result: ResultMap) {
-  fs.writeFileSync(file_fi, JSON.stringify(flatToDeep(result, 'fi'), null, 2));
-  fs.writeFileSync(file_sv, JSON.stringify(flatToDeep(result, 'sv'), null, 2));
-  fs.writeFileSync(file_en, JSON.stringify(flatToDeep(result, 'en'), null, 2));
+  fs.writeFileSync(file_fi, JSON.stringify(flatToDeep(result, 'fi'), null, 2) + '\n');
+  fs.writeFileSync(file_sv, JSON.stringify(flatToDeep(result, 'sv'), null, 2) + '\n');
+  fs.writeFileSync(file_en, JSON.stringify(flatToDeep(result, 'en'), null, 2) + '\n');
 }
 
 function run() {


### PR DESCRIPTION
# Description

Support new structures in localization Excel file export and import. Mainly these concern atm `hankeForm.haittojenhallintaForm.procedureTips` which has not just strings or objects (of strings or nested objects) but also numbers and arrays of strings and objects.

### Jira Issue:

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

* run `yarn locales:export`
* check the excel file `locale_export.xlsx` - see how `hankeForm.haittojenhallintaForm.procedureTips` is structured
* adjust some missing Swedish and/or English texts under `hankeForm.haittojenhallintaForm.procedureTips` and save the Excel file
* run `yarn locales:import`
* check modifications in `sv.json` and `en.json`

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
