### PR TITLE
HAI-2340 Prevent drawing work areas outside hanke areas

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@popperjs/core": "^2.11.8",
     "@reduxjs/toolkit": "^2.1.0",
     "@sentry/react": "^8.1.0",
-    "@turf/boolean-intersects": "^7.1.0",
+    "@turf/boolean-contains": "^7.1.0",
     "@turf/center": "^7.1.0",
     "@turf/helpers": "^7.1.0",
     "@turf/kinks": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@reduxjs/toolkit": "^2.1.0",
     "@sentry/react": "^8.1.0",
     "@turf/boolean-contains": "^7.1.0",
+    "@turf/boolean-intersects": "^7.1.0",
     "@turf/center": "^7.1.0",
     "@turf/helpers": "^7.1.0",
     "@turf/kinks": "^7.1.0",

--- a/src/common/components/map/modules/draw/DrawModule.tsx
+++ b/src/common/components/map/modules/draw/DrawModule.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-import { Feature } from 'ol';
+import { Feature, Map, MapBrowserEvent } from 'ol';
 import Geometry from 'ol/geom/Geometry';
-import DrawControl from './DrawControl';
+import { Condition } from 'ol/events/condition';
 import DrawIntercation from './DrawInteraction';
+import { ModifyEvent } from 'ol/interaction/Modify';
+import { FeatureLike } from 'ol/Feature';
+import { Style } from 'ol/style';
+import DrawControl from './DrawControl';
 
 type Props = {
   /**
@@ -10,11 +14,31 @@ type Props = {
    * It is called with the self-intersecting polygon or null if there is no self-intersection.
    */
   onSelfIntersectingPolygon?: (feature: Feature<Geometry> | null) => void;
+  drawCondition?: Condition;
+  drawFinishCondition?: (event: MapBrowserEvent<UIEvent>, feature: Feature) => boolean;
+  drawStyleFunction?: (map: Map, feature: FeatureLike) => Style | Style[];
+  handleModifyEnd?: (
+    event: ModifyEvent,
+    originalFeature: Feature | null,
+    modifiedFeature: Feature,
+  ) => void;
 };
 
