### PR TITLE
HAI-2698 Fix banners and public hankkeet for user who is not logged in

### DIFF
--- a/src/domain/api/api.ts
+++ b/src/domain/api/api.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance, AxiosResponse, AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { getApiTokenFromStorage } from 'hds-react';
+import { publicEndpoints } from './publicEndpoints';
 
 const api: AxiosInstance = axios.create({
   baseURL: '/api',
@@ -9,14 +10,16 @@ api.defaults.headers.post['Content-Type'] = 'application/json';
 
 api.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
+    if (config.url && publicEndpoints.includes(config.url)) {
+      return config;
+    }
     const token = getApiTokenFromStorage(window._env_.REACT_APP_OIDC_AUDIENCE_BACKEND);
     if (config.headers && token) {
       // eslint-disable-next-line no-param-reassign
       config.headers.Authorization = `Bearer ${token}`;
       return config;
-    } else {
-      return Promise.reject();
     }
+    return Promise.reject(new Error('No token'));
   },
   (error: AxiosError) => Promise.reject(error),
 );

--- a/src/domain/api/publicEndpoints.ts
+++ b/src/domain/api/publicEndpoints.ts
@@ -1,0 +1,1 @@
+export const publicEndpoints = ['/banners', '/public-hankkeet'];


### PR DESCRIPTION
# Description

Made a change that token is not required for /banners and /public-hankkeet endpoints which are public.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2698

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
