### PR TITLE
HAI-2383 Nuisance control plan is not mandatory for undetected traffic nuisances

### DIFF
--- a/src/domain/forms/hooks/useValidationErrors.ts
+++ b/src/domain/forms/hooks/useValidationErrors.ts
@@ -8,12 +8,11 @@ import { cloneDeep, isEqual, uniqBy } from 'lodash';
 export function useValidationErrors<T>(schema: ObjectSchema<AnyObject>, data: T) {
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
   const ref = useRef<T | null>(null);
-
   useEffect(() => {
     if (!isEqual(ref.current, data)) {
       ref.current = cloneDeep(data);
       schema
-        .validate(data, { abortEarly: false })
+        .validate(data, { abortEarly: false, context: { hanke: data } })
         .then(() => {
           setValidationErrors([]);
         })
@@ -22,6 +21,5 @@ export function useValidationErrors<T>(schema: ObjectSchema<AnyObject>, data: T)
         });
     }
   }, [schema, data]);
-
   return validationErrors;
 }

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -283,18 +283,32 @@ describe('HankeForm', () => {
     await setupHaittojenHallintaPage();
 
     expect(screen.getByText('Yleisten haittojen hallintasuunnitelma')).toBeInTheDocument();
+    expect(screen.getByTestId('alueet.0.haittojenhallintasuunnitelma.YLEINEN')).toBeRequired();
     expect(
       screen.getByText('Pyöräliikenteelle koituvien haittojen hallintasuunnitelma'),
     ).toBeInTheDocument();
     expect(screen.getByTestId('test-PYORALIIKENNE')).toHaveTextContent('3.5');
     expect(
+      screen.getByTestId('alueet.0.haittojenhallintasuunnitelma.PYORALIIKENNE'),
+    ).toBeRequired();
+    expect(
       screen.getByText('Autoliikenteelle koituvien haittojen hallintasuunnitelma'),
     ).toBeInTheDocument();
     expect(screen.getByTestId('test-AUTOLIIKENNE')).toHaveTextContent('3');
+    expect(screen.getByTestId('alueet.0.haittojenhallintasuunnitelma.AUTOLIIKENNE')).toBeRequired();
     expect(
-      screen.getByText('Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma'),
+      screen.getByText('Joukkoliikenteen merkittävyys: Linja-autojen paikallisliikenne'),
     ).toBeInTheDocument();
-    expect(screen.getByTestId('test-LINJAAUTOLIIKENNE')).toHaveTextContent('1');
+    expect(
+      screen.getByText(
+        'Haitaton ei löytänyt tätä kohderyhmää alueelta. Voit tarvittaessa lisätä toimet haittojen hallintaan.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Lisää toimet haittojen hallintaan')).toBeInTheDocument();
+    expect(screen.queryByTestId('test-LINJAAUTOLIIKENNE')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('alueet.0.haittojenhallintasuunnitelma.LINJAAUTOLIIKENNE'),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText('Raitioliikenteelle koituvien haittojen hallintasuunnitelma'),
     ).toBeInTheDocument();
@@ -322,6 +336,21 @@ describe('HankeForm', () => {
     expect(screen.getByTestId('test-haitanKesto')).toHaveTextContent('3');
   });
 
+  test('Non-detected nuisance field is shown correctly on nuisance control plan page', async () => {
+    const { user } = await setupHaittojenHallintaPage();
+
+    await user.click(screen.getByRole('button', { name: /lisää toimet haittojen hallintaan/i }));
+
+    screen.debug(undefined, 300000);
+    expect(screen.getByTestId('test-LINJAAUTOLIIKENNE')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('alueet.0.haittojenhallintasuunnitelma.LINJAAUTOLIIKENNE'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('alueet.0.haittojenhallintasuunnitelma.LINJAAUTOLIIKENNE'),
+    ).not.toBeRequired();
+  });
+
   test('Nuisance control plan is updated correctly', async () => {
     const { user } = await setupHaittojenHallintaPage();
     let haittojenhallintasuunnitelma: HankkeenHaittojenhallintasuunnitelma;
@@ -347,10 +376,6 @@ describe('HankeForm', () => {
       updatedHaittojenhallintasuunnitelma,
     );
     await user.type(
-      screen.getByTestId('alueet.0.haittojenhallintasuunnitelma.LINJAAUTOLIIKENNE'),
-      updatedHaittojenhallintasuunnitelma,
-    );
-    await user.type(
       screen.getByTestId('alueet.0.haittojenhallintasuunnitelma.RAITIOLIIKENNE'),
       updatedHaittojenhallintasuunnitelma,
     );
@@ -373,9 +398,7 @@ describe('HankeForm', () => {
       'Autoliikenteelle koituvien haittojen hallintasuunnitelma, johon on lisätty tekstiä.',
     );
     // @ts-expect-error updatedHaittojenhallintasuunnitelma is set in the request handler above
-    expect(haittojenhallintasuunnitelma.LINJAAUTOLIIKENNE).toBe(
-      'Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma, johon on lisätty tekstiä.',
-    );
+    expect(haittojenhallintasuunnitelma.LINJAAUTOLIIKENNE).toBe('');
     // @ts-expect-error updatedHaittojenhallintasuunnitelma is set in the request handler above
     expect(haittojenhallintasuunnitelma.RAITIOLIIKENNE).toBe(
       'Raitioliikenteelle koituvien haittojen hallintasuunnitelma, johon on lisätty tekstiä.',
@@ -803,7 +826,7 @@ describe('HankeForm', () => {
 
     expect(screen.getByTestId('test-pyoraliikenneindeksi')).toHaveTextContent('3.5');
     expect(screen.getByTestId('test-autoliikenneindeksi')).toHaveTextContent('3');
-    expect(screen.getByTestId('test-linjaautoliikenneindeksi')).toHaveTextContent('1');
+    expect(screen.getByTestId('test-linjaautoliikenneindeksi')).toHaveTextContent('0');
     expect(screen.getByTestId('test-raitioliikenneindeksi')).toHaveTextContent('2');
 
     await user.click(screen.getByRole('button', { name: 'Kaistahaittojen pituus *' }));

--- a/src/domain/hanke/edit/HankeForm.tsx
+++ b/src/domain/hanke/edit/HankeForm.tsx
@@ -64,6 +64,7 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
     shouldUnregister: false,
     defaultValues: formData,
     resolver: yupResolver(hankeSchema),
+    context: { hanke: formData },
   });
 
   const {

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -1,5 +1,6 @@
 import yup from '../../../common/utils/yup';
 import {
+  CONTACT_TYYPPI,
   HAITTOJENHALLINTATYYPPI,
   HANKE_KAISTAHAITTA_KEY,
   HANKE_KAISTAPITUUSHAITTA_KEY,
@@ -9,14 +10,13 @@ import {
   HANKE_TARINAHAITTA_KEY,
   HANKE_TYOMAATYYPPI_KEY,
   HANKE_VAIHE_KEY,
-} from './../../types/hanke';
-import { CONTACT_TYYPPI } from '../../types/hanke';
+} from '../../types/hanke';
 import {
-  FORMFIELD,
   CONTACT_FORMFIELD,
-  YHTEYSHENKILO_FORMFIELD,
-  HankeDataFormState,
+  FORMFIELD,
   HANKE_PAGES,
+  HankeDataFormState,
+  YHTEYSHENKILO_FORMFIELD,
 } from './types';
 import { HaittaIndexData } from '../../common/haittaIndexes/types';
 
@@ -61,18 +61,31 @@ const muuYhteystietoSchema = yhteystietoSchema
     [CONTACT_FORMFIELD.OSASTO]: yup.string().defined(),
   });
 
-const haittojenhallintaTyyppiSchema = yup
-  .string()
-  .required()
-  .meta({ pageName: HANKE_PAGES.HAITTOJEN_HALLINTA });
-
 const haittojenhallintaSchema = yup.object({
-  [HAITTOJENHALLINTATYYPPI.YLEINEN]: haittojenhallintaTyyppiSchema,
-  [HAITTOJENHALLINTATYYPPI.PYORALIIKENNE]: haittojenhallintaTyyppiSchema,
-  [HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE]: haittojenhallintaTyyppiSchema,
-  [HAITTOJENHALLINTATYYPPI.RAITIOLIIKENNE]: haittojenhallintaTyyppiSchema,
-  [HAITTOJENHALLINTATYYPPI.LINJAAUTOLIIKENNE]: haittojenhallintaTyyppiSchema,
-  [HAITTOJENHALLINTATYYPPI.MUUT]: haittojenhallintaTyyppiSchema,
+  [HAITTOJENHALLINTATYYPPI.YLEINEN]: yup
+    .string()
+    .required()
+    .meta({ pageName: HANKE_PAGES.HAITTOJEN_HALLINTA }),
+  [HAITTOJENHALLINTATYYPPI.PYORALIIKENNE]: yup
+    .string()
+    .detectedTrafficNuisance(HAITTOJENHALLINTATYYPPI.PYORALIIKENNE)
+    .meta({ pageName: HANKE_PAGES.HAITTOJEN_HALLINTA }),
+  [HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE]: yup
+    .string()
+    .detectedTrafficNuisance(HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE)
+    .meta({ pageName: HANKE_PAGES.HAITTOJEN_HALLINTA }),
+  [HAITTOJENHALLINTATYYPPI.RAITIOLIIKENNE]: yup
+    .string()
+    .detectedTrafficNuisance(HAITTOJENHALLINTATYYPPI.RAITIOLIIKENNE)
+    .meta({ pageName: HANKE_PAGES.HAITTOJEN_HALLINTA }),
+  [HAITTOJENHALLINTATYYPPI.LINJAAUTOLIIKENNE]: yup
+    .string()
+    .detectedTrafficNuisance(HAITTOJENHALLINTATYYPPI.LINJAAUTOLIIKENNE)
+    .meta({ pageName: HANKE_PAGES.HAITTOJEN_HALLINTA }),
+  [HAITTOJENHALLINTATYYPPI.MUUT]: yup
+    .string()
+    .required()
+    .meta({ pageName: HANKE_PAGES.HAITTOJEN_HALLINTA }),
 });
 
 export const hankeAlueetSchema = yup.object({

--- a/src/domain/hanke/edit/utils.ts
+++ b/src/domain/hanke/edit/utils.ts
@@ -181,19 +181,12 @@ export function getAreaDefaultName(areas?: HankeAlueFormState[]) {
  */
 export function sortedLiikenneHaittojenhallintatyyppi(
   tormaystarkasteluTulos: HaittaIndexData | undefined,
-): [string, number][] {
+): [HAITTOJENHALLINTATYYPPI, number][] {
   const defaultOrder = Object.values(HAITTOJENHALLINTATYYPPI).filter(
     (type) => type !== HAITTOJENHALLINTATYYPPI.YLEINEN && type !== HAITTOJENHALLINTATYYPPI.MUUT,
   );
   if (!tormaystarkasteluTulos) {
-    return Object.entries(
-      defaultOrder.reduce(
-        (acc, type) => {
-          return { ...acc, [type]: 0 };
-        },
-        {} as Record<HAITTOJENHALLINTATYYPPI, number>,
-      ),
-    );
+    return defaultOrder.map((type) => [type, 0] as [HAITTOJENHALLINTATYYPPI, number]);
   }
 
   function keyOfIndexType(key: HAITTA_INDEX_TYPE): keyof HaittaIndexData {
@@ -220,12 +213,5 @@ export function sortedLiikenneHaittojenhallintatyyppi(
       return diff;
     });
 
-  return Object.entries(
-    sortedIndices.reduce(
-      (acc, item) => {
-        return { ...acc, [item.type]: item.value };
-      },
-      {} as Record<HAITTOJENHALLINTATYYPPI, number>,
-    ),
-  );
+  return sortedIndices.map((item) => [item.type, item.value] as [HAITTOJENHALLINTATYYPPI, number]);
 }

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -129,7 +129,7 @@ test('Correct information about hanke should be displayed', async () => {
   expect(screen.getAllByText('2.1.2023–24.2.2023').length).toBe(2);
   expect(screen.getByTestId('test-pyoraliikenneindeksi')).toHaveTextContent('3.5');
   expect(screen.getByTestId('test-raitioliikenneindeksi')).toHaveTextContent('2');
-  expect(screen.getByTestId('test-linjaautoliikenneindeksi')).toHaveTextContent('1');
+  expect(screen.getByTestId('test-linjaautoliikenneindeksi')).toHaveTextContent('0');
   expect(screen.getByTestId('test-autoliikenneindeksi')).toHaveTextContent('3');
   expect(screen.queryByText('11974 m²')).toBeInTheDocument();
   expect(screen.queryByText('Meluhaitta: 1: Satunnainen meluhaitta')).toBeInTheDocument();

--- a/src/domain/mocks/data/hankkeet-data.ts
+++ b/src/domain/mocks/data/hankkeet-data.ts
@@ -397,7 +397,7 @@ const hankkeet: HankeDataDraft[] = [
             kaistapituushaitta: 3,
           },
           pyoraliikenneindeksi: 3.5,
-          linjaautoliikenneindeksi: 1,
+          linjaautoliikenneindeksi: 0,
           raitioliikenneindeksi: 2,
           liikennehaittaindeksi: {
             indeksi: 3.5,
@@ -408,7 +408,7 @@ const hankkeet: HankeDataDraft[] = [
           YLEINEN: 'Yleisten haittojen hallintasuunnitelma',
           PYORALIIKENNE: 'Pyöräliikenteelle koituvien haittojen hallintasuunnitelma',
           AUTOLIIKENNE: 'Autoliikenteelle koituvien haittojen hallintasuunnitelma',
-          LINJAAUTOLIIKENNE: 'Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma',
+          LINJAAUTOLIIKENNE: '',
           RAITIOLIIKENNE: 'Raitioliikenteelle koituvien haittojen hallintasuunnitelma',
           MUUT: 'Muiden haittojen hallintasuunnitelma',
         },

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -679,6 +679,8 @@
       "instructionsGeneral": "<0><0>Varmista jalankulun turvallisuus ja esteettömyys</0><1>Varmista kulkuyhteydet kiinteistöihin</1><2>Tee yhteensovitus muiden hankkeiden ja töiden sekä niiden kiertoreittien kanssa</2><3>Ilmoita aina katujen sulkemisesta liikenteeltä Pelastuslaitokselle ja Poliisille</3><4>Tarkista aina, onko hankkeesi tai työsi erikoiskuljetusten reitillä</4><5>Tarkista vaikutukset olevaan liikennevalo-ohjaukseen (kaistajärjestelyt, ilmaisimet, valojen toimivuus)</5><6>Poikkeavat työajat</6></0>",
       "helperText": "Hankealueella tehtävät tai sovitut toimet haittojen hallitsemiseksi tai estämiseksi.",
       "subHeaderTrafficNuisanceIndex": "Hankkeellesi lasketun liikennehaittaindeksin perusteella seuraaviin vaatimuksiin tulee kiinnittää erityistä huomiota.",
+      "noNuisanceDetected": "Haitaton ei löytänyt tätä kohderyhmää alueelta. Voit tarvittaessa lisätä toimet haittojen hallintaan.",
+      "addControlPlan": "Lisää toimet haittojen hallintaan",
       "nuisanceType": {
         "PYORALIIKENNE": "Pyöräliikenteen merkittävyys",
         "AUTOLIIKENNE": "Autoliikenteen ruuhkautuminen",

--- a/src/types/yup-extensions.d.ts
+++ b/src/types/yup-extensions.d.ts
@@ -1,10 +1,12 @@
 import { Message } from 'yup';
+import { HAITTOJENHALLINTATYYPPI } from '../domain/types/hanke';
 
 declare module 'yup' {
   interface StringSchema {
     phone(message?: Message): this;
     businessId(message?: Message): this;
     uniqueEmail(): this;
+    detectedTrafficNuisance(type: HAITTOJENHALLINTATYYPPI): this;
   }
   interface CustomSchemaMetadata {
     pageName?: string | string[];


### PR DESCRIPTION
# Description

When there is no traffic nuisance detected for some traffic type in some hanke area, the nuisance control plan is not mandatory for that type.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2383

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

* Create a new or open an existing hanke
* Add some areas to it with different nuisance indexes (incl. some 0 too)
* Check Haittojenhallintasuunnitelma page
* For those areas and types where nuisance index is 0, the control plan field is hidden behind a button and is not mandatory

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
