### PR TITLE
HAI-2590 Change contact name field to search input in application

### DIFF
--- a/src/common/components/searchInput/SearchInput.module.scss
+++ b/src/common/components/searchInput/SearchInput.module.scss
@@ -1,0 +1,11 @@
+.searchInputInvalid > div {
+  border-color: var(--color-error) !important;
+}
+
+.errorNotification {
+  margin-top: var(--spacing-2-xs);
+
+  & div {
+    font-size: var(--fontsize-body-m) !important;
+  }
+}

--- a/src/common/components/searchInput/SearchInput.test.tsx
+++ b/src/common/components/searchInput/SearchInput.test.tsx
@@ -1,0 +1,33 @@
+import { FormProvider, useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { TextInput } from 'hds-react';
+import yup from '../../utils/yup';
+import SearchInput from './SearchInput';
+import { render, act, screen } from '../../../testUtils/render';
+
+const validationSchema = yup.object({ testField: yup.string().required() });
+
+function TestComponent() {
+  const methods = useForm({
+    defaultValues: { testField: '' },
+    resolver: yupResolver(validationSchema),
+    mode: 'onBlur',
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <SearchInput id="test-field" name="testField" label="Test field" onSubmit={() => {}} />
+      <TextInput id="other-field" label="Other field" />
+    </FormProvider>
+  );
+}
+
+test('Should show error message when input is invalid', async () => {
+  render(<TestComponent />);
+  await act(async () => {
+    screen.getByRole('combobox', { name: /test field/i }).focus();
+    screen.getByLabelText('Other field').focus();
+  });
+
+  expect(screen.getByText('Kenttä on pakollinen')).toBeInTheDocument();
+});

--- a/src/common/components/searchInput/SearchInput.tsx
+++ b/src/common/components/searchInput/SearchInput.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+import { useController } from 'react-hook-form';
+import { SearchInput as HDSSearchInput, Notification, SearchInputProps } from 'hds-react';
+import { Box } from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+import { getInputErrorText } from '../../utils/form';
+import styles from './SearchInput.module.scss';
+
+type Props = {
+  name: string;
+  id: string;
+};
+
+export default function SearchInput<T>({
+  name,
+  id,
+  ...searchInputProps
+}: Readonly<Props & SearchInputProps<T>>) {
+  const { t } = useTranslation();
+  const inputClassName = `search-input-${id}`;
+  const [inputElement] = useState(
+    () => document.querySelector(`.${inputClassName} input`) as HTMLInputElement | null,
+  );
+  console.log('inputElement', inputElement);
+  // const inputElement = document.querySelector(
+  //   `.${inputClassName} input`,
+  // ) as HTMLInputElement | null;
+  const {
+    field,
+    fieldState: { error },
+  } = useController({ name });
+  const errorText = getInputErrorText(t, error);
+
+  useEffect(() => {
+    if (inputElement) {
+      console.log('Adding event listener');
+      inputElement.addEventListener('blur', field.onBlur);
+      field.ref(inputElement);
+    }
+
+    return function cleanup() {
+      if (inputElement) {
+        console.log('Removing event listener');
+        inputElement.removeEventListener('blur', field.onBlur);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputElement]);
+
+  return (
+    <Box>
+      <HDSSearchInput
+        {...searchInputProps}
+        onChange={field.onChange}
+        value={field.value}
+        clearButtonAriaLabel={t('common:components:multiselect:clear')}
+        className={clsx(inputClassName, {
+          [styles.searchInputInvalid]: errorText !== undefined,
+        })}
+      />
+      {errorText !== undefined && (
+        <Notification
+          type="error"
+          label={t('form:validations:defined')}
+          size="small"
+          className={styles.errorNotification}
+        >
+          {errorText}
+        </Notification>
+      )}
+    </Box>
+  );
+  // return (
+  //   <Controller
+  //     name={name}
+  //     render={({ field, fieldState: { error } }) => {
+  //       // Pitäisikö laittaa useEffectiin, että voisi removeEventListenerin?
+  //       // Pitäisi varmaan käyttää useControlleria, jotta voisi tehdä sen.
+  //       if (inputElement && !inputRegistered.current) {
+  //         inputElement.addEventListener('blur', field.onBlur);
+  //         field.ref(inputElement);
+  //         inputRegistered.current = true;
+  //       }
+
+  //       const errorText = getInputErrorText(t, error);
+
+  //       return (
+  //         <Box>
+  //           <HDSSearchInput
+  //             {...searchInputProps}
+  //             onChange={field.onChange}
+  //             value={field.value}
+  //             clearButtonAriaLabel={t('common:components:multiselect:clear')}
+  //             className={clsx(inputClassName, {
+  //               [styles.searchInputInvalid]: errorText !== undefined,
+  //             })}
+  //           />
+  //           {errorText !== undefined && (
+  //             <Notification
+  //               type="error"
+  //               label={t('form:validations:defined')}
+  //               size="small"
+  //               className={styles.errorNotification}
+  //             >
+  //               {errorText}
+  //             </Notification>
+  //           )}
+  //         </Box>
+  //       );
+  //     }}
+  //   />
+  // );
+}

--- a/src/common/components/searchInput/SearchInput.tsx
+++ b/src/common/components/searchInput/SearchInput.tsx
@@ -8,24 +8,18 @@ import { getInputErrorText } from '../../utils/form';
 import styles from './SearchInput.module.scss';
 
 type Props = {
-  name: string;
   id: string;
+  name: string;
 };
 
 export default function SearchInput<T>({
-  name,
   id,
+  name,
   ...searchInputProps
 }: Readonly<Props & SearchInputProps<T>>) {
   const { t } = useTranslation();
   const inputClassName = `search-input-${id}`;
-  const [inputElement] = useState(
-    () => document.querySelector(`.${inputClassName} input`) as HTMLInputElement | null,
-  );
-  console.log('inputElement', inputElement);
-  // const inputElement = document.querySelector(
-  //   `.${inputClassName} input`,
-  // ) as HTMLInputElement | null;
+  const [inputElement, setInputElement] = useState<HTMLInputElement | null>(null);
   const {
     field,
     fieldState: { error },
@@ -33,15 +27,17 @@ export default function SearchInput<T>({
   const errorText = getInputErrorText(t, error);
 
   useEffect(() => {
+    setInputElement(document.querySelector(`.${inputClassName} input`) as HTMLInputElement);
+  }, [inputClassName]);
+
+  useEffect(() => {
     if (inputElement) {
-      console.log('Adding event listener');
       inputElement.addEventListener('blur', field.onBlur);
       field.ref(inputElement);
     }
 
     return function cleanup() {
       if (inputElement) {
-        console.log('Removing event listener');
         inputElement.removeEventListener('blur', field.onBlur);
       }
     };
@@ -62,7 +58,7 @@ export default function SearchInput<T>({
       {errorText !== undefined && (
         <Notification
           type="error"
-          label={t('form:validations:defined')}
+          label={t('form:validations:default')}
           size="small"
           className={styles.errorNotification}
         >
@@ -71,44 +67,4 @@ export default function SearchInput<T>({
       )}
     </Box>
   );
-  // return (
-  //   <Controller
-  //     name={name}
-  //     render={({ field, fieldState: { error } }) => {
-  //       // Pitäisikö laittaa useEffectiin, että voisi removeEventListenerin?
-  //       // Pitäisi varmaan käyttää useControlleria, jotta voisi tehdä sen.
-  //       if (inputElement && !inputRegistered.current) {
-  //         inputElement.addEventListener('blur', field.onBlur);
-  //         field.ref(inputElement);
-  //         inputRegistered.current = true;
-  //       }
-
-  //       const errorText = getInputErrorText(t, error);
-
-  //       return (
-  //         <Box>
-  //           <HDSSearchInput
-  //             {...searchInputProps}
-  //             onChange={field.onChange}
-  //             value={field.value}
-  //             clearButtonAriaLabel={t('common:components:multiselect:clear')}
-  //             className={clsx(inputClassName, {
-  //               [styles.searchInputInvalid]: errorText !== undefined,
-  //             })}
-  //           />
-  //           {errorText !== undefined && (
-  //             <Notification
-  //               type="error"
-  //               label={t('form:validations:defined')}
-  //               size="small"
-  //               className={styles.errorNotification}
-  //             >
-  //               {errorText}
-  //             </Notification>
-  //           )}
-  //         </Box>
-  //       );
-  //     }}
-  //   />
-  // );
 }

--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -20,6 +20,7 @@ import FormContact from '../../forms/components/FormContact';
 import { HankeUser } from '../../hanke/hankeUsers/hankeUser';
 import { useHankeUsers } from '../../hanke/hankeUsers/hooks/useHankeUsers';
 import { mapHankeUserToContact } from '../../hanke/hankeUsers/utils';
+import UserSearchInput from '../../hanke/hankeUsers/UserSearchInput';
 
 function getEmptyCustomerWithContacts(): CustomerWithContacts {
   return {
@@ -38,7 +39,7 @@ function getEmptyCustomerWithContacts(): CustomerWithContacts {
 const CustomerFields: React.FC<{
   customerType: CustomerType;
   hankeUsers?: HankeUser[];
-}> = ({ customerType }) => {
+}> = ({ customerType, hankeUsers }) => {
   const { t } = useTranslation();
   const { watch, setValue } = useFormContext<Application>();
 
@@ -64,6 +65,15 @@ const CustomerFields: React.FC<{
       });
     }
   }, [registryKey, customerType, setValue]);
+
+  function handleUserSelect(user: HankeUser) {
+    setValue(`applicationData.${customerType}.customer.email`, user.sahkoposti, {
+      shouldValidate: true,
+    });
+    setValue(`applicationData.${customerType}.customer.phone`, user.puhelinnumero, {
+      shouldValidate: true,
+    });
+  }
 
   return (
     <Fieldset
@@ -94,11 +104,12 @@ const CustomerFields: React.FC<{
         />
       </ResponsiveGrid>
       <ResponsiveGrid maxColumns={2}>
-        <TextInput
-          name={`applicationData.${customerType}.customer.name`}
-          label={t('form:yhteystiedot:labels:nimi')}
+        <UserSearchInput
+          fieldName={`applicationData.${customerType}.customer.name`}
+          customerType={customerType}
           required
-          autoComplete={selectedContactType === 'PERSON' ? 'name' : 'organization'}
+          hankeUsers={hankeUsers}
+          onUserSelect={handleUserSelect}
         />
         <TextInput
           name={`applicationData.${customerType}.customer.registryKey`}

--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -106,7 +106,7 @@ const CustomerFields: React.FC<{
       <ResponsiveGrid maxColumns={2}>
         <UserSearchInput
           fieldName={`applicationData.${customerType}.customer.name`}
-          customerType={customerType}
+          id={customerType}
           required
           hankeUsers={hankeUsers}
           onUserSelect={handleUserSelect}

--- a/src/domain/hanke/hankeUsers/UserSearchInput.tsx
+++ b/src/domain/hanke/hankeUsers/UserSearchInput.tsx
@@ -1,0 +1,66 @@
+import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Box, Flex } from '@chakra-ui/react';
+import SearchInput from '../../../common/components/searchInput/SearchInput';
+import { HankeUser } from './hankeUser';
+import { CustomerType } from '../../application/types/application';
+
+type Props = {
+  fieldName: string;
+  customerType: CustomerType;
+  onUserSelect: (user: HankeUser) => void;
+  hankeUsers?: HankeUser[];
+  required?: boolean;
+};
+
+export default function UserSearchInput({
+  fieldName,
+  customerType,
+  onUserSelect,
+  hankeUsers,
+  required,
+}: Readonly<Props>) {
+  const { t } = useTranslation();
+  const suggestions = useRef([] as (HankeUser & { label: string })[]);
+
+  async function getSuggestions(searchString: string) {
+    const suggestionsItems =
+      hankeUsers
+        ?.map((user) => ({
+          ...user,
+          label: `${user.etunimi} ${user.sukunimi}`,
+        }))
+        .filter((user) => user.label.toLowerCase().includes(searchString.toLowerCase())) ?? [];
+    suggestions.current = suggestionsItems;
+    return suggestionsItems;
+  }
+
+  function handleSubmit(value: string) {
+    const user = suggestions.current.find((suggestion) => suggestion.label === value);
+    if (user) {
+      onUserSelect(user);
+    }
+  }
+
+  return (
+    <SearchInput
+      name={fieldName}
+      id={customerType}
+      label={
+        <Flex alignItems="flex-end">
+          {t('form:yhteystiedot:labels:nimi')}
+          {required ? (
+            <Box ml="var(--spacing-2-xs)" fontSize="var(--fontsize-body-xl)" lineHeight={1}>
+              *
+            </Box>
+          ) : null}
+        </Flex>
+      }
+      suggestionKeyField="id"
+      suggestionLabelField="label"
+      hideSearchButton
+      getSuggestions={getSuggestions}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/src/domain/hanke/hankeUsers/UserSearchInput.tsx
+++ b/src/domain/hanke/hankeUsers/UserSearchInput.tsx
@@ -3,11 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { Box, Flex } from '@chakra-ui/react';
 import SearchInput from '../../../common/components/searchInput/SearchInput';
 import { HankeUser } from './hankeUser';
-import { CustomerType } from '../../application/types/application';
 
 type Props = {
   fieldName: string;
-  customerType: CustomerType;
+  id: string;
   onUserSelect: (user: HankeUser) => void;
   hankeUsers?: HankeUser[];
   required?: boolean;
@@ -15,7 +14,7 @@ type Props = {
 
 export default function UserSearchInput({
   fieldName,
-  customerType,
+  id,
   onUserSelect,
   hankeUsers,
   required,
@@ -45,7 +44,7 @@ export default function UserSearchInput({
   return (
     <SearchInput
       name={fieldName}
-      id={customerType}
+      id={id}
       label={
         <Flex alignItems="flex-end">
           {t('form:yhteystiedot:labels:nimi')}

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -144,7 +144,7 @@ function fillContactsInformation() {
   // Fill customer info
   fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
   fireEvent.click(screen.getAllByText(/yritys/i)[0]);
-  fireEvent.change(screen.getByTestId('applicationData.customerWithContacts.customer.name'), {
+  fireEvent.change(screen.getAllByRole('combobox', { name: /nimi/i })[0], {
     target: { value: 'Yritys Oy' },
   });
   fireEvent.change(
@@ -163,7 +163,7 @@ function fillContactsInformation() {
   // Fill contractor info
   fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
   fireEvent.click(screen.getAllByText(/yritys/i)[1]);
-  fireEvent.change(screen.getByTestId('applicationData.contractorWithContacts.customer.name'), {
+  fireEvent.change(screen.getAllByRole('combobox', { name: /nimi/i })[1], {
     target: { value: 'Yritys 2 Oy' },
   });
   fireEvent.change(

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -897,10 +897,10 @@ test('Should be able to fill user email and phone by selecting existing user in 
   const { user } = render(
     <KaivuilmoitusContainer hankeData={hankeData} application={application} />,
   );
-  await user.click(await screen.findByRole('button', { name: /yhteistiedot/i }));
+  await user.click(await screen.findByRole('button', { name: /yhteystiedot/i }));
   await user.type(screen.getAllByRole('combobox', { name: /nimi/i })[0], 'matti');
-  await screen.findByText('Matti Meikäläinen (matti.meikalainen@test.com)');
-  await user.click(screen.getByText('Matti Meikäläinen (matti.meikalainen@test.com)'));
+  await screen.findByText('Matti Meikäläinen');
+  await user.click(screen.getByText('Matti Meikäläinen'));
 
   expect(screen.getByTestId('applicationData.customerWithContacts.customer.email')).toHaveValue(
     'matti.meikalainen@test.com',

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -190,7 +190,7 @@ function fillContactsInformation(
   // Fill customer info
   fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
   fireEvent.click(screen.getAllByText(/yritys/i)[0]);
-  fireEvent.change(screen.getByTestId('applicationData.customerWithContacts.customer.name'), {
+  fireEvent.change(screen.getAllByRole('combobox', { name: /nimi/i })[0], {
     target: { value: customer.name },
   });
   fireEvent.change(
@@ -209,7 +209,7 @@ function fillContactsInformation(
   // Fill contractor info
   fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
   fireEvent.click(screen.getAllByText(/yritys/i)[1]);
-  fireEvent.change(screen.getByTestId('applicationData.contractorWithContacts.customer.name'), {
+  fireEvent.change(screen.getAllByRole('combobox', { name: /nimi/i })[1], {
     target: { value: contractor.name },
   });
   fireEvent.change(
@@ -889,4 +889,23 @@ test('Should show and disable send button and show notification when user is not
       'Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö.',
     ),
   ).toHaveLength(2);
+});
+
+test('Should be able to fill user email and phone by selecting existing user in user name search input', async () => {
+  const hankeData = hankkeet[1] as HankeData;
+  const application = applications[4] as Application<KaivuilmoitusData>;
+  const { user } = render(
+    <KaivuilmoitusContainer hankeData={hankeData} application={application} />,
+  );
+  await user.click(await screen.findByRole('button', { name: /yhteistiedot/i }));
+  await user.type(screen.getAllByRole('combobox', { name: /nimi/i })[0], 'matti');
+  await screen.findByText('Matti Meikäläinen (matti.meikalainen@test.com)');
+  await user.click(screen.getByText('Matti Meikäläinen (matti.meikalainen@test.com)'));
+
+  expect(screen.getByTestId('applicationData.customerWithContacts.customer.email')).toHaveValue(
+    'matti.meikalainen@test.com',
+  );
+  expect(screen.getByTestId('applicationData.customerWithContacts.customer.phone')).toHaveValue(
+    '0401234567',
+  );
 });


### PR DESCRIPTION
# Description

Replaced contact name field in johtoselvitys and kaivuilmoitus form contacts page with search input to allow user to select existing hanke user as they are typing the name. Selecting existing user fills email and phone fields for that contact.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2590

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create or modify existing johtoselvitys or kaivuilmoitus and go to the contacts page
2. Start typing to the name field of for example "Työstä vastaava"
3. Suggestions of existing hanke users should be displayed if their name matches the input value
4. Try selecting a suggestion
5. Email and phone should be filled for that user

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
