### PR TITLE
HAI-2681 Make sure that empty OVT and registry key fields are sent as null in kaivuilmoitus

### DIFF
--- a/src/common/components/inputCombobox/InputCombobox.tsx
+++ b/src/common/components/inputCombobox/InputCombobox.tsx
@@ -15,6 +15,7 @@ type Props = {
   pattern?: RegExp;
   errorText?: string;
   uppercase?: boolean;
+  required?: boolean;
 };
 
 /**
@@ -32,6 +33,7 @@ export default function InputCombobox({
   pattern,
   errorText,
   uppercase,
+  required,
 }: Readonly<Props>) {
   const { t } = useTranslation();
   const { setValue, getValues } = useFormContext();
@@ -96,6 +98,7 @@ export default function InputCombobox({
             clearButtonAriaLabel={t('common:components:multiselect:clear')}
             invalid={!valid}
             error={errorText}
+            required={required}
           />
         );
       }}

--- a/src/common/components/searchInput/SearchInput.tsx
+++ b/src/common/components/searchInput/SearchInput.tsx
@@ -10,11 +10,13 @@ import styles from './SearchInput.module.scss';
 type Props = {
   id: string;
   name: string;
+  defaultValue?: string;
 };
 
 export default function SearchInput<T>({
   id,
   name,
+  defaultValue = '',
   ...searchInputProps
 }: Readonly<Props & SearchInputProps<T>>) {
   const { t } = useTranslation();
@@ -23,7 +25,7 @@ export default function SearchInput<T>({
   const {
     field,
     fieldState: { error },
-  } = useController({ name });
+  } = useController({ name, defaultValue });
   const errorText = getInputErrorText(t, error);
 
   useEffect(() => {
@@ -49,7 +51,7 @@ export default function SearchInput<T>({
       <HDSSearchInput
         {...searchInputProps}
         onChange={field.onChange}
-        value={field.value}
+        value={field.value || ''}
         clearButtonAriaLabel={t('common:components:multiselect:clear')}
         className={clsx(inputClassName, {
           [styles.searchInputInvalid]: errorText !== undefined,

--- a/src/common/components/textInput/TextInput.tsx
+++ b/src/common/components/textInput/TextInput.tsx
@@ -20,7 +20,7 @@ type PropTypes = {
   className?: string;
   style?: CSSProperties;
   autoComplete?: string;
-  defaultValue?: string;
+  defaultValue?: string | null;
 };
 
 const TextInput: React.FC<React.PropsWithChildren<PropTypes>> = ({
@@ -65,7 +65,7 @@ const TextInput: React.FC<React.PropsWithChildren<PropTypes>> = ({
           required={required}
           readOnly={readOnly}
           onBlur={onBlur}
-          onChange={onChange}
+          onChange={(event) => onChange(defaultValue !== null ? event : event.target.value || null)}
           ref={ref}
           autoComplete={autoComplete}
           {...tooltip}

--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -41,12 +41,13 @@ const CustomerFields: React.FC<{
   hankeUsers?: HankeUser[];
 }> = ({ customerType, hankeUsers }) => {
   const { t } = useTranslation();
-  const { watch, setValue } = useFormContext<Application>();
+  const { watch, setValue, getValues } = useFormContext<Application>();
 
-  const [selectedContactType, registryKey] = watch([
-    `applicationData.${customerType}.customer.type`,
-    `applicationData.${customerType}.customer.registryKey`,
-  ]);
+  const applicationType = getValues('applicationData.applicationType');
+
+  const selectedContactType = watch(`applicationData.${customerType}.customer.type`);
+  const registryKeyInputDisabled =
+    selectedContactType === 'PERSON' || selectedContactType === 'OTHER';
 
   useEffect(() => {
     // If setting contact type to other than company or association, set null to registry key
@@ -56,15 +57,6 @@ const CustomerFields: React.FC<{
       });
     }
   }, [selectedContactType, customerType, setValue]);
-
-  useEffect(() => {
-    // When emptying registry key field, set its value to null
-    if (registryKey === '') {
-      setValue(`applicationData.${customerType}.customer.registryKey`, null, {
-        shouldValidate: true,
-      });
-    }
-  }, [registryKey, customerType, setValue]);
 
   function handleUserSelect(user: HankeUser) {
     setValue(`applicationData.${customerType}.customer.email`, user.sahkoposti, {
@@ -114,8 +106,10 @@ const CustomerFields: React.FC<{
         <TextInput
           name={`applicationData.${customerType}.customer.registryKey`}
           label={t('form:yhteystiedot:labels:ytunnus')}
-          disabled={selectedContactType === 'PERSON' || selectedContactType === 'OTHER'}
+          disabled={registryKeyInputDisabled}
           autoComplete="on"
+          defaultValue={null}
+          required={applicationType === 'EXCAVATION_NOTIFICATION' && !registryKeyInputDisabled}
         />
       </ResponsiveGrid>
       <ResponsiveGrid maxColumns={2}>

--- a/src/domain/application/yupSchemas.ts
+++ b/src/domain/application/yupSchemas.ts
@@ -12,7 +12,7 @@ const contactSchema = yup
   .required();
 
 // business id i.e. Y-tunnus
-const registryKeySchema = yup
+export const registryKeySchema = yup
   .string()
   .defined()
   .nullable()
@@ -21,7 +21,7 @@ const registryKeySchema = yup
     then: (schema) => schema.businessId(),
   });
 
-const customerSchema = contactSchema.omit(['firstName', 'lastName']).shape({
+export const customerSchema = contactSchema.omit(['firstName', 'lastName']).shape({
   yhteystietoId: yup.string().nullable(),
   name: yup.string().trim().max(100).required(),
   type: yup.mixed<ContactType>().nullable().required(),

--- a/src/domain/kaivuilmoitus/BasicInfo.tsx
+++ b/src/domain/kaivuilmoitus/BasicInfo.tsx
@@ -206,6 +206,7 @@ export default function BasicInfo({ johtoselvitysIds }: Readonly<Props>) {
           errorText={t('hakemus:errors:cableReport')}
           placeholder="JSXXXXXXX"
           uppercase
+          required={createCableReportNotChecked}
         />
       )}
 

--- a/src/domain/kaivuilmoitus/Contacts.tsx
+++ b/src/domain/kaivuilmoitus/Contacts.tsx
@@ -89,6 +89,7 @@ export default function Contacts() {
             label={t('form:yhteystiedot:labels:yTunnusTaiHetu')}
             required
             autoComplete="on"
+            defaultValue={null}
           />
         </ResponsiveGrid>
         <ResponsiveGrid>
@@ -97,12 +98,14 @@ export default function Contacts() {
             label={t('form:yhteystiedot:labels:ovt')}
             disabled={ovtDisabled}
             required={ovtRequired}
+            defaultValue={null}
           />
           <TextInput
             name="applicationData.invoicingCustomer.invoicingOperator"
             label={t('form:yhteystiedot:labels:invoicingOperator')}
             disabled={ovtDisabled}
             required={ovtRequired}
+            defaultValue={null}
           />
           <TextInput
             name="applicationData.invoicingCustomer.customerReference"

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -110,7 +110,7 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
     trigger,
     watch,
     handleSubmit,
-    formState: { isDirty, isValid },
+    formState: { isDirty, isValid, errors },
   } = formContext;
   const watchFormValues = watch();
 
@@ -285,7 +285,9 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
   const attachmentsUploadingText: string = t('common:components:fileUpload:loadingText');
 
   function validateStepChange(changeStep: () => void, stepIndex: number) {
-    return changeFormStep(changeStep, pageFieldsToValidate[stepIndex] || [], trigger);
+    return changeFormStep(changeStep, pageFieldsToValidate[stepIndex] || [], trigger, errors, [
+      'required',
+    ]);
   }
 
   return (

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -630,7 +630,7 @@ const hakemukset: Application[] = [
           country: 'FI',
           email: 'yritys2@test.com',
           phone: '040123456',
-          registryKey: null,
+          registryKey: '1234567-1',
           ovt: null,
           invoicingOperator: null,
           sapCustomerNumber: null,


### PR DESCRIPTION
# Description

There was an issue that if OVT and registry key fields in kaivuilmoitus would be left empty, they would be sent as empty strings to backend, which caused errors.

Made a change that those fields are null by default and if they are clered they are set as null.

Also fixed validation of rockExcavation and cableReport fields and set registry key fields of yhteystiedot as required.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2681

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create new kaivuilmoitus or edit existing
2. Fill address fields for invoicing customer (laskutustiedot), but leave "OVT-tunnus" and "Välittäjän tunnus" fields empty
3. Change page so that application is saved
4. Save should be successful and there should not be any errors from backend

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
