### PR TITLE
HAI-2557 Report kaivuilmoitus in operational condition

### DIFF
--- a/src/common/utils/yup.ts
+++ b/src/common/utils/yup.ts
@@ -4,6 +4,9 @@ import isValidBusinessId from '../../common/utils/isValidBusinessId';
 import { HankeUser } from '../../domain/hanke/hankeUsers/hankeUser';
 import { HAITTOJENHALLINTATYYPPI } from '../../domain/types/hanke';
 import { HankeDataFormState } from '../../domain/hanke/edit/types';
+import { Application } from '../../domain/application/types/application';
+import { format } from 'date-fns/format';
+import { fi } from 'date-fns/locale';
 
 // https://github.com/jquense/yup/blob/master/src/locale.ts
 yup.setLocale({
@@ -136,6 +139,60 @@ yup.addMethod(
         return true;
       },
     );
+  },
+);
+
+yup.addMethod(
+  yup.date,
+  'validOperationalConditionDate',
+  function isValidOperationalConditionDate() {
+    return this.test('validOperationalConditionDate', 'Invalid date', function (value) {
+      if (!value) {
+        return true;
+      }
+      const context = this.options.context;
+      if (!context) {
+        return true;
+      }
+      const { application, dateBeforeStartErrorMessageKey, dateInFutureErrorMessageKey } =
+        context as {
+          application: Application;
+          dateBeforeStartErrorMessageKey: string;
+          dateInFutureErrorMessageKey: string;
+        };
+      if (!application) {
+        return true;
+      }
+      if (!application.applicationData.startTime) {
+        return true;
+      }
+      const date = new Date(value);
+      date.setHours(0, 0, 0, 0);
+      const startDate = new Date(application.applicationData.startTime);
+      startDate.setHours(0, 0, 0, 0);
+      let isValid = date >= startDate;
+      if (!isValid) {
+        return this.createError({
+          path: this.path,
+          message: {
+            key: dateBeforeStartErrorMessageKey,
+            values: {
+              startDate: format(startDate, 'd.M.yyyy', { locale: fi }),
+            },
+          },
+        });
+      }
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      isValid = date <= today;
+      return (
+        isValid ||
+        this.createError({
+          path: this.path,
+          message: { key: dateInFutureErrorMessageKey, values: {} },
+        })
+      );
+    });
   },
 );
 

