### PR TITLE
HAI-2598 Change label for new kaivuilmoitus to include text about cable report

### DIFF
--- a/src/domain/application/components/ApplicationAddDialog.test.tsx
+++ b/src/domain/application/components/ApplicationAddDialog.test.tsx
@@ -12,7 +12,7 @@ test('Continue to application button should be disabled if application type is n
   expect(screen.getByRole('button', { name: /luo hakemus/i })).toBeDisabled();
 
   await user.click(screen.getByRole('button', { name: /hakemustyyppi/i }));
-  await user.click(screen.getByText(/johtoselvitys/i));
+  await user.click(screen.getByText('Johtoselvitys'));
 
   expect(screen.getByRole('button', { name: /luo hakemus/i })).not.toBeDisabled();
 });
@@ -24,7 +24,7 @@ test('Navigates to cable application correctly', async () => {
   const { user } = render(<ApplicationAddDialog hanke={hanke} isOpen onClose={handleClose} />);
 
   await user.click(screen.getByRole('button', { name: /hakemustyyppi/i }));
-  await user.click(screen.getByText(/johtoselvitys/i));
+  await user.click(screen.getByText('Johtoselvitys'));
   await user.click(screen.getByRole('button', { name: /luo hakemus/i }));
 
   expect(window.location.pathname).toBe('/fi/johtoselvityshakemus');

--- a/src/domain/application/components/ApplicationAddDialog.test.tsx
+++ b/src/domain/application/components/ApplicationAddDialog.test.tsx
@@ -30,3 +30,15 @@ test('Navigates to cable application correctly', async () => {
   expect(window.location.pathname).toBe('/fi/johtoselvityshakemus');
   expect(window.location.search).toBe('?hanke=HAI22-1');
 });
+
+test('Application type labels are correct', async () => {
+  const hanke = hankkeetData[0] as HankeData;
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  function handleClose() {}
+  const { user } = render(<ApplicationAddDialog hanke={hanke} isOpen onClose={handleClose} />);
+
+  await user.click(screen.getByRole('button', { name: /hakemustyyppi/i }));
+
+  expect(screen.getByText('Johtoselvitys')).toBeInTheDocument();
+  expect(screen.getByText('Kaivuilmoitus (ja johtoselvitys)')).toBeInTheDocument();
+});

--- a/src/domain/application/components/ApplicationAddDialog.tsx
+++ b/src/domain/application/components/ApplicationAddDialog.tsx
@@ -29,9 +29,9 @@ const ApplicationAddDialog: React.FC<Props> = ({ isOpen, onClose, hanke }) => {
 
   const dialogTitle = t('hakemus:headers:pickApplication');
   const applicationTypeOptions: Option[] = [
-    { label: t('hakemus:applicationTypes:CABLE_REPORT'), value: 'CABLE_REPORT' },
+    { label: t('hakemus:addApplicationTypes:CABLE_REPORT'), value: 'CABLE_REPORT' },
     {
-      label: t('hakemus:applicationTypes:EXCAVATION_NOTIFICATION'),
+      label: t('hakemus:addApplicationTypes:EXCAVATION_NOTIFICATION'),
       value: 'EXCAVATION_NOTIFICATION',
     },
   ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1177,7 +1177,11 @@
       "CABLE_REPORT": "Luonnos",
       "EXCAVATION_NOTIFICATION": "Luonnos"
     },
-    "applicationTypeInstruction": "Valitse hakemustyyppi. Kaivuilmoituksen kautta pääset tekemään myös johtoselvityksen, mikäli sinulla ei sellaista vielä ole."
+    "applicationTypeInstruction": "Valitse hakemustyyppi. Kaivuilmoituksen kautta pääset tekemään myös johtoselvityksen, mikäli sinulla ei sellaista vielä ole.",
+    "addApplicationTypes": {
+      "CABLE_REPORT": "$t(hakemus:applicationTypes:CABLE_REPORT)",
+      "EXCAVATION_NOTIFICATION": "$t(hakemus:applicationTypes:EXCAVATION_NOTIFICATION) (ja johtoselvitys)"
+    }
   },
   "hankeSidebar": {
     "ariaSidebarContent": "Hankkeen tiedot",


### PR DESCRIPTION
# Description

Changed label for new kaivuilmoitus to include text "(ja johtoselvitys)".

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2598

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

* Add a new application for hanke
* Check that the label is correct for kaivuilmoitus

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
