### PR TITLE
HAI-2621 Decision download links

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -8,208 +8,221 @@ import * as applicationApi from '../utils';
 import hakemukset from '../../mocks/data/hakemukset-data';
 import { cloneDeep } from 'lodash';
 
-test('Correct information about application should be displayed', async () => {
-  render(<ApplicationViewContainer id={4} />);
-  await waitForLoadingToFinish();
+describe('Cable report application view', () => {
+  test('Correct information about application should be displayed', async () => {
+    render(<ApplicationViewContainer id={4} />);
+    await waitForLoadingToFinish();
 
-  expect(screen.getAllByText('Mannerheimintien kairaukset').length).toBe(2);
-  expect(screen.queryByText('JS2300003')).toBeInTheDocument();
-  expect(screen.queryByText('Odottaa käsittelyä')).toBeInTheDocument();
-  expect(screen.queryByText('Kaikki oikeudet')).toBeInTheDocument();
+    expect(screen.getAllByText('Mannerheimintien kairaukset').length).toBe(2);
+    expect(screen.queryByText('JS2300003')).toBeInTheDocument();
+    expect(screen.queryByText('Odottaa käsittelyä')).toBeInTheDocument();
+    expect(screen.queryByText('Kaikki oikeudet')).toBeInTheDocument();
+  });
+
+  test('Link back to related hanke should work', async () => {
+    const { user } = render(<ApplicationViewContainer id={4} />);
+    await waitForLoadingToFinish();
+
+    await user.click(screen.getByRole('link', { name: 'Mannerheimintien kaukolämpö (HAI22-3)' }));
+
+    expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-3');
+  });
+
+  test('Should show error notification if application is not found', async () => {
+    server.use(
+      rest.get('/api/hakemukset/:id', async (_, res, ctx) => {
+        return res(ctx.status(404), ctx.json({ errorMessage: 'Failed for testing purposes' }));
+      }),
+    );
+
+    render(<ApplicationViewContainer id={4} />);
+    await waitForLoadingToFinish();
+
+    expect(await screen.findByText('Hakemusta ei löytynyt')).toBeInTheDocument();
+  });
+
+  test('Should show error notification if loading application fails', async () => {
+    server.use(
+      rest.get('/api/hakemukset/:id', async (_, res, ctx) => {
+        return res(ctx.status(500), ctx.json({ errorMessage: 'Failed for testing purposes' }));
+      }),
+    );
+
+    render(<ApplicationViewContainer id={4} />);
+    await waitForLoadingToFinish();
+
+    expect(await screen.findByText('Virhe tietojen lataamisessa.')).toBeInTheDocument();
+    expect(await screen.findByText('Yritä hetken päästä uudelleen.')).toBeInTheDocument();
+  });
+
+  test('Should be able to go editing application when editing is possible', async () => {
+    const { user } = render(<ApplicationViewContainer id={1} />);
+
+    await screen.findByRole('button', { name: 'Muokkaa hakemusta' }, { timeout: 10000 });
+    await user.click(screen.getByRole('button', { name: 'Muokkaa hakemusta' }));
+
+    expect(window.location.pathname).toBe('/fi/johtoselvityshakemus/1/muokkaa');
+  });
+
+  test('Application edit button should not be displayed when editing is not possible', async () => {
+    render(<ApplicationViewContainer id={2} />);
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('button', { name: 'Muokkaa hakemusta' })).not.toBeInTheDocument();
+  });
+
+  test('Should be able to cancel application if it is possible', async () => {
+    const { user } = render(<ApplicationViewContainer id={4} />);
+    await waitForLoadingToFinish();
+
+    await screen.findByRole('button', { name: 'Peru hakemus' }, { timeout: 10000 });
+    await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
+    await user.click(screen.getByRole('button', { name: 'Vahvista' }));
+
+    expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-3');
+    await screen.findByText('Hakemus peruttiin onnistuneesti');
+    expect(screen.queryByText('Hakemus peruttiin onnistuneesti')).toBeInTheDocument();
+  });
+
+  test('Should not be able to cancel application if it has moved to handling in Allu', async () => {
+    render(<ApplicationViewContainer id={3} />);
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('button', { name: 'Peru hakemus' })).not.toBeInTheDocument();
+  });
+
+  test('Should be able to send application if it is not already sent', async () => {
+    const hakemus = cloneDeep(hakemukset[0]);
+    server.use(
+      rest.get(`/api/hakemukset/:id`, async (_, res, ctx) => {
+        return res(ctx.status(200), ctx.json(hakemus));
+      }),
+      rest.post(`/api/hakemukset/:id/laheta`, async (_, res, ctx) => {
+        hakemus.alluStatus = 'PENDING';
+        return res(ctx.status(200), ctx.json(hakemus));
+      }),
+    );
+
+    const { user } = render(<ApplicationViewContainer id={1} />);
+    await waitForLoadingToFinish();
+
+    await screen.findByRole('button', { name: 'Lähetä hakemus' });
+    const sendButton = screen.getByRole('button', { name: 'Lähetä hakemus' });
+    expect(sendButton).toBeEnabled();
+    await user.click(sendButton);
+
+    await screen.findByText('Hakemus lähetetty');
+    expect(screen.getByText('Hakemus lähetetty')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Lähetä hakemus' })).not.toBeInTheDocument();
+  });
+
+  test('Should not be able to send application if it has moved to handling in Allu', async () => {
+    render(<ApplicationViewContainer id={3} />);
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('button', { name: 'Lähetä hakemus' })).not.toBeInTheDocument();
+  });
+
+  test('Should disable Send button if user is not a contact person on application', async () => {
+    server.resetHandlers();
+    server.use(
+      rest.get('/api/hankkeet/:hankeTunnus/whoami', async (_, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json<SignedInUser>({
+            hankeKayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afb4',
+            kayttooikeustaso: 'HAKEMUSASIOINTI',
+            kayttooikeudet: ['EDIT_APPLICATIONS'],
+          }),
+        );
+      }),
+    );
+
+    render(<ApplicationViewContainer id={1} />);
+
+    await screen.findByRole('button', { name: 'Lähetä hakemus' }, { timeout: 10000 });
+    const sendButton = screen.getByRole('button', { name: 'Lähetä hakemus' });
+    expect(sendButton).toBeDisabled();
+  });
+
+  test('Should not show Edit, Cancel or Send buttons if user does not have correct permission', async () => {
+    server.resetHandlers();
+    server.use(
+      rest.get('/api/hankkeet/:hankeTunnus/whoami', async (_, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json<SignedInUser>({
+            hankeKayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            kayttooikeustaso: 'KATSELUOIKEUS',
+            kayttooikeudet: ['VIEW'],
+          }),
+        );
+      }),
+    );
+
+    render(<ApplicationViewContainer id={1} />);
+
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('button', { name: 'Muokkaa hakemusta' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Peru hakemus' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Lähetä hakemus' })).not.toBeInTheDocument();
+  });
+
+  test('Should not send multiple requests if clicking application cancel confirm button many times', async () => {
+    server.use(
+      rest.delete('/api/hakemukset/:id', async (_, res, ctx) => {
+        return res(ctx.delay(200), ctx.status(200));
+      }),
+    );
+
+    const cancelApplication = jest.spyOn(applicationApi, 'cancelApplication');
+    const { user } = render(<ApplicationViewContainer id={1} />);
+
+    await waitForLoadingToFinish();
+    await screen.findByRole('button', { name: 'Peru hakemus' });
+
+    await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
+    const confirmCancelButton = screen.getByRole('button', { name: 'Vahvista' });
+    await user.click(confirmCancelButton);
+    await user.click(confirmCancelButton);
+    await user.click(confirmCancelButton);
+    await screen.findByText('Hakemus peruttiin onnistuneesti');
+
+    expect(cancelApplication).toHaveBeenCalledTimes(1);
+
+    cancelApplication.mockRestore();
+  });
+
+  test('Should not send multiple requests if clicking Send button many times', async () => {
+    server.use(
+      rest.post('/api/hakemukset/:id/laheta', async (_, res, ctx) => {
+        return res(ctx.delay(200), ctx.status(200));
+      }),
+    );
+    const sendApplication = jest.spyOn(applicationApi, 'sendApplication');
+    const { user } = render(<ApplicationViewContainer id={1} />);
+    await waitForLoadingToFinish();
+
+    const sendButton = await screen.findByRole('button', { name: 'Lähetä hakemus' });
+    await user.click(sendButton);
+    await user.click(sendButton);
+    await user.click(sendButton);
+    await screen.findByText('Hakemus on lähetetty käsiteltäväksi.');
+
+    expect(sendApplication).toHaveBeenCalledTimes(1);
+
+    sendApplication.mockRestore();
+  });
 });
 