-const DrawModule: React.FC<React.PropsWithChildren<Props>> = ({ onSelfIntersectingPolygon }) => (
+const DrawModule: React.FC<React.PropsWithChildren<Props>> = ({
+  onSelfIntersectingPolygon,
+  drawCondition,
+  drawFinishCondition,
+  drawStyleFunction,
+  handleModifyEnd,
+}) => (
   <>
-    <DrawIntercation onSelfIntersectingPolygon={onSelfIntersectingPolygon} />
+    <DrawIntercation
+      onSelfIntersectingPolygon={onSelfIntersectingPolygon}
+      drawCondition={drawCondition}
+      drawFinishCondition={drawFinishCondition}
+      drawStyleFunction={drawStyleFunction}
+      handleModifyEnd={handleModifyEnd}
+    />
     <DrawControl />
   </>
 );

--- a/src/domain/johtoselvitys/Geometries.tsx
+++ b/src/domain/johtoselvitys/Geometries.tsx
@@ -213,6 +213,7 @@ export function Geometries({ hankeData }: Readonly<Props>) {
           showDrawControls={Boolean(workTimesSet)}
           onAddArea={handleAddArea}
           mapCenter={addressCoordinate}
+          restrictDrawingToHankeAreas={!hankeData?.generated}
         >
           {/* Don't show hanke areas when hanke is generated */}
           {!hankeData?.generated && (

--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -37,6 +37,7 @@ import { getTotalSurfaceArea } from '../map/utils';
 import TyoalueTable from './components/TyoalueTable';
 import AreaSelectDialog from './components/AreaSelectDialog';
 import booleanContains from '@turf/boolean-contains';
+import { getAreaDefaultName } from '../application/utils';
 
 function getEmptyArea(
   hankeData: HankeData,
@@ -85,9 +86,16 @@ export default function Areas({ hankeData }: Readonly<Props>) {
 
   const [drawSource] = useState<VectorSource>(() => {
     const features = applicationAreas.flatMap((area) =>
-      area.tyoalueet.flatMap((tyoalue) => {
+      area.tyoalueet.flatMap((tyoalue, index) => {
         if (tyoalue.openlayersFeature) {
-          tyoalue.openlayersFeature.set('relatedHankeAreaName', area.name);
+          const areaName = getAreaDefaultName(t, index, area.tyoalueet.length);
+          tyoalue.openlayersFeature?.setProperties({
+            areaName,
+            hankeName: hankeData.nimi,
+            relatedHankeAreaName: area.name,
+            startDate: getValues('applicationData.startTime'),
+            endDate: getValues('applicationData.endTime'),
+          });
           return tyoalue.openlayersFeature;
         }
         return [];
@@ -109,7 +117,18 @@ export default function Areas({ hankeData }: Readonly<Props>) {
 
   function addTyoAlueToHankeArea(hankeArea: HankeAlue, feature: Feature<Geometry>) {
     const existingArea = applicationAreas.find((alue) => alue.hankealueId === hankeArea.id);
-    feature.set('relatedHankeAreaName', hankeArea.nimi);
+    const areaName = getAreaDefaultName(
+      t,
+      existingArea?.tyoalueet.length || 0,
+      existingArea?.tyoalueet.length || 0,
+    );
+    feature.setProperties({
+      areaName,
+      hankeName: hankeData.nimi,
+      startDate: getValues('applicationData.startTime'),
+      endDate: getValues('applicationData.endTime'),
+      relatedHankeAreaName: hankeArea.nimi,
+    });
     if (!existingArea) {
       append(getEmptyArea(hankeData, hankeArea, feature));
     } else {
@@ -285,7 +304,6 @@ export default function Areas({ hankeData }: Readonly<Props>) {
                   alueIndex={index}
                   drawSource={drawSource}
                   hankeAlueName={alue.name}
-                  hankeName={hankeData.nimi}
                   onRemoveLastArea={() => remove(index)}
                 />
 

--- a/src/domain/kaivuilmoitus/components/TyoalueTable.tsx
+++ b/src/domain/kaivuilmoitus/components/TyoalueTable.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useFieldArray, useFormContext } from 'react-hook-form';
+import { useFieldArray } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Box, Flex } from '@chakra-ui/react';
 import { IconLocation, IconTrash, Table } from 'hds-react';
@@ -18,7 +18,6 @@ type Props = {
   alueIndex: number;
   drawSource: VectorSource;
   hankeAlueName: string;
-  hankeName: string;
   onRemoveLastArea?: () => void;
 };
 
@@ -34,7 +33,6 @@ export default function TyoalueTable({
   alueIndex,
   drawSource,
   hankeAlueName,
-  hankeName,
   onRemoveLastArea,
 }: Readonly<Props>) {
   const { t } = useTranslation();
@@ -42,7 +40,6 @@ export default function TyoalueTable({
     state: { selectedFeature },
     actions: { setSelectedFeature },
   } = useDrawContext();
-  const { getValues } = useFormContext<KaivuilmoitusFormValues>();
   const { fields: tyoalueet, remove } = useFieldArray<
     KaivuilmoitusFormValues,
     `applicationData.areas.${number}.tyoalueet`
@@ -53,12 +50,7 @@ export default function TyoalueTable({
 
   const tableRows: TableData[] = tyoalueet.map((alue, index) => {
     const areaName = getAreaDefaultName(t, index, tyoalueet.length);
-    alue.openlayersFeature?.setProperties({
-      areaName,
-      hankeName,
-      startDate: getValues('applicationData.startTime'),
-      endDate: getValues('applicationData.endTime'),
-    });
+    alue.openlayersFeature?.set('areaName', areaName);
     return {
       id: alue.id,
       nimi: areaName,

--- a/src/domain/map/components/Layers/HankeLayer.tsx
+++ b/src/domain/map/components/Layers/HankeLayer.tsx
@@ -32,6 +32,7 @@ function HankeLayer({
 }: Readonly<Props>) {
   const { hankkeet: hankkeetFromContext } = useContext(HankkeetContext);
   const hankeSource = useRef(new VectorSource());
+  hankeSource.current.set('sourceName', 'hankeSource');
   const hankkeet = hankeData || hankkeetFromContext;
 
   const hankkeetFilteredByDates = useMemo(

--- a/src/domain/map/utils/isFeatureWithinFeatures.ts
+++ b/src/domain/map/utils/isFeatureWithinFeatures.ts
@@ -1,0 +1,18 @@
+import { FeatureLike } from 'ol/Feature';
+import { Polygon } from 'ol/geom';
+import { Feature } from 'geojson';
+import booleanContains from '@turf/boolean-contains';
+import { polygon as turfPolygon } from '@turf/helpers';
+
+/**
+ * Check if feature is completely contained within any of the features given as second argument
+ */
+export default function isFeatureWithinFeatures(featureToCheck: Feature, features: FeatureLike[]) {
+  if (features.length === 0) {
+    return false;
+  }
+  return features.some((feature) => {
+    const polygon = turfPolygon((feature.getGeometry() as Polygon).getCoordinates());
+    return booleanContains(polygon, featureToCheck);
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4368,6 +4368,30 @@
     "@types/geojson" "^7946.0.10"
     tslib "^2.6.2"
 
+"@turf/boolean-disjoint@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-disjoint/-/boolean-disjoint-7.1.0.tgz#2ed06023f369ffc2bccfec463be13d7db2193acf"
+  integrity sha512-JapOG03kOCoGeYMWgTQjEifhr1nUoK4Os2cX0iC5X9kvZF4qCHeruX8/rffBQDx7PDKQKusSTXq8B1ISFi0hOw==
+  dependencies:
+    "@turf/boolean-point-in-polygon" "^7.1.0"
+    "@turf/helpers" "^7.1.0"
+    "@turf/line-intersect" "^7.1.0"
+    "@turf/meta" "^7.1.0"
+    "@turf/polygon-to-line" "^7.1.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.6.2"
+
+"@turf/boolean-intersects@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-intersects/-/boolean-intersects-7.1.0.tgz#2004b3e866447c748c56ebf44ffadbbd1f7066bf"
+  integrity sha512-gpksWbb0RT+Z3nfqRfoACY3KEFyv2BPaxJ3L76PH67DhHZviq3Nfg85KYbpuhS64FSm+9tXe4IaKn6EjbHo20g==
+  dependencies:
+    "@turf/boolean-disjoint" "^7.1.0"
+    "@turf/helpers" "^7.1.0"
+    "@turf/meta" "^7.1.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.6.2"
+
 "@turf/boolean-point-in-polygon@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.1.0.tgz#dec07b467d74b4409eb03acc60b874958f71b49a"
@@ -4425,6 +4449,16 @@
     "@types/geojson" "^7946.0.10"
     tslib "^2.6.2"
 
+"@turf/line-intersect@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-intersect/-/line-intersect-7.1.0.tgz#60c46a62143e42d6663be93f893de1cfac584cf9"
+  integrity sha512-JI3dvOsAoCqd4vUJ134FIzgcC42QpC/tBs+b4OJoxWmwDek3REv4qGaZY6wCg9X4hFSlCKFcnhMIQQZ/n720Qg==
+  dependencies:
+    "@turf/helpers" "^7.1.0"
+    "@types/geojson" "^7946.0.10"
+    sweepline-intersections "^1.5.0"
+    tslib "^2.6.2"
+
 "@turf/meta@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-7.1.0.tgz#b2af85afddd0ef08aeae8694a12370a4f06b6d13"
@@ -4432,6 +4466,16 @@
   dependencies:
     "@turf/helpers" "^7.1.0"
     "@types/geojson" "^7946.0.10"
+
+"@turf/polygon-to-line@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@turf/polygon-to-line/-/polygon-to-line-7.1.0.tgz#fcacd153ab481dec27d821889758452642f09288"
+  integrity sha512-FBlfyBWNQZCTVGqlJH7LR2VXmvj8AydxrA8zegqek/5oPGtQDeUgIppKmvmuNClqbglhv59QtCUVaDK4bOuCTA==
+  dependencies:
+    "@turf/helpers" "^7.1.0"
+    "@turf/invariant" "^7.1.0"
+    "@types/geojson" "^7946.0.10"
+    tslib "^2.6.2"
 
 "@types/aria-query@^5.0.1":
   version "5.0.1"
@@ -14262,6 +14306,13 @@ svgo@^2.7.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
+sweepline-intersections@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz#85ab3629a291875926fae0acd508496430d8a647"
+  integrity sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==
+  dependencies:
+    tinyqueue "^2.0.0"
+
 symbol-observable@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
@@ -14411,6 +14462,11 @@ tiny-invariant@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tinyqueue@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
+  integrity sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==
 
 tmpl@1.0.x:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4355,27 +4355,16 @@
     "@types/geojson" "^7946.0.10"
     tslib "^2.6.2"
 
-"@turf/boolean-disjoint@^7.1.0":
+"@turf/boolean-contains@^7.1.0":
   version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-disjoint/-/boolean-disjoint-7.1.0.tgz#2ed06023f369ffc2bccfec463be13d7db2193acf"
-  integrity sha512-JapOG03kOCoGeYMWgTQjEifhr1nUoK4Os2cX0iC5X9kvZF4qCHeruX8/rffBQDx7PDKQKusSTXq8B1ISFi0hOw==
+  resolved "https://registry.yarnpkg.com/@turf/boolean-contains/-/boolean-contains-7.1.0.tgz#6ceaf8083c7ed82e41187951eccb2111c23c004e"
+  integrity sha512-ldy4j1/RVChYTYjEb4wWaE/JyF1jA87WpsB4eVLic6OcAYJGs7POF1kfKbcdkJJiRBmhI3CXNA+u+m9y4Z/j3g==
   dependencies:
+    "@turf/bbox" "^7.1.0"
     "@turf/boolean-point-in-polygon" "^7.1.0"
+    "@turf/boolean-point-on-line" "^7.1.0"
     "@turf/helpers" "^7.1.0"
-    "@turf/line-intersect" "^7.1.0"
-    "@turf/meta" "^7.1.0"
-    "@turf/polygon-to-line" "^7.1.0"
-    "@types/geojson" "^7946.0.10"
-    tslib "^2.6.2"
-
-"@turf/boolean-intersects@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-intersects/-/boolean-intersects-7.1.0.tgz#2004b3e866447c748c56ebf44ffadbbd1f7066bf"
-  integrity sha512-gpksWbb0RT+Z3nfqRfoACY3KEFyv2BPaxJ3L76PH67DhHZviq3Nfg85KYbpuhS64FSm+9tXe4IaKn6EjbHo20g==
-  dependencies:
-    "@turf/boolean-disjoint" "^7.1.0"
-    "@turf/helpers" "^7.1.0"
-    "@turf/meta" "^7.1.0"
+    "@turf/invariant" "^7.1.0"
     "@types/geojson" "^7946.0.10"
     tslib "^2.6.2"
 
@@ -4388,6 +4377,16 @@
     "@turf/invariant" "^7.1.0"
     "@types/geojson" "^7946.0.10"
     point-in-polygon-hao "^1.1.0"
+    tslib "^2.6.2"
+
+"@turf/boolean-point-on-line@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-on-line/-/boolean-point-on-line-7.1.0.tgz#03a29be5e9806b1b34255e69f03c3af1adfbcc4d"
+  integrity sha512-Kd83EjeTyY4kVMAhcW3Lb8aChwh24BUIhmpE9Or8M+ETNsFGzn9M7qtIySJHLRzKAL3letvWSKXKQPuK1AhAzg==
+  dependencies:
+    "@turf/helpers" "^7.1.0"
+    "@turf/invariant" "^7.1.0"
+    "@types/geojson" "^7946.0.10"
     tslib "^2.6.2"
 
 "@turf/center@^7.1.0":
@@ -4426,16 +4425,6 @@
     "@types/geojson" "^7946.0.10"
     tslib "^2.6.2"
 
-"@turf/line-intersect@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@turf/line-intersect/-/line-intersect-7.1.0.tgz#60c46a62143e42d6663be93f893de1cfac584cf9"
-  integrity sha512-JI3dvOsAoCqd4vUJ134FIzgcC42QpC/tBs+b4OJoxWmwDek3REv4qGaZY6wCg9X4hFSlCKFcnhMIQQZ/n720Qg==
-  dependencies:
-    "@turf/helpers" "^7.1.0"
-    "@types/geojson" "^7946.0.10"
-    sweepline-intersections "^1.5.0"
-    tslib "^2.6.2"
-
 "@turf/meta@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-7.1.0.tgz#b2af85afddd0ef08aeae8694a12370a4f06b6d13"
@@ -4443,16 +4432,6 @@
   dependencies:
     "@turf/helpers" "^7.1.0"
     "@types/geojson" "^7946.0.10"
-
-"@turf/polygon-to-line@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@turf/polygon-to-line/-/polygon-to-line-7.1.0.tgz#fcacd153ab481dec27d821889758452642f09288"
-  integrity sha512-FBlfyBWNQZCTVGqlJH7LR2VXmvj8AydxrA8zegqek/5oPGtQDeUgIppKmvmuNClqbglhv59QtCUVaDK4bOuCTA==
-  dependencies:
-    "@turf/helpers" "^7.1.0"
-    "@turf/invariant" "^7.1.0"
-    "@types/geojson" "^7946.0.10"
-    tslib "^2.6.2"
 
 "@types/aria-query@^5.0.1":
   version "5.0.1"
@@ -13865,15 +13844,8 @@ statuses@2.0.1, statuses@^2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stream-browserify@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
-  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
-  dependencies:
-    inherits "~2.0.4"
-    readable-stream "^3.5.0"
-
-"stream@npm:stream-browserify":
+stream-browserify@^3.0.0, "stream@npm:stream-browserify":
+  name stream
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
   integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
@@ -14290,13 +14262,6 @@ svgo@^2.7.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
-sweepline-intersections@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz#85ab3629a291875926fae0acd508496430d8a647"
-  integrity sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==
-  dependencies:
-    tinyqueue "^2.0.0"
-
 symbol-observable@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
@@ -14446,11 +14411,6 @@ tiny-invariant@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
-
-tinyqueue@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
-  integrity sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
# Description

In kaivuilmoitus and johtoselvitys drawing outside hanke areas is prevented. However this restriction does not apply to johtoselvitys which has generated hanke.

This is implemented by not allowing drawing to start outside of hanke areas and it also cannot be ended outside. Also modifying work areas is restricted to hanke areas. Also when drawing tool is active point geometry is not displayed when cursor is outside hanke areas to indicate that drawing is not possible.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2340

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create new kaivuilmoitus or edit existing
2. When drawing new work areas check that they cannot be drawn outside hanke areas
3. Also check that work areas can't be modified so that they go outside hanke areas

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
