### PR TITLE
HAI-2511 Change contact name field to search input in hanke form

### DIFF
--- a/src/common/components/searchInput/SearchInput.tsx
+++ b/src/common/components/searchInput/SearchInput.tsx
@@ -34,6 +34,7 @@ export default function SearchInput<T>({
     if (inputElement) {
       inputElement.addEventListener('blur', field.onBlur);
       field.ref(inputElement);
+      inputElement.setAttribute('id', name);
     }
 
     return function cleanup() {

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -24,6 +24,7 @@ import { HankeUser } from '../hankeUsers/hankeUser';
 import { useQueryClient } from 'react-query';
 import { mapHankeUserToHankeYhteyshenkilo } from '../hankeUsers/utils';
 import { Box } from '@chakra-ui/react';
+import UserSearchInput from '../hankeUsers/UserSearchInput';
 
 function getEmptyContact(): Omit<HankeYhteystieto, 'id'> {
   return {
@@ -58,7 +59,7 @@ const ContactFields: React.FC<
     index: number;
     hankeUsers?: HankeUser[];
   }>
-> = ({ contactType, index }) => {
+> = ({ contactType, index, hankeUsers }) => {
   const { t } = useTranslation();
   const { watch, setValue } = useFormContext();
   const selectedContactType = watch(`${contactType}.${index}.tyyppi`);
@@ -71,6 +72,15 @@ const ContactFields: React.FC<
       });
     }
   }, [registryKeyInputDisabled, contactType, index, setValue]);
+
+  function handleUserSelect(user: HankeUser) {
+    setValue(`${contactType}.${index}.${CONTACT_FORMFIELD.EMAIL}`, user.sahkoposti, {
+      shouldValidate: true,
+    });
+    setValue(`${contactType}.${index}.${CONTACT_FORMFIELD.PUHELINNUMERO}`, user.puhelinnumero, {
+      shouldValidate: true,
+    });
+  }
 
   return (
     <Box maxWidth="var(--width-form-2-col)">
@@ -90,10 +100,12 @@ const ContactFields: React.FC<
         />
       </ResponsiveGrid>
       <ResponsiveGrid maxColumns={2}>
-        <TextInput
-          name={`${contactType}.${index}.${CONTACT_FORMFIELD.NIMI}`}
-          label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.NIMI}`)}
+        <UserSearchInput
+          fieldName={`${contactType}.${index}.${CONTACT_FORMFIELD.NIMI}`}
+          id={`${contactType}-${index}`}
           required
+          hankeUsers={hankeUsers}
+          onUserSelect={handleUserSelect}
         />
         <TextInput
           name={`${contactType}.${index}.${CONTACT_FORMFIELD.TUNNUS}`}
@@ -178,6 +190,19 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
     );
 
     void queryClient.invalidateQueries(['hankeUsers', hanke.hankeTunnus]);
+  }
+
+  function handleMuuTahoUserSelect(user: HankeUser, index: number) {
+    setValue(`${FORMFIELD.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.EMAIL}`, user.sahkoposti, {
+      shouldValidate: true,
+    });
+    setValue(
+      `${FORMFIELD.MUUTTAHOT}.${index}.${CONTACT_FORMFIELD.PUHELINNUMERO}`,
+      user.puhelinnumero,
+      {
+        shouldValidate: true,
+      },
+    );
   }
 
   return (
@@ -364,10 +389,12 @@ const HankeFormYhteystiedot: React.FC<Readonly<FormProps>> = ({ hanke }) => {
                   />
                 </ResponsiveGrid>
                 <ResponsiveGrid>
-                  <TextInput
-                    name={`${fieldPath}.${CONTACT_FORMFIELD.NIMI}`}
-                    label={t(`form:yhteystiedot:labels:${CONTACT_FORMFIELD.NIMI}`)}
+                  <UserSearchInput
+                    fieldName={`${fieldPath}.${CONTACT_FORMFIELD.NIMI}`}
+                    id={`${HANKE_CONTACT_TYPE.MUUTTAHOT}-${index}`}
                     required
+                    hankeUsers={hankeUsers}
+                    onUserSelect={(user) => handleMuuTahoUserSelect(user, index)}
                   />
                   <TextInput
                     name={`${fieldPath}.${CONTACT_FORMFIELD.ORGANISAATIO}`}


### PR DESCRIPTION
# Description

Replaced contact name field in hanke form contacts page with search input to allow user to select existing hanke user as they are typing the name. Selecting existing user fills email and phone fields for that contact.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2511

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create or modify existing hanke and go to the contacts page
2. Start typing to the name field of for example "Hankkeen omistaja"
3. Suggestions of existing hanke users should be displayed if their name matches the input value
4. Try selecting a suggestion
5. Email and phone should be filled for that user

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