--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -266,6 +266,11 @@ describe('Excavation announcement application view', () => {
     });
 
     describe('Report in operational condition confirmation dialog', () => {
+      afterEach(() => {
+        jest.restoreAllMocks();
+        jest.clearAllMocks();
+      });
+
       test('Shows previous operational condition reports in confirmation dialog', async () => {
         const user = await setup();
 
@@ -281,7 +286,10 @@ describe('Excavation announcement application view', () => {
             exact: false,
           }),
         ).toBeInTheDocument();
-        expect(screen.getByText('1.8.2024 18:15 päivämäärälle 1.8.2024')).toBeInTheDocument();
+        const reportedDate = new Date('2024-08-01T15:15:00.000Z');
+        expect(
+          screen.getByText(`1.8.2024 ${format(reportedDate, 'HH:mm')} päivämäärälle 1.8.2024`),
+        ).toBeInTheDocument();
       });
 
       test('Confirm button is disabled until a valid date is entered', async () => {
@@ -351,6 +359,7 @@ describe('Excavation announcement application view', () => {
       });
 
       test('Confirms the report', async () => {
+        const sendApplication = jest.spyOn(applicationApi, 'reportOperationalCondition');
         const user = await setup();
 
         const button = await screen.findByRole('button', {
@@ -366,6 +375,9 @@ describe('Excavation announcement application view', () => {
         await user.click(confirmButton);
 
         expect(await screen.findByText('Ilmoitus lähetetty')).toBeInTheDocument();
+        expect(sendApplication).toHaveBeenCalledTimes(1);
+        const reportedDate = sendApplication.mock.lastCall?.[0].date as Date;
+        expect(format(reportedDate, 'd.M.yyyy')).toBe(validDate);
       });
 
       test('Cancels the report', async () => {

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -371,7 +371,7 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
         <ApplicationReportOperationalConditionDialog
           isOpen={showReportOperationalConditionDialog}
           onClose={closeReportOperationalConditionDialog}
-          application={application}
+          applicationId={application.id as number}
         />
       )}
     </InformationViewContainer>

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -1,6 +1,7 @@
 import {
   Accordion,
   Button,
+  IconCheck,
   IconEnvelope,
   IconPen,
   IconTrash,
@@ -46,6 +47,7 @@ import {
   getAreaDefaultName,
   getCurrentDecisions,
   getDecisionFilename,
+  isApplicationReportableInOperationalCondition,
   isApplicationSent,
   isContactIn,
 } from '../utils';
@@ -68,6 +70,7 @@ import { SignedInUser } from '../../hanke/hankeUsers/hankeUser';
 import useSendApplication from '../hooks/useSendApplication';
 import { validationSchema as johtoselvitysValidationSchema } from '../../johtoselvitys/validationSchema';
 import { validationSchema as kaivuilmoitusValidationSchema } from '../../kaivuilmoitus/validationSchema';
+import ApplicationReportOperationalConditionDialog from '../../kaivuilmoitus/components/ApplicationReportOperationalConditionDialog';
 
 const validationSchemas = {
   CABLE_REPORT: johtoselvitysValidationSchema,
@@ -84,6 +87,8 @@ type Props = {
 function ApplicationView({ application, hanke, signedInUser, onEditApplication }: Readonly<Props>) {
   const { t } = useTranslation();
   const [isSendButtonDisabled, setIsSendButtonDisabled] = useState(false);
+  const [showReportOperationalConditionDialog, setShowReportOperationalConditionDialog] =
+    useState(false);
   const locale = useLocale();
   const hankeViewPath = useHankeViewPath(application.hankeTunnus);
   const { applicationData, applicationIdentifier, applicationType, alluStatus, id, paatokset } =
@@ -121,12 +126,23 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
   const isContact = isContactIn(signedInUser, applicationData);
   const showSendButton = !isSent && isValid;
   const disableSendButton = showSendButton && !isContact;
-
+  const showReportOperationalConditionButton = isApplicationReportableInOperationalCondition(
+    applicationType,
+    alluStatus,
+  );
   const applicationSendMutation = useSendApplication();
 
   async function onSendApplication() {
     setIsSendButtonDisabled(true);
     applicationSendMutation.mutate(id as number);
+  }
+
+  function openReportOperationalConditionDialog() {
+    setShowReportOperationalConditionDialog(true);
+  }
+
+  function closeReportOperationalConditionDialog() {
+    setShowReportOperationalConditionDialog(false);
   }
 
   return (
@@ -215,6 +231,17 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
               >
                 {t('hakemus:notifications:sendApplicationDisabled')}
               </Notification>
+            </CheckRightsByHanke>
+          )}
+          {showReportOperationalConditionButton && (
+            <CheckRightsByHanke requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>
+              <Button
+                theme="coat"
+                iconLeft={<IconCheck aria-hidden="true" />}
+                onClick={openReportOperationalConditionDialog}
+              >
+                {t('hakemus:buttons:reportOperationalCondition')}
+              </Button>
             </CheckRightsByHanke>
           )}
         </InformationViewHeaderButtons>
@@ -340,6 +367,13 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
           )}
         </InformationViewSidebar>
       </InformationViewContentContainer>
+      {applicationType === 'EXCAVATION_NOTIFICATION' && (
+        <ApplicationReportOperationalConditionDialog
+          isOpen={showReportOperationalConditionDialog}
+          onClose={closeReportOperationalConditionDialog}
+          application={application}
+        />
+      )}
     </InformationViewContainer>
   );
 }

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -230,10 +230,10 @@ export interface Paatos {
   size: number;
 }
 
-export type IlmoitusType = 'TOIMINNALLINEN_KUNTO' | 'TYO_VALMIS';
+export type ValmistumisilmoitusType = 'TOIMINNALLINEN_KUNTO' | 'TYO_VALMIS';
 
-export interface Ilmoitus {
-  type: IlmoitusType;
+export interface Valmistumisilmoitus {
+  type: ValmistumisilmoitusType;
   dateReported: Date;
   reportedAt: Date;
 }
@@ -247,7 +247,7 @@ export interface Application<T = JohtoselvitysData | KaivuilmoitusData> {
   applicationIdentifier?: string | null;
   hankeTunnus: string | null;
   paatokset?: { [key: string]: Paatos[] };
-  ilmoitukset?: { [key in IlmoitusType]?: Ilmoitus[] } | null;
+  valmistumisilmoitukset?: { [key in ValmistumisilmoitusType]?: Valmistumisilmoitus[] } | null;
 }
 
 export interface HankkeenHakemus {

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -16,6 +16,7 @@ import { Feature } from 'ol';
 import { Geometry, Polygon as OlPolygon } from 'ol/geom';
 import { getSurfaceArea } from '../../../common/components/map/utils';
 import { HaittaIndexData } from '../../common/haittaIndexes/types';
+import { reportOperationalConditionSchema } from '../../kaivuilmoitus/validationSchema';
 
 export type ApplicationType = 'CABLE_REPORT' | 'EXCAVATION_NOTIFICATION';
 
@@ -229,6 +230,14 @@ export interface Paatos {
   size: number;
 }
 
+export type IlmoitusType = 'TOIMINNALLINEN_KUNTO' | 'TYO_VALMIS';
+
+export interface Ilmoitus {
+  type: IlmoitusType;
+  dateReported: Date;
+  reportedAt: Date;
+}
+
 export interface Application<T = JohtoselvitysData | KaivuilmoitusData> {
   id: number | null;
   alluid?: number | null;
@@ -238,6 +247,7 @@ export interface Application<T = JohtoselvitysData | KaivuilmoitusData> {
   applicationIdentifier?: string | null;
   hankeTunnus: string | null;
   paatokset?: { [key: string]: Paatos[] };
+  ilmoitukset?: { [key in IlmoitusType]?: Ilmoitus[] } | null;
 }
 
 export interface HankkeenHakemus {
@@ -348,3 +358,5 @@ export interface KaivuilmoitusUpdateData
   representativeWithContacts?: ApplicationUpdateCustomerWithContacts | null;
   propertyDeveloperWithContacts?: ApplicationUpdateCustomerWithContacts | null;
 }
+
+export type ReportOperationalConditionData = yup.InferType<typeof reportOperationalConditionSchema>;

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -5,12 +5,14 @@ import {
   AlluStatusStrings,
   Application,
   ApplicationDeletionResult,
+  ApplicationType,
   JohtoselvitysData,
   KaivuilmoitusData,
   NewJohtoselvitysData,
   Paatos,
   PaatosTila,
   PaatosTyyppi,
+  ReportOperationalConditionData,
 } from './types/application';
 import { SignedInUser } from '../hanke/hankeUsers/hankeUser';
 
@@ -53,6 +55,15 @@ export async function sendApplication(applicationId: number) {
 }
 
 /**
+ * Report application in operational condition
+ */
+export async function reportOperationalCondition(data: ReportOperationalConditionData) {
+  await api.post<Application>(`/hakemukset/${data.applicationId}/toiminnallinen-kunto`, {
+    date: data.date,
+  });
+}
+
+/**
  * Check if application is sent to Allu
  */
 export function isApplicationSent(alluStatus: AlluStatusStrings | null): boolean {
@@ -80,6 +91,21 @@ export function isApplicationCancelled(alluStatus: AlluStatusStrings | null): bo
 
 export function isApplicationDraft(alluStatus: AlluStatus | null) {
   return alluStatus === null;
+}
+
+export function isApplicationReportableInOperationalCondition(
+  applicationType: ApplicationType,
+  alluStatus: AlluStatusStrings | null,
+) {
+  return (
+    applicationType === 'EXCAVATION_NOTIFICATION' &&
+    (alluStatus === AlluStatus.PENDING ||
+      alluStatus === AlluStatus.HANDLING ||
+      alluStatus === AlluStatus.INFORMATION_RECEIVED ||
+      alluStatus === AlluStatus.RETURNED_TO_PREPARATION ||
+      alluStatus === AlluStatus.DECISIONMAKING ||
+      alluStatus === AlluStatus.DECISION)
+  );
 }
 
 export async function cancelApplication(applicationId: number | null) {

--- a/src/domain/johtoselvitys/validationSchema.ts
+++ b/src/domain/johtoselvitys/validationSchema.ts
@@ -58,7 +58,7 @@ export const validationSchema: yup.ObjectSchema<JohtoselvitysFormValues> = yup.o
       .required(),
     areas: yup.array(areaSchema).min(1).required(),
   }),
-  ilmoitukset: yup.object().nullable().notRequired(),
+  valmistumisilmoitukset: yup.object().nullable().notRequired(),
   selfIntersectingPolygon: yup.boolean().isFalse(),
   geometriesChanged: yup.boolean(),
 });

--- a/src/domain/johtoselvitys/validationSchema.ts
+++ b/src/domain/johtoselvitys/validationSchema.ts
@@ -58,6 +58,7 @@ export const validationSchema: yup.ObjectSchema<JohtoselvitysFormValues> = yup.o
       .required(),
     areas: yup.array(areaSchema).min(1).required(),
   }),
+  ilmoitukset: yup.object().nullable().notRequired(),
   selfIntersectingPolygon: yup.boolean().isFalse(),
   geometriesChanged: yup.boolean(),
 });

--- a/src/domain/kaivuilmoitus/components/ApplicationReportOperationalConditionDialog.tsx
+++ b/src/domain/kaivuilmoitus/components/ApplicationReportOperationalConditionDialog.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, IconCheck, IconInfoCircleFill, Notification } from 'hds-react';
+import { Button, Dialog, IconCheck, IconInfoCircleFill } from 'hds-react';
 import React, { useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import DatePicker from '../../../common/components/datePicker/DatePicker';
@@ -87,12 +87,7 @@ const ApplicationReportOperationalConditionDialog: React.FC<Props> = ({
   });
   const { handleSubmit, reset: resetForm, formState } = formContext;
   const isConsifmButtonEnabled = formState.isValid;
-  const {
-    mutate,
-    reset: resetMutation,
-    isLoading,
-    isError,
-  } = useMutation(reportOperationalCondition);
+  const { mutate, reset: resetMutation, isLoading } = useMutation(reportOperationalCondition);
   const { showReportOperationalConditionSuccess, showReportOperationalConditionError } =
     useApplicationReportOperationalConditionNotification();
   const dialogTitle = t('hakemus:operationalConditionDialog:title');
@@ -162,11 +157,6 @@ const ApplicationReportOperationalConditionDialog: React.FC<Props> = ({
               helperText={t('form:helperTexts:dateInForm')}
               required
             />
-            {isError && (
-              <Box marginTop="var(--spacing-m)">
-                <Notification label={t('form:validations:required')} type="error" />
-              </Box>
-            )}
           </Dialog.Content>
 
           <Dialog.ActionButtons>

--- a/src/domain/kaivuilmoitus/components/ApplicationReportOperationalConditionDialog.tsx
+++ b/src/domain/kaivuilmoitus/components/ApplicationReportOperationalConditionDialog.tsx
@@ -4,7 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import DatePicker from '../../../common/components/datePicker/DatePicker';
 import {
   Application,
-  Ilmoitus,
+  Valmistumisilmoitus,
   ReportOperationalConditionData,
 } from '../../application/types/application';
 import useLocale from '../../../common/hooks/useLocale';
@@ -19,7 +19,7 @@ import { format } from 'date-fns/format';
 import { fi } from 'date-fns/locale';
 import { useApplication } from '../../application/hooks/useApplication';
 
-const Instructions = ({ previousReports }: { previousReports: Ilmoitus[] }) => {
+const Instructions = ({ previousReports }: { previousReports: Valmistumisilmoitus[] }) => {
   const { t } = useTranslation();
 
   // Generate the list of dates
@@ -28,7 +28,7 @@ const Instructions = ({ previousReports }: { previousReports: Ilmoitus[] }) => {
       <ul>
         {previousReports
           .sort(
-            (a: Ilmoitus, b: Ilmoitus) =>
+            (a: Valmistumisilmoitus, b: Valmistumisilmoitus) =>
               new Date(b.reportedAt).getTime() - new Date(a.reportedAt).getTime(),
           )
           .map((report) => {
@@ -91,9 +91,10 @@ const ApplicationReportOperationalConditionDialog: React.FC<Props> = ({
   const { showReportOperationalConditionSuccess, showReportOperationalConditionError } =
     useApplicationReportOperationalConditionNotification();
   const dialogTitle = t('hakemus:operationalConditionDialog:title');
-  const { id, applicationData, ilmoitukset } = application as Application;
-  const previousReports = ilmoitukset?.TOIMINNALLINEN_KUNTO ?? ([] as Ilmoitus[]);
-  const startDate = applicationData.startTime as Date;
+  const { id, applicationData, valmistumisilmoitukset } = application as Application;
+  const previousReports =
+    valmistumisilmoitukset?.TOIMINNALLINEN_KUNTO ?? ([] as Valmistumisilmoitus[]);
+  const startDate = new Date(applicationData.startTime?.toString() ?? 0);
   const today = new Date();
 
   useEffect(() => {

--- a/src/domain/kaivuilmoitus/components/ApplicationReportOperationalConditionDialog.tsx
+++ b/src/domain/kaivuilmoitus/components/ApplicationReportOperationalConditionDialog.tsx
@@ -1,0 +1,178 @@
+import { Button, Dialog, IconCheck, IconInfoCircleFill, Notification } from 'hds-react';
+import React, { useEffect } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import DatePicker from '../../../common/components/datePicker/DatePicker';
+import {
+  Application,
+  Ilmoitus,
+  ReportOperationalConditionData,
+} from '../../application/types/application';
+import useLocale from '../../../common/hooks/useLocale';
+import { FormProvider, useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { reportOperationalConditionSchema } from '../validationSchema';
+import { useMutation } from 'react-query';
+import { reportOperationalCondition } from '../../application/utils';
+import { Box, VisuallyHiddenInput } from '@chakra-ui/react';
+import useApplicationReportOperationalConditionNotification from '../hooks/useApplicationReportOperationalConditionNotification';
+import { format } from 'date-fns/format';
+import { fi } from 'date-fns/locale';
+
+const Instructions = ({ previousReports }: { previousReports: Ilmoitus[] }) => {
+  const { t } = useTranslation();
+
+  // Generate the list of dates
+  const previousReportsList =
+    previousReports.length > 0 ? (
+      <ul>
+        {previousReports.map((report) => {
+          const reportedAt = format(new Date(report.reportedAt), 'd.M.yyyy HH:mm', { locale: fi });
+          const dateReported = format(new Date(report.dateReported), 'd.M.yyyy', { locale: fi });
+
+          return (
+            <li key={report.reportedAt.toString()}>
+              {t('hakemus:operationalConditionDialog:previouslyReportedAt', {
+                reportedAt,
+                dateReported,
+              })}
+            </li>
+          );
+        })}
+      </ul>
+    ) : null;
+
+  const previousReportsIntro =
+    previousReports.length > 0 ? t('hakemus:operationalConditionDialog:previousReportsIntro') : '';
+
+  return (
+    <Box marginBottom="var(--spacing-m)">
+      <Trans i18nKey="hakemus:operationalConditionDialog:instructions">
+        {{ previousReportsIntro }}
+      </Trans>
+      {previousReports.length > 0 && <Box marginLeft="var(--spacing-m)">{previousReportsList}</Box>}
+    </Box>
+  );
+};
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  application: Application;
+};
+
+const ApplicationReportOperationalConditionDialog: React.FC<Props> = ({
+  isOpen,
+  onClose,
+  application,
+}) => {
+  const { t } = useTranslation();
+  const locale = useLocale();
+  const formContext = useForm<ReportOperationalConditionData>({
+    mode: 'onTouched',
+    resolver: yupResolver(reportOperationalConditionSchema),
+    context: {
+      application: application,
+      dateBeforeStartErrorMessageKey: 'dateBeforeStart',
+      dateInFutureErrorMessageKey: 'dateInFuture',
+    },
+  });
+  const { handleSubmit, reset: resetForm, formState } = formContext;
+  const isConsifmButtonEnabled = formState.isValid;
+  const {
+    mutate,
+    reset: resetMutation,
+    isLoading,
+    isError,
+  } = useMutation(reportOperationalCondition);
+  const { showReportOperationalConditionSuccess, showReportOperationalConditionError } =
+    useApplicationReportOperationalConditionNotification();
+  const dialogTitle = t('hakemus:operationalConditionDialog:title');
+  const { id, applicationData, ilmoitukset } = application;
+  const previousReports = ilmoitukset?.TOIMINNALLINEN_KUNTO ?? ([] as Ilmoitus[]);
+  const startDate = applicationData.startTime as Date;
+  const today = new Date();
+
+  useEffect(() => {
+    formContext.setValue('applicationId', id as number);
+  }, [formContext, id]);
+
+  function handleClose() {
+    resetForm();
+    resetMutation();
+    onClose();
+  }
+
+  async function submitForm(data: ReportOperationalConditionData) {
+    mutate(data, {
+      onSuccess() {
+        showReportOperationalConditionSuccess();
+        handleClose();
+      },
+      onError() {
+        showReportOperationalConditionError();
+      },
+    });
+  }
+
+  return (
+    <Dialog
+      id="application-report-operational-condition"
+      isOpen={isOpen}
+      aria-labelledby={dialogTitle}
+      variant="primary"
+      close={onClose}
+      closeButtonLabelText={t('common:ariaLabels:closeButtonLabelText')}
+    >
+      <Dialog.Header
+        id="application-report-operational-condition-title"
+        title={dialogTitle}
+        iconLeft={<IconInfoCircleFill aria-hidden="true" />}
+      />
+      <FormProvider {...formContext}>
+        <form onSubmit={handleSubmit(submitForm)}>
+          <Dialog.Content>
+            <Instructions previousReports={previousReports} />
+            <VisuallyHiddenInput
+              name="applicationId"
+              value={id as number}
+              aria-hidden="true"
+              readOnly
+            />
+            <DatePicker
+              name="date"
+              label={t(`hakemus:operationalConditionDialog:date`)}
+              locale={locale}
+              minDate={startDate}
+              maxDate={today}
+              initialMonth={today}
+              helperText={t('form:helperTexts:dateInForm')}
+              required
+            />
+            {isError && (
+              <Box marginTop="var(--spacing-m)">
+                <Notification label={t('form:validations:required')} type="error" />
+              </Box>
+            )}
+          </Dialog.Content>
+
+          <Dialog.ActionButtons>
+            <Button
+              type="submit"
+              iconLeft={<IconCheck />}
+              isLoading={isLoading}
+              loadingText={t('common:buttons:sendingText')}
+              disabled={!isConsifmButtonEnabled}
+            >
+              {t('common:confirmationDialog:confirmButton')}
+            </Button>
+            <Button variant="secondary" onClick={onClose}>
+              {t('common:confirmationDialog:cancelButton')}
+            </Button>
+          </Dialog.ActionButtons>
+        </form>
+      </FormProvider>
+    </Dialog>
+  );
+};
+
+export default ApplicationReportOperationalConditionDialog;

--- a/src/domain/kaivuilmoitus/hooks/useApplicationReportOperationalConditionNotification.tsx
+++ b/src/domain/kaivuilmoitus/hooks/useApplicationReportOperationalConditionNotification.tsx
@@ -39,6 +39,8 @@ export default function useApplicationReportOperationalConditionNotification(
     setNotification(true, {
       position: 'top-right',
       dismissible: true,
+      autoClose: true,
+      autoCloseDuration: 8000,
       label: t('hakemus:notifications:reportOperationalConditionErrorLabel'),
       message: errorMessage,
       type: 'error',

--- a/src/domain/kaivuilmoitus/hooks/useApplicationReportOperationalConditionNotification.tsx
+++ b/src/domain/kaivuilmoitus/hooks/useApplicationReportOperationalConditionNotification.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Link } from 'hds-react';
+import { Trans, useTranslation } from 'react-i18next';
+import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
+
+/**
+ * Returns functions for showing success and error notifications for reporting application in operational condition.
+ */
+export default function useApplicationReportOperationalConditionNotification(
+  errorMessageKey: string = 'hakemus:notifications:reportOperationalConditionErrorText',
+) {
+  const { t } = useTranslation();
+  const { setNotification } = useGlobalNotification();
+
+  function showSuccess() {
+    setNotification(true, {
+      position: 'top-right',
+      dismissible: true,
+      autoClose: true,
+      autoCloseDuration: 8000,
+      label: t('hakemus:notifications:reportOperationalConditionSuccessLabel'),
+      message: t('hakemus:notifications:reportOperationalConditionSuccessText'),
+      type: 'success',
+      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+    });
+  }
+
+  function showError() {
+    const errorMessage = (
+      <Trans i18nKey={errorMessageKey}>
+        <p>
+          Lähettämisessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman
+          tekniseen tukeen sähköpostiosoitteessa
+          <Link href="mailto:haitatontuki@hel.fi">haitatontuki@hel.fi</Link>.
+        </p>
+      </Trans>
+    );
+
+    setNotification(true, {
+      position: 'top-right',
+      dismissible: true,
+      label: t('hakemus:notifications:reportOperationalConditionErrorLabel'),
+      message: errorMessage,
+      type: 'error',
+      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+    });
+  }
+
+  return {
+    showReportOperationalConditionSuccess: showSuccess,
+    showReportOperationalConditionError: showError,
+  };
+}

--- a/src/domain/kaivuilmoitus/validationSchema.ts
+++ b/src/domain/kaivuilmoitus/validationSchema.ts
@@ -119,7 +119,7 @@ export const validationSchema: yup.ObjectSchema<KaivuilmoitusFormValues> = yup.o
   applicationIdentifier: yup.string().nullable(),
   hankeTunnus: yup.string().defined().nullable(),
   applicationData: applicationDataSchema,
-  ilmoitukset: yup.object().nullable().notRequired(),
+  valmistumisilmoitukset: yup.object().nullable().notRequired(),
   selfIntersectingPolygon: yup.boolean().isFalse(),
   geometriesChanged: yup.boolean(),
 });

--- a/src/domain/kaivuilmoitus/validationSchema.ts
+++ b/src/domain/kaivuilmoitus/validationSchema.ts
@@ -119,6 +119,7 @@ export const validationSchema: yup.ObjectSchema<KaivuilmoitusFormValues> = yup.o
   applicationIdentifier: yup.string().nullable(),
   hankeTunnus: yup.string().defined().nullable(),
   applicationData: applicationDataSchema,
+  ilmoitukset: yup.object().nullable().notRequired(),
   selfIntersectingPolygon: yup.boolean().isFalse(),
   geometriesChanged: yup.boolean(),
 });
@@ -152,4 +153,9 @@ export const yhteystiedotSchema = yup.object({
 
 export const liitteetSchema = yup.object({
   applicationData: applicationDataSchema.pick(['additionalInfo']),
+});
+
+export const reportOperationalConditionSchema = yup.object({
+  applicationId: yup.number(),
+  date: yup.date().validOperationalConditionDate().nullable().required(),
 });

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -860,6 +860,15 @@ const hakemukset: Application[] = [
         },
       ],
     },
+    ilmoitukset: {
+      TOIMINNALLINEN_KUNTO: [
+        {
+          type: 'TOIMINNALLINEN_KUNTO',
+          dateReported: new Date('2024-08-01'),
+          reportedAt: new Date('2024-08-01T15:15:15Z'),
+        },
+      ],
+    },
   } as Application<KaivuilmoitusData>,
 ];
 

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -860,7 +860,7 @@ const hakemukset: Application[] = [
         },
       ],
     },
-    ilmoitukset: {
+    valmistumisilmoitukset: {
       TOIMINNALLINEN_KUNTO: [
         {
           type: 'TOIMINNALLINEN_KUNTO',

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -125,3 +125,13 @@ export async function sendHakemus(id: number) {
   updatedHakemus.alluStatus = 'PENDING';
   return updatedHakemus;
 }
+
+export async function reportOperationalCondition(id: number) {
+  const hakemus = await read(id);
+  if (!hakemus) {
+    throw new ApiError(`No application with id ${id}`, 404);
+  }
+  const updatedHakemus = cloneDeep(hakemus);
+  updatedHakemus.alluStatus = 'OPERATIONAL_CONDITION';
+  return updatedHakemus;
+}

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -194,6 +194,23 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(hakemus));
   }),
 
+  rest.post(`${apiUrl}/hakemukset/:id/toiminnallinen-kunto`, async (req, res, ctx) => {
+    const { id } = req.params;
+    const hakemus = await hakemuksetDB.reportOperationalCondition(Number(id));
+
+    if (!hakemus) {
+      return res(
+        ctx.status(404),
+        ctx.json({
+          errorMessage: 'Hakemus not found',
+          errorCode: 'HAI1001',
+        }),
+      );
+    }
+
+    return res(ctx.status(200));
+  }),
+
   rest.delete(`${apiUrl}/hakemukset/:id`, async (req, res, ctx) => {
     const { id } = req.params;
     try {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -108,7 +108,9 @@
       "dateMax": "Viimeinen mahdollinen päivä on {{max}}",
       "yhteyshenkilotMin": "Vähintään yksi yhteyshenkilö tulee olla asetettuna",
       "emailAlreadyUsedInContacts": "Valitsemasi sähköpostiosoite löytyy jo hankkeen käyttäjähallinnasta. Lisää yhteyshenkilö pudotusvalikosta.",
-      "emailAlreadyUsedInUserManagement": "Valitsemasi sähköpostiosoite löytyy jo toiselta käyttäjältä."
+      "emailAlreadyUsedInUserManagement": "Valitsemasi sähköpostiosoite löytyy jo toiselta käyttäjältä.",
+      "dateBeforeStart": "Päivämäärä ei voi olla ennen hakemuksen töiden alkamispäivää ({{startDate}})",
+      "dateInFuture": "Päivämäärä ei voi olla tulevaisuudessa"
     },
     "errors": {
       "areaRequired": "Vähintään yksi alue vaaditaan",
@@ -1125,7 +1127,11 @@
       "noApplications": "Hankkeella ei ole lisättyjä hakemuksia",
       "maxAttachmentsNumberExceeded": "Tiedoston ({{fileName}}) lataus epäonnistui, liitteiden enimmäismäärä ({{maxNumber}} kpl) ylitetty.",
       "sentApplicationPersonalInfoNotification": "Lähetetyn hakemuksen omia tietoja ei voi muokata",
-      "sendApplicationDisabled": "Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö."
+      "sendApplicationDisabled": "Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö.",
+      "reportOperationalConditionSuccessLabel": "Ilmoitus lähetetty",
+      "reportOperationalConditionSuccessText": "Ilmoitus toiminnallisesta kunnosta on lähetetty hyväksyttäväksi.",
+      "reportOperationalConditionErrorLabel": "Ilmoituksen lähettäminen epäonnistui",
+      "reportOperationalConditionErrorText": "<0>Lähettämisessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>"
     },
     "sentDialog": {
       "title": "Hakemus lähetetty",
@@ -1136,6 +1142,13 @@
       "title": "Valitse työalueen hankealue",
       "instructions": "Työalue sijoittuu useamman hankealueen alueelle. Valitse hankealue, jolle työalue lisätään.",
       "cancelButton": "Peruuta ja poista työalue"
+    },
+    "operationalConditionDialog": {
+      "title": "Ilmoita toiminnalliseen kuntoon?",
+      "instructions": "<p>Jos kaivutyön työalue on talvikaudella (1.12.–14.5.) normaalissa käytössä, voit ilmoittaa työn toiminnalliseen kuntoon ja alueen käyttömaksu katkeaa.</p><br><p>Ajoradan, pyörätien ja jalkakäytävän tulee olla tilapäisesti päällystetty asfaltilla pintaan saakka. Kaikki liikenteenohjauslaitteet tulee olla poistettu maastosta. Jalkakäytävillä ja muilla alueilla voi käyttää kivituhkaa tai hienoa mursketta, jos asiasta on sovittu etukäteen tarkastajan kanssa.</p><br><p>Jos tilapäistä päällystystä ei ole laitettu, eikä ilmoitusta toiminnallisesta tilasta ole tehty, laskutus jatkuu, kunnes ohjeita on noudatettu.<br>Katuluokan mukainen lopullinen päällystys on tehtävä 14.5. mennessä tai käyttömaksun laskutus jatkuu 15.5. alkaen, kunnes työ on hyväksytysti vastaanotettu.</p><br><p>Anna päivämäärä, jolle ilmoitat työn toiminnalliseen kuntoon. {{previousReportsIntro}}</p>",
+      "previousReportsIntro": "Työ on aiemmin ilmoitettu toiminnalliseen kuntoon seuraavasti:",
+      "previouslyReportedAt": "{{reportedAt}} päivämäärälle {{dateReported}}",
+      "date": "Päivämäärä"
     },
     "status": {
       "PENDING_CLIENT": "Näkyy viranomaiselle",
@@ -1158,7 +1171,8 @@
       "sendApplication": "Lähetä hakemus",
       "cancelApplication": "Peru hakemus",
       "editApplication": "Muokkaa hakemusta",
-      "deletePlacementContract": "Poista sijoitussopimustunnus {{id}}"
+      "deletePlacementContract": "Poista sijoitussopimustunnus {{id}}",
+      "reportOperationalCondition": "Ilmoita toiminnalliseen kuntoon"
     },
     "errors": {
       "cancelConflict": "Hakemusta ei voida perua, koska se on edennyt käsittelyyn",

--- a/src/types/yup-extensions.d.ts
+++ b/src/types/yup-extensions.d.ts
@@ -8,6 +8,9 @@ declare module 'yup' {
     uniqueEmail(): this;
     detectedTrafficNuisance(type: HAITTOJENHALLINTATYYPPI): this;
   }
+  interface DateSchema {
+    validOperationalConditionDate(): this;
+  }
   interface CustomSchemaMetadata {
     pageName?: string | string[];
   }


### PR DESCRIPTION
# Description

A new button is shown on application page if the application has correct status and the user has correct permissions. When the button is clicked, a dialog is shown where the user can fill in the reporting date. When the date is given and verification button clicked, the data is sent to backend.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2557

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

* Create a new kaivuilmoitus or use an existing one
* Send kaivuilmoitus to Allu
* Button "Ilmoita toiminnalliseen kuntoon" should be visible in application view
* Clicking the button open a dialog
* Enter a date (valid dates are from the beginning of application start date until today)
* "Vahvista" button should be enabled if the date is valid
* Clicking "Vahvista" calls API and closes the dialog
* If clicking "Ilmoita toiminnalliseen kuntoon" again the dialog should show the previous report dates (the previous reports should be sorted descending by their reported-at date)

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