-test('Link back to related hanke should work', async () => {
-  const { user } = render(<ApplicationViewContainer id={4} />);
-  await waitForLoadingToFinish();
+describe('Excavation notification application view', () => {
+  test('Shows decision links if decisions are available', async () => {
+    render(<ApplicationViewContainer id={8} />);
+    await waitForLoadingToFinish();
 
-  await user.click(screen.getByRole('link', { name: 'Mannerheimintien kaukolämpö (HAI22-3)' }));
-
-  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-3');
-});
-
-test('Should show error notification if application is not found', async () => {
-  server.use(
-    rest.get('/api/hakemukset/:id', async (_, res, ctx) => {
-      return res(ctx.status(404), ctx.json({ errorMessage: 'Failed for testing purposes' }));
-    }),
-  );
-
-  render(<ApplicationViewContainer id={4} />);
-  await waitForLoadingToFinish();
-
-  expect(await screen.findByText('Hakemusta ei löytynyt')).toBeInTheDocument();
-});
-
-test('Should show error notification if loading application fails', async () => {
-  server.use(
-    rest.get('/api/hakemukset/:id', async (_, res, ctx) => {
-      return res(ctx.status(500), ctx.json({ errorMessage: 'Failed for testing purposes' }));
-    }),
-  );
-
-  render(<ApplicationViewContainer id={4} />);
-  await waitForLoadingToFinish();
-
-  expect(await screen.findByText('Virhe tietojen lataamisessa.')).toBeInTheDocument();
-  expect(await screen.findByText('Yritä hetken päästä uudelleen.')).toBeInTheDocument();
-});
-
-test('Should be able to go editing application when editing is possible', async () => {
-  const { user } = render(<ApplicationViewContainer id={1} />);
-
-  await screen.findByRole('button', { name: 'Muokkaa hakemusta' }, { timeout: 10000 });
-  await user.click(screen.getByRole('button', { name: 'Muokkaa hakemusta' }));
-
-  expect(window.location.pathname).toBe('/fi/johtoselvityshakemus/1/muokkaa');
-});
-
-test('Application edit button should not be displayed when editing is not possible', async () => {
-  render(<ApplicationViewContainer id={2} />);
-  await waitForLoadingToFinish();
-
-  expect(screen.queryByRole('button', { name: 'Muokkaa hakemusta' })).not.toBeInTheDocument();
-});
-
-test('Should be able to cancel application if it is possible', async () => {
-  const { user } = render(<ApplicationViewContainer id={4} />);
-  await waitForLoadingToFinish();
-
-  await screen.findByRole('button', { name: 'Peru hakemus' }, { timeout: 10000 });
-  await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
-  await user.click(screen.getByRole('button', { name: 'Vahvista' }));
-
-  expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-3');
-  await screen.findByText('Hakemus peruttiin onnistuneesti');
-  expect(screen.queryByText('Hakemus peruttiin onnistuneesti')).toBeInTheDocument();
-});
-
-test('Should not be able to cancel application if it has moved to handling in Allu', async () => {
-  render(<ApplicationViewContainer id={3} />);
-  await waitForLoadingToFinish();
-
-  expect(screen.queryByRole('button', { name: 'Peru hakemus' })).not.toBeInTheDocument();
-});
-
-test('Should be able to send application if it is not already sent', async () => {
-  const hakemus = cloneDeep(hakemukset[0]);
-  server.use(
-    rest.get(`/api/hakemukset/:id`, async (_, res, ctx) => {
-      return res(ctx.status(200), ctx.json(hakemus));
-    }),
-    rest.post(`/api/hakemukset/:id/laheta`, async (_, res, ctx) => {
-      hakemus.alluStatus = 'PENDING';
-      return res(ctx.status(200), ctx.json(hakemus));
-    }),
-  );
-
-  const { user } = render(<ApplicationViewContainer id={1} />);
-  await waitForLoadingToFinish();
-
-  await screen.findByRole('button', { name: 'Lähetä hakemus' });
-  const sendButton = screen.getByRole('button', { name: 'Lähetä hakemus' });
-  expect(sendButton).toBeEnabled();
-  await user.click(sendButton);
-
-  await screen.findByText('Hakemus lähetetty');
-  expect(screen.getByText('Hakemus lähetetty')).toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: 'Lähetä hakemus' })).not.toBeInTheDocument();
-});
-
-test('Should not be able to send application if it has moved to handling in Allu', async () => {
-  render(<ApplicationViewContainer id={3} />);
-  await waitForLoadingToFinish();
-
-  expect(screen.queryByRole('button', { name: 'Lähetä hakemus' })).not.toBeInTheDocument();
-});
-
-test('Should disable Send button if user is not a contact person on application', async () => {
-  server.resetHandlers();
-  server.use(
-    rest.get('/api/hankkeet/:hankeTunnus/whoami', async (_, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json<SignedInUser>({
-          hankeKayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afb4',
-          kayttooikeustaso: 'HAKEMUSASIOINTI',
-          kayttooikeudet: ['EDIT_APPLICATIONS'],
-        }),
-      );
-    }),
-  );
-
-  render(<ApplicationViewContainer id={1} />);
-
-  await screen.findByRole('button', { name: 'Lähetä hakemus' }, { timeout: 10000 });
-  const sendButton = screen.getByRole('button', { name: 'Lähetä hakemus' });
-  expect(sendButton).toBeDisabled();
-});
-
-test('Should not show Edit, Cancel or Send buttons if user does not have correct permission', async () => {
-  server.resetHandlers();
-  server.use(
-    rest.get('/api/hankkeet/:hankeTunnus/whoami', async (_, res, ctx) => {
-      return res(
-        ctx.status(200),
-        ctx.json<SignedInUser>({
-          hankeKayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-          kayttooikeustaso: 'KATSELUOIKEUS',
-          kayttooikeudet: ['VIEW'],
-        }),
-      );
-    }),
-  );
-
-  render(<ApplicationViewContainer id={1} />);
-
-  await waitForLoadingToFinish();
-
-  expect(screen.queryByRole('button', { name: 'Muokkaa hakemusta' })).not.toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: 'Peru hakemus' })).not.toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: 'Lähetä hakemus' })).not.toBeInTheDocument();
-});
-
-test('Should not send multiple requests if clicking application cancel confirm button many times', async () => {
-  server.use(
-    rest.delete('/api/hakemukset/:id', async (_, res, ctx) => {
-      return res(ctx.delay(200), ctx.status(200));
-    }),
-  );
-
-  const cancelApplication = jest.spyOn(applicationApi, 'cancelApplication');
-  const { user } = render(<ApplicationViewContainer id={1} />);
-
-  await waitForLoadingToFinish();
-  await screen.findByRole('button', { name: 'Peru hakemus' });
-
-  await user.click(screen.getByRole('button', { name: 'Peru hakemus' }));
-  const confirmCancelButton = screen.getByRole('button', { name: 'Vahvista' });
-  await user.click(confirmCancelButton);
-  await user.click(confirmCancelButton);
-  await user.click(confirmCancelButton);
-  await screen.findByText('Hakemus peruttiin onnistuneesti');
-
-  expect(cancelApplication).toHaveBeenCalledTimes(1);
-
-  cancelApplication.mockRestore();
-});
-
-test('Should not send multiple requests if clicking Send button many times', async () => {
-  server.use(
-    rest.post('/api/hakemukset/:id/laheta', async (_, res, ctx) => {
-      return res(ctx.delay(200), ctx.status(200));
-    }),
-  );
-  const sendApplication = jest.spyOn(applicationApi, 'sendApplication');
-  const { user } = render(<ApplicationViewContainer id={1} />);
-  await waitForLoadingToFinish();
-
-  const sendButton = await screen.findByRole('button', { name: 'Lähetä hakemus' });
-  await user.click(sendButton);
-  await user.click(sendButton);
-  await user.click(sendButton);
-  await screen.findByText('Hakemus on lähetetty käsiteltäväksi.');
-
-  expect(sendApplication).toHaveBeenCalledTimes(1);
-
-  sendApplication.mockRestore();
+    expect(screen.getByText('Lataa päätös (PDF)')).toBeInTheDocument();
+    expect(screen.getByText('Lataa toiminnallinen kunto (PDF)')).toBeInTheDocument();
+    expect(screen.getByText('Lataa työ valmis (PDF)')).toBeInTheDocument();
+  });
 });

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -43,7 +43,13 @@ import KaivuilmoitusBasicInformationSummary from '../components/summary/Kaivuilm
 import { getAreaGeometries, getAreaGeometry } from '../../johtoselvitys/utils';
 import { formatSurfaceArea, getTotalSurfaceArea } from '../../map/utils';
 import useLocale from '../../../common/hooks/useLocale';
-import { getAreaDefaultName, isApplicationSent, isContactIn } from '../utils';
+import {
+  getAreaDefaultName,
+  getCurrentDecisions,
+  getDecisionFilename,
+  isApplicationSent,
+  isContactIn,
+} from '../utils';
 import ApplicationDates from '../components/ApplicationDates';
 import ContactsSummary from '../components/summary/ContactsSummary';
 import OwnHankeMapHeader from '../../map/components/OwnHankeMap/OwnHankeMapHeader';
@@ -81,7 +87,8 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
   const [isSendButtonDisabled, setIsSendButtonDisabled] = useState(false);
   const locale = useLocale();
   const hankeViewPath = useHankeViewPath(application.hankeTunnus);
-  const { applicationData, applicationIdentifier, applicationType, alluStatus, id } = application;
+  const { applicationData, applicationIdentifier, applicationType, alluStatus, id, paatokset } =
+    application;
   const {
     name,
     areas,
@@ -96,7 +103,7 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
     applicationType === 'CABLE_REPORT'
       ? (areas as ApplicationArea[])
       : (areas as KaivuilmoitusAlue[]).flatMap((area) => area.tyoalueet);
-
+  const currentDecisions = getCurrentDecisions(paatokset);
   const applicationId =
     applicationIdentifier || t(`hakemus:applicationTypeDraft:${applicationType}`);
 
@@ -138,17 +145,20 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
           </SectionItemContent>
           <SectionItemTitle>{t('hakemus:labels:applicationState')}:</SectionItemTitle>
           <SectionItemContent>
-            <Box display="flex">
-              <Box as="span" mr="var(--spacing-2-xs)">
+            <Box>
+              <Box mb="var(--spacing-2-xs)">
                 <ApplicationStatusTag status={alluStatus} />
               </Box>
-              {alluStatus === AlluStatus.DECISION && (
-                <DecisionLink
-                  applicationId={id}
-                  linkText={t('hakemus:labels:downloadDecisionShort')}
-                  filename={applicationIdentifier}
-                />
-              )}
+              {alluStatus === AlluStatus.DECISION &&
+                currentDecisions.map((paatos) => (
+                  <Box key={paatos.tyyppi} mt="var(--spacing-2-xs)">
+                    <DecisionLink
+                      id={paatos.id}
+                      linkText={t(`hakemus:labels:downloadDecision:${paatos.tyyppi}`)}
+                      filename={getDecisionFilename(paatos)}
+                    />
+                  </Box>
+                ))}
             </Box>
           </SectionItemContent>
           <SectionItemTitle>{t('hakemus:labels:relatedHanke')}:</SectionItemTitle>

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -122,6 +122,10 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
   const isContact = isContactIn(signedInUser, applicationData);
   const showSendButton = !isSent && isValid;
   const disableSendButton = showSendButton && !isContact;
+  const showDecisionLinks =
+    alluStatus === AlluStatus.DECISION ||
+    alluStatus === AlluStatus.OPERATIONAL_CONDITION ||
+    alluStatus === AlluStatus.FINISHED;
 
   const applicationSendMutation = useSendApplication();
 
@@ -149,7 +153,7 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
               <Box mb="var(--spacing-2-xs)">
                 <ApplicationStatusTag status={alluStatus} />
               </Box>
-              {alluStatus === AlluStatus.DECISION &&
+              {showDecisionLinks &&
                 currentDecisions.map((paatos) => (
                   <Box key={paatos.tyyppi} mt="var(--spacing-2-xs)">
                     <DecisionLink

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -31,7 +31,6 @@ import {
 import { HankeData } from '../../types/hanke';
 import ApplicationStatusTag from '../components/ApplicationStatusTag';
 import {
-  AlluStatus,
   Application,
   ApplicationArea,
   JohtoselvitysData,
@@ -122,10 +121,6 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
   const isContact = isContactIn(signedInUser, applicationData);
   const showSendButton = !isSent && isValid;
   const disableSendButton = showSendButton && !isContact;
-  const showDecisionLinks =
-    alluStatus === AlluStatus.DECISION ||
-    alluStatus === AlluStatus.OPERATIONAL_CONDITION ||
-    alluStatus === AlluStatus.FINISHED;
 
   const applicationSendMutation = useSendApplication();
 
@@ -153,16 +148,15 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
               <Box mb="var(--spacing-2-xs)">
                 <ApplicationStatusTag status={alluStatus} />
               </Box>
-              {showDecisionLinks &&
-                currentDecisions.map((paatos) => (
-                  <Box key={paatos.tyyppi} mt="var(--spacing-2-xs)">
-                    <DecisionLink
-                      id={paatos.id}
-                      linkText={t(`hakemus:labels:downloadDecision:${paatos.tyyppi}`)}
-                      filename={getDecisionFilename(paatos)}
-                    />
-                  </Box>
-                ))}
+              {currentDecisions.map((paatos) => (
+                <Box key={paatos.tyyppi} mt="var(--spacing-2-xs)">
+                  <DecisionLink
+                    id={paatos.id}
+                    linkText={t(`hakemus:labels:downloadDecision:${paatos.tyyppi}`)}
+                    filename={getDecisionFilename(paatos)}
+                  />
+                </Box>
+              ))}
             </Box>
           </SectionItemContent>
           <SectionItemTitle>{t('hakemus:labels:relatedHanke')}:</SectionItemTitle>

--- a/src/domain/application/components/ApplicationList.test.tsx
+++ b/src/domain/application/components/ApplicationList.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '../../../testUtils/render';
+import ApplicationList from './ApplicationList';
+import { hankkeenHakemukset } from '../../mocks/data/hakemukset-data';
+
+describe('Application list', () => {
+  test('Correct information about each application should be displayed', async () => {
+    render(<ApplicationList applications={hankkeenHakemukset} />);
+
+    // application types
+    expect(screen.getAllByText('Johtoselvitys').length).toBe(3);
+    expect(screen.getAllByText('Kaivuilmoitus').length).toBe(3);
+    // application statuses
+    expect(screen.getAllByText('Luonnos').length).toBe(6); // 3 x 2 as 'Luonnos' is both the application identifier and the status of the application when it's in draft state
+    expect(screen.getAllByText('Odottaa käsittelyä').length).toBe(1);
+    expect(screen.getAllByText('Käsittelyssä').length).toBe(1);
+    expect(screen.getAllByText('Päätös').length).toBe(1);
+    // application names
+    expect(screen.getByText('Aidasmäentien viimeiset kaivuut')).toBeInTheDocument();
+    expect(screen.getByText('Aidasmäentien laajennetut kaivuut')).toBeInTheDocument();
+    expect(screen.getByText('Aidasmäentien toiset kaivuut')).toBeInTheDocument();
+    expect(screen.getByText('Mannerheimintien parantaminen')).toBeInTheDocument();
+    expect(screen.getByText('Mannerheimintien kuopat')).toBeInTheDocument();
+    expect(screen.getByText('Mannerheimintien kaivuut')).toBeInTheDocument();
+    // decisions of the single application in 'Päätös' state
+    expect(screen.getByText('Lataa päätös (PDF)')).toBeInTheDocument();
+    expect(screen.getByText('Lataa toiminnallinen kunto (PDF)')).toBeInTheDocument();
+    expect(screen.getByText('Lataa työ valmis (PDF)')).toBeInTheDocument();
+  });
+});

--- a/src/domain/application/components/ApplicationListItem.tsx
+++ b/src/domain/application/components/ApplicationListItem.tsx
@@ -10,6 +10,7 @@ import useLinkPath from '../../../common/hooks/useLinkPath';
 import { ROUTES } from '../../../common/types/route';
 import ApplicationDates from './ApplicationDates';
 import DecisionLink from './DecisionLink';
+import { getCurrentDecisions, getDecisionFilename } from '../utils';
 
 type Props = { application: HankkeenHakemus };
 
@@ -17,13 +18,16 @@ function ApplicationListItem({ application }: Readonly<Props>) {
   const { t } = useTranslation();
   const getApplicationPathView = useLinkPath(ROUTES.HAKEMUS);
 
-  const { applicationData, alluStatus, applicationIdentifier, id, applicationType } = application;
+  const { applicationData, alluStatus, applicationIdentifier, id, applicationType, paatokset } =
+    application;
   const { name, startTime, endTime } = applicationData;
 
   const applicationId =
     applicationIdentifier || t(`hakemus:applicationTypeDraft:${applicationType}`);
 
   const applicationViewPath = getApplicationPathView({ id: (id as number).toString() });
+
+  const currentDecisions = getCurrentDecisions(paatokset);
 
   return (
     <Card
@@ -55,13 +59,16 @@ function ApplicationListItem({ application }: Readonly<Props>) {
           <ApplicationDates startTime={startTime} endTime={endTime} />
           <Grid alignItems="start" templateColumns="auto 1fr" columnGap="var(--spacing-xs)">
             <ApplicationStatusTag status={alluStatus} />
-            {alluStatus === AlluStatus.DECISION && (
-              <DecisionLink
-                applicationId={id}
-                linkText={t('hakemus:labels:downloadDecision')}
-                filename={applicationIdentifier}
-              />
-            )}
+            {alluStatus === AlluStatus.DECISION &&
+              currentDecisions.map((paatos) => (
+                <Box as="span" key={paatos.tyyppi}>
+                  <DecisionLink
+                    id={paatos.id}
+                    linkText={t(`hakemus:labels:downloadDecision:${paatos.tyyppi}`)}
+                    filename={getDecisionFilename(paatos)}
+                  />
+                </Box>
+              ))}
           </Grid>
         </div>
         <Link

--- a/src/domain/application/components/ApplicationListItem.tsx
+++ b/src/domain/application/components/ApplicationListItem.tsx
@@ -28,6 +28,10 @@ function ApplicationListItem({ application }: Readonly<Props>) {
   const applicationViewPath = getApplicationPathView({ id: (id as number).toString() });
 
   const currentDecisions = getCurrentDecisions(paatokset);
+  const showDecisionLinks =
+    alluStatus === AlluStatus.DECISION ||
+    alluStatus === AlluStatus.OPERATIONAL_CONDITION ||
+    alluStatus === AlluStatus.FINISHED;
 
   return (
     <Card
@@ -59,7 +63,7 @@ function ApplicationListItem({ application }: Readonly<Props>) {
           <ApplicationDates startTime={startTime} endTime={endTime} />
           <Grid alignItems="start" templateColumns="auto 1fr" columnGap="var(--spacing-xs)">
             <ApplicationStatusTag status={alluStatus} />
-            {alluStatus === AlluStatus.DECISION &&
+            {showDecisionLinks &&
               currentDecisions.map((paatos) => (
                 <Box as="span" key={paatos.tyyppi}>
                   <DecisionLink

--- a/src/domain/application/components/ApplicationListItem.tsx
+++ b/src/domain/application/components/ApplicationListItem.tsx
@@ -2,7 +2,7 @@ import { Card, IconEye } from 'hds-react';
 import { Box, Flex, Grid } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { AlluStatus, HankkeenHakemus } from '../types/application';
+import { HankkeenHakemus } from '../types/application';
 import styles from './ApplicationListItem.module.scss';
 import Text from '../../../common/components/text/Text';
 import ApplicationStatusTag from './ApplicationStatusTag';
@@ -28,10 +28,6 @@ function ApplicationListItem({ application }: Readonly<Props>) {
   const applicationViewPath = getApplicationPathView({ id: (id as number).toString() });
 
   const currentDecisions = getCurrentDecisions(paatokset);
-  const showDecisionLinks =
-    alluStatus === AlluStatus.DECISION ||
-    alluStatus === AlluStatus.OPERATIONAL_CONDITION ||
-    alluStatus === AlluStatus.FINISHED;
 
   return (
     <Card
@@ -63,16 +59,15 @@ function ApplicationListItem({ application }: Readonly<Props>) {
           <ApplicationDates startTime={startTime} endTime={endTime} />
           <Grid alignItems="start" templateColumns="auto 1fr" columnGap="var(--spacing-xs)">
             <ApplicationStatusTag status={alluStatus} />
-            {showDecisionLinks &&
-              currentDecisions.map((paatos) => (
-                <Box as="span" key={paatos.tyyppi}>
-                  <DecisionLink
-                    id={paatos.id}
-                    linkText={t(`hakemus:labels:downloadDecision:${paatos.tyyppi}`)}
-                    filename={getDecisionFilename(paatos)}
-                  />
-                </Box>
-              ))}
+            {currentDecisions.map((paatos) => (
+              <Box as="span" key={paatos.tyyppi}>
+                <DecisionLink
+                  id={paatos.id}
+                  linkText={t(`hakemus:labels:downloadDecision:${paatos.tyyppi}`)}
+                  filename={getDecisionFilename(paatos)}
+                />
+              </Box>
+            ))}
           </Grid>
         </div>
         <Link

--- a/src/domain/application/components/DecisionLink.tsx
+++ b/src/domain/application/components/DecisionLink.tsx
@@ -1,29 +1,29 @@
 import React from 'react';
-import { IconDocument } from 'hds-react';
+import { IconDownload } from 'hds-react';
 import api from '../../api/api';
 import FileDownloadLink from '../../../common/components/fileDownloadLink/FileDownloadLink';
 
-async function getDecision(id: number | null): Promise<string> {
-  const { data } = await api.get<Blob>(`hakemukset/${id}/paatos`, { responseType: 'blob' });
+async function getDecision(id: string | null): Promise<string> {
+  const { data } = await api.get<Blob>(`/paatokset/${id}`, { responseType: 'blob' });
   return URL.createObjectURL(data);
 }
 
 type Props = {
-  applicationId: number | null;
+  id: string;
   linkText: string;
   filename: string | undefined | null;
 };
 
-function DecisionLink({ linkText, filename, applicationId }: Props) {
+function DecisionLink({ linkText, filename, id }: Props) {
   return (
     <FileDownloadLink
       linkText={linkText}
       fileName={filename}
       linkIcon={
-        <IconDocument aria-hidden size="xs" style={{ marginRight: 'var(--spacing-3-xs)' }} />
+        <IconDownload aria-hidden size="xs" style={{ marginRight: 'var(--spacing-3-xs)' }} />
       }
-      queryKey={['decision', applicationId]}
-      queryFunction={() => getDecision(applicationId)}
+      queryKey={['decision', id]}
+      queryFunction={() => getDecision(id)}
     />
   );
 }

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -206,6 +206,29 @@ export interface KaivuilmoitusData {
 
 export type NewJohtoselvitysData = yup.InferType<typeof newJohtoselvitysSchema>;
 
+export enum PaatosTyyppi {
+  PAATOS = 'PAATOS',
+  TOIMINNALLINEN_KUNTO = 'TOIMINNALLINEN_KUNTO',
+  TYO_VALMIS = 'TYO_VALMIS',
+}
+
+export enum PaatosTila {
+  NYKYINEN = 'NYKYINEN',
+  KORVATTU = 'KORVATTU',
+}
+
+export interface Paatos {
+  id: string;
+  hakemusId: number;
+  hakemustunnus: string;
+  tyyppi: PaatosTyyppi;
+  tila: PaatosTila;
+  nimi: string;
+  alkupaiva: Date;
+  loppupaiva: Date;
+  size: number;
+}
+
 export interface Application<T = JohtoselvitysData | KaivuilmoitusData> {
   id: number | null;
   alluid?: number | null;
@@ -214,6 +237,7 @@ export interface Application<T = JohtoselvitysData | KaivuilmoitusData> {
   applicationData: T;
   applicationIdentifier?: string | null;
   hankeTunnus: string | null;
+  paatokset?: { [key: string]: Paatos[] };
 }
 
 export interface HankkeenHakemus {
@@ -228,6 +252,7 @@ export interface HankkeenHakemus {
     endTime: Date | null;
     pendingOnClient: boolean;
   };
+  paatokset?: { [key: string]: Paatos[] };
 }
 
 export interface ApplicationDeletionResult {

--- a/src/domain/application/utils.test.ts
+++ b/src/domain/application/utils.test.ts
@@ -1,0 +1,59 @@
+import { getCurrentDecisions, getDecisionFilename } from './utils';
+import hakemukset from '../mocks/data/hakemukset-data';
+
+describe('getCurrentDecisions', () => {
+  test('returns all current decisions in correct order ', () => {
+    const paatokset = hakemukset[7].paatokset;
+
+    const currentDecisions = getCurrentDecisions(paatokset);
+
+    expect(currentDecisions).toEqual([
+      {
+        id: 'f4b3b3b4-4b3b-4b3b-4b3b-4b3b4b3b4b3b',
+        hakemusId: 8,
+        hakemustunnus: 'KP2400001-2',
+        tyyppi: 'TYO_VALMIS',
+        tila: 'NYKYINEN',
+        nimi: 'KI 2024-06-27',
+        alkupaiva: new Date('2024-05-28'),
+        loppupaiva: new Date('2024-05-31'),
+        size: 35764,
+      },
+      {
+        id: '59e202c4-7571-4b16-96d0-2945d689bedf',
+        hakemusId: 8,
+        hakemustunnus: 'KP2400001-2',
+        tyyppi: 'TOIMINNALLINEN_KUNTO',
+        tila: 'NYKYINEN',
+        nimi: 'KI 2024-06-27',
+        alkupaiva: new Date('2024-05-28'),
+        loppupaiva: new Date('2024-05-31'),
+        size: 35764,
+      },
+      {
+        id: '6a24e4a6-8f87-4da7-96f9-5f6b54ea6834',
+        hakemusId: 8,
+        hakemustunnus: 'KP2400001-2',
+        tyyppi: 'PAATOS',
+        tila: 'NYKYINEN',
+        nimi: 'KI 2024-06-27',
+        alkupaiva: new Date('2024-05-28'),
+        loppupaiva: new Date('2024-05-31'),
+        size: 35764,
+      },
+    ]);
+  });
+});
+
+describe('getDecisionFilename', () => {
+  test('returns correct filename for decisions', () => {
+    const paatokset = hakemukset[7].paatokset;
+    const currentDecisions = getCurrentDecisions(paatokset);
+
+    expect(getDecisionFilename(currentDecisions[0])).toEqual('KP2400001-2-tyo-valmis.pdf');
+    expect(getDecisionFilename(currentDecisions[1])).toEqual(
+      'KP2400001-2-toiminnallinen-kunto.pdf',
+    );
+    expect(getDecisionFilename(currentDecisions[2])).toEqual('KP2400001-2-paatos.pdf');
+  });
+});

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -8,6 +8,9 @@ import {
   JohtoselvitysData,
   KaivuilmoitusData,
   NewJohtoselvitysData,
+  Paatos,
+  PaatosTila,
+  PaatosTyyppi,
 } from './types/application';
 import { SignedInUser } from '../hanke/hankeUsers/hankeUser';
 
@@ -111,4 +114,23 @@ export function isContactIn(
     return found !== undefined;
   }
   return false;
+}
+
+export function getCurrentDecisions(paatokset?: { [key: string]: Paatos[] }): Paatos[] {
+  if (!paatokset) {
+    return [];
+  }
+  const allDecisions = Object.values(paatokset).flat();
+  const order = {
+    [PaatosTyyppi.TYO_VALMIS]: 1,
+    [PaatosTyyppi.TOIMINNALLINEN_KUNTO]: 2,
+    [PaatosTyyppi.PAATOS]: 3,
+  };
+  const currentOrders = allDecisions.filter((paatos) => paatos.tila === PaatosTila.NYKYINEN);
+  currentOrders.sort((a, b) => order[a.tyyppi] - order[b.tyyppi]);
+  return currentOrders;
+}
+
+export function getDecisionFilename(paatos: Paatos): string {
+  return `${paatos.hakemustunnus}-${paatos.tyyppi.toLowerCase().replace('_', '-')}.pdf`;
 }

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -209,7 +209,7 @@ test('Should render correct number of applications if they exist', async () => {
 
   await user.click(screen.getByRole('tab', { name: /hakemukset/i }));
 
-  expect(screen.getAllByTestId('application-card')).toHaveLength(5);
+  expect(screen.getAllByTestId('application-card')).toHaveLength(6);
 });
 
 test('Should show information if no applications exist', async () => {

--- a/src/domain/homepage/Homepage.test.tsx
+++ b/src/domain/homepage/Homepage.test.tsx
@@ -131,7 +131,7 @@ describe('Create johtoselvitys from dialog', () => {
     fillInformation();
     await user.click(screen.getByRole('button', { name: /luo hakemus/i }));
 
-    expect(window.location.pathname).toBe('/fi/johtoselvityshakemus/8/muokkaa');
+    expect(window.location.pathname).toBe('/fi/johtoselvityshakemus/9/muokkaa');
   });
 
   test('Should show validation errors and not create johtoselvitys if information is missing', async () => {

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -317,7 +317,7 @@ test('Save and quit works', async () => {
   await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
 
   expect(await screen.findAllByText(/hakemus tallennettu/i)).toHaveLength(2);
-  expect(window.location.pathname).toBe('/fi/hakemus/10');
+  expect(window.location.pathname).toBe('/fi/hakemus/11');
 });
 
 test('Should not save and quit if current form page is not valid', async () => {

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -231,7 +231,7 @@ test('Cable report application form can be filled and saved and sent to Allu', a
 
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
   expect(await screen.findByText(/hakemus lähetetty/i)).toBeInTheDocument();
-  expect(window.location.pathname).toBe('/fi/hakemus/8');
+  expect(window.location.pathname).toBe('/fi/hakemus/9');
 });
 
 test('Should show error message when saving fails', async () => {

--- a/src/domain/johtoselvitys/types.ts
+++ b/src/domain/johtoselvitys/types.ts
@@ -10,7 +10,7 @@ export interface JohtoselvitysFormData extends JohtoselvitysData {
   areas: JohtoselvitysArea[];
 }
 
-export interface JohtoselvitysFormValues extends Application<JohtoselvitysData> {
+export interface JohtoselvitysFormValues extends Omit<Application<JohtoselvitysData>, 'paatokset'> {
   applicationData: JohtoselvitysFormData;
   geometriesChanged?: boolean; // virtualField
   selfIntersectingPolygon?: boolean; // virtualField

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -273,7 +273,7 @@ test('Should be able fill perustiedot and save form', async () => {
   await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
 
   expect(screen.queryAllByText(/hakemus tallennettu/i).length).toBe(2);
-  expect(window.location.pathname).toBe('/fi/hakemus/8');
+  expect(window.location.pathname).toBe('/fi/hakemus/9');
 });
 
 test('Should not be able to save form if work name is missing', async () => {

--- a/src/domain/kaivuilmoitus/types.ts
+++ b/src/domain/kaivuilmoitus/types.ts
@@ -1,6 +1,6 @@
 import { Application, KaivuilmoitusData } from '../application/types/application';
 
-export interface KaivuilmoitusFormValues extends Application<KaivuilmoitusData> {
+export interface KaivuilmoitusFormValues extends Omit<Application<KaivuilmoitusData>, 'paatokset'> {
   geometriesChanged?: boolean; // virtualField
   selfIntersectingPolygon?: boolean; // virtualField
 }

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -3,6 +3,7 @@ import {
   AlluStatus,
   JohtoselvitysData,
   KaivuilmoitusData,
+  HankkeenHakemus,
 } from '../../application/types/application';
 
 const hakemukset: Application[] = [
@@ -660,6 +661,225 @@ const hakemukset: Application[] = [
       },
     },
   } as Application<KaivuilmoitusData>,
+  {
+    id: 8,
+    alluStatus: 'DECISION',
+    applicationType: 'EXCAVATION_NOTIFICATION',
+    hankeTunnus: 'HAI22-2',
+    applicationIdentifier: 'KP2400001',
+    applicationData: {
+      applicationType: 'EXCAVATION_NOTIFICATION',
+      name: 'Aidasmäentien viimeiset kaivuut',
+      startTime: new Date('2023-01-12T00:00:00Z'),
+      endTime: new Date('2024-11-12T00:00:00Z'),
+      workDescription: 'Kaivetaan Aidasmäentiellä',
+      constructionWork: true,
+      maintenanceWork: false,
+      emergencyWork: false,
+      propertyConnectivity: false,
+      rockExcavation: false,
+      cableReportDone: false,
+      requiredCompetence: true,
+      cableReports: ['JS2300002'],
+      placementContracts: ['SL1234567'],
+      areas: [
+        {
+          name: 'Hankealue 2',
+          hankealueId: 2,
+          tyoalueet: [
+            {
+              geometry: {
+                type: 'Polygon',
+                crs: {
+                  type: 'name',
+                  properties: {
+                    name: 'urn:ogc:def:crs:EPSG::3879',
+                  },
+                },
+                coordinates: [
+                  [
+                    [25498585.50387858, 6679353.862125141],
+                    [25498588.30930639, 6679372.671835153],
+                    [25498578.30073113, 6679371.404998987],
+                    [25498577.10224065, 6679355.728613365],
+                    [25498585.50387858, 6679353.862125141],
+                  ],
+                ],
+              },
+              area: 158.4294946899533,
+            },
+            {
+              geometry: {
+                type: 'Polygon',
+                crs: {
+                  type: 'name',
+                  properties: {
+                    name: 'urn:ogc:def:crs:EPSG::3879',
+                  },
+                },
+                coordinates: [
+                  [
+                    [25498581.440262634, 6679345.526261961],
+                    [25498582.233686976, 6679350.99321805],
+                    [25498576.766730886, 6679351.786642391],
+                    [25498575.973306544, 6679346.319686302],
+                    [25498581.440262634, 6679345.526261961],
+                  ],
+                ],
+              },
+              area: 30.345726208334995,
+            },
+          ],
+          katuosoite: 'Aidasmäentie 5',
+          tyonTarkoitukset: ['VESI'],
+          meluhaitta: 'TOISTUVA_MELUHAITTA',
+          polyhaitta: 'JATKUVA_POLYHAITTA',
+          tarinahaitta: 'SATUNNAINEN_TARINAHAITTA',
+          kaistahaitta: 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA',
+          kaistahaittojenPituus: 'PITUUS_10_99_METRIA',
+          lisatiedot: '',
+        },
+      ],
+      customerWithContacts: {
+        customer: {
+          type: 'COMPANY',
+          name: 'Yritys Oy',
+          country: 'FI',
+          email: 'yritys@test.com',
+          phone: '0000000000',
+          registryKey: '1164243-9',
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            email: 'matti.meikalainen@test.com',
+            firstName: 'Matti',
+            lastName: 'Meikäläinen',
+            orderer: true,
+            phone: '0401234567',
+          },
+        ],
+      },
+      contractorWithContacts: {
+        customer: {
+          type: 'COMPANY',
+          name: 'Yritys 2 Oy',
+          country: 'FI',
+          email: 'yritys2@test.com',
+          phone: '040123456',
+          registryKey: null,
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afb1',
+            email: 'tauno@test.com',
+            firstName: 'Tauno',
+            lastName: 'Testinen',
+            orderer: false,
+            phone: '0401234567',
+          },
+        ],
+      },
+      representativeWithContacts: null,
+      propertyDeveloperWithContacts: null,
+      invoicingCustomer: {
+        type: 'COMPANY',
+        name: 'Laskutus Oy',
+        registryKey: '1234567-1',
+        postalAddress: {
+          streetAddress: { streetName: 'Laskutuskuja 1' },
+          postalCode: '00100',
+          city: 'Helsinki',
+        },
+      },
+    },
+    paatokset: {
+      KP2400001: [
+        {
+          id: '4567652f-85fd-4ae1-b7f0-1694a93bddaa',
+          hakemusId: 8,
+          hakemustunnus: 'KP2400001',
+          tyyppi: 'TOIMINNALLINEN_KUNTO',
+          tila: 'KORVATTU',
+          nimi: 'KI 2024-06-27',
+          alkupaiva: new Date('2024-05-28'),
+          loppupaiva: new Date('2024-05-31'),
+          size: 35764,
+        },
+        {
+          id: '404e0300-db95-4c65-9d27-eff8930fef23',
+          hakemusId: 8,
+          hakemustunnus: 'KP2400001',
+          tyyppi: 'PAATOS',
+          tila: 'KORVATTU',
+          nimi: 'KI 2024-06-27',
+          alkupaiva: new Date('2024-05-28'),
+          loppupaiva: new Date('2024-05-31'),
+          size: 35764,
+        },
+      ],
+      'KP240001-2': [
+        {
+          id: '6a24e4a6-8f87-4da7-96f9-5f6b54ea6834',
+          hakemusId: 8,
+          hakemustunnus: 'KP2400001-2',
+          tyyppi: 'PAATOS',
+          tila: 'NYKYINEN',
+          nimi: 'KI 2024-06-27',
+          alkupaiva: new Date('2024-05-28'),
+          loppupaiva: new Date('2024-05-31'),
+          size: 35764,
+        },
+        {
+          id: '59e202c4-7571-4b16-96d0-2945d689bedf',
+          hakemusId: 8,
+          hakemustunnus: 'KP2400001-2',
+          tyyppi: 'TOIMINNALLINEN_KUNTO',
+          tila: 'NYKYINEN',
+          nimi: 'KI 2024-06-27',
+          alkupaiva: new Date('2024-05-28'),
+          loppupaiva: new Date('2024-05-31'),
+          size: 35764,
+        },
+        {
+          id: 'f4b3b3b4-4b3b-4b3b-4b3b-4b3b4b3b4b3b',
+          hakemusId: 8,
+          hakemustunnus: 'KP2400001-2',
+          tyyppi: 'TYO_VALMIS',
+          tila: 'NYKYINEN',
+          nimi: 'KI 2024-06-27',
+          alkupaiva: new Date('2024-05-28'),
+          loppupaiva: new Date('2024-05-31'),
+          size: 35764,
+        },
+      ],
+    },
+  } as Application<KaivuilmoitusData>,
 ];
 
 export default hakemukset;
+
+export const hankkeenHakemukset: HankkeenHakemus[] = hakemukset
+  .filter((hakemus) => hakemus.hankeTunnus === 'HAI22-2')
+  .map((hakemus) => {
+    return {
+      id: hakemus.id,
+      alluid: hakemus.alluid,
+      alluStatus: hakemus.alluStatus,
+      applicationIdentifier: hakemus.applicationIdentifier,
+      applicationType: hakemus.applicationType,
+      applicationData: {
+        name: hakemus.applicationData.name,
+        startTime: hakemus.applicationData.startTime,
+        endTime: hakemus.applicationData.endTime,
+        pendingOnClient: hakemus.alluStatus === AlluStatus.PENDING_CLIENT,
+      },
+      paatokset: hakemus.paatokset,
+    };
+  });

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1082,8 +1082,6 @@
       "totalSurfaceAreaLong": "Piirrettyjen työalueiden yhteenlaskettu kokonaispinta-ala:",
       "applicationState": "Hakemuksen tila",
       "relatedHanke": "Liittyy hankkeeseen",
-      "downloadDecision": "Lataa päätös (PDF)",
-      "downloadDecisionShort": "Lataa PDF",
       "addedAreas": "Lisäämäsi työalueet",
       "removeAreaTitle": "Poista työalue?",
       "removeAreaDescription": "Haluatko varmasti poistaa työalueen {{areaName}}?",
@@ -1100,7 +1098,12 @@
       "requiredCompetenceTitle": "Työhön vaadittava pätevyys",
       "requiredCompetence": "Työstä vastaavana tai asianhoitajana vakuutan, että työmaalla oleskeltaessa tai työskenneltäessä on paikalla aina ainakin yksi henkilö, jolla on voimassa Pääkaupunkiseudun katutyöt -koulutuksella saatu pätevyys (PKS-katutyökortti). Vastaan myös siitä, että kaivutyöstä vastaavalla on voimassa oleva Tieturva 1, Tieturva 2 tai PKS-katutyökortti. *",
       "additionalInformation": "Lisätietoja hakemuksesta",
-      "tyonTarkoitus": "Työn tarkoitus"
+      "tyonTarkoitus": "Työn tarkoitus",
+      "downloadDecision": {
+        "PAATOS": "Lataa päätös (PDF)",
+        "TOIMINNALLINEN_KUNTO": "Lataa toiminnallinen kunto (PDF)",
+        "TYO_VALMIS": "Lataa työ valmis (PDF)"
+      }
     },
     "notifications": {
       "saveSuccessLabel": "Hakemus tallennettu",


### PR DESCRIPTION
# Description

Add paatokset into Application (and HankkeenHakemus even though it is needed a bit later with decision history). Show download links for each current decision type in application view. Added similar code for application list view also but API does not yet provide the data for that view.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2621

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

* Create some decision(s) for a kaivuilmoitus (see e.g. https://github.com/City-of-Helsinki/haitaton-backend/pull/776 and https://github.com/City-of-Helsinki/haitaton-backend/pull/777 and https://github.com/City-of-Helsinki/haitaton-backend/pull/781)
* Open the application, there should be working download links for decision(s)

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
