### PR TITLE
HAI-2652 Prevent multiple requests happening because of multiple button clicks

### DIFF
--- a/src/common/components/fileUpload/FileList.tsx
+++ b/src/common/components/fileUpload/FileList.tsx
@@ -2,13 +2,13 @@ import { useState } from 'react';
 import { IconTrash, Notification } from 'hds-react';
 import { Box } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
-import { useMutation } from 'react-query';
 import { AttachmentMetadata } from '../../types/attachment';
 import ConfirmationDialog from '../HDSConfirmationDialog/ConfirmationDialog';
 import FileListItem from './FileListItem';
 import { FileDeleteFunction, FileDownLoadFunction, ShowDeleteButtonFunction } from './types';
 import { AxiosError } from 'axios';
 import { sortBy } from 'lodash';
+import useDebouncedMutation from '../../hooks/useDebouncedMutation';
 
 type Props = {
   files: AttachmentMetadata[];
@@ -28,7 +28,7 @@ export default function FileList({
   const { t } = useTranslation();
   // Sort files in descending order by their createdAt date
   const sortedFiles = sortBy(files, (file) => new Date(file.createdAt)).reverse();
-  const deleteMutation = useMutation<void, AxiosError, AttachmentMetadata, unknown>(
+  const deleteMutation = useDebouncedMutation<void, AxiosError, AttachmentMetadata, unknown>(
     fileDeleteFunction,
     {
       onSuccess() {

--- a/src/common/components/map/overlay/Overlay.tsx
+++ b/src/common/components/map/overlay/Overlay.tsx
@@ -21,14 +21,18 @@ export default function MapOverlay({ position, children }: Readonly<Props>) {
       position,
     });
 
-    map.addOverlay(overlay);
+    if (children) {
+      map.addOverlay(overlay);
+    } else {
+      map.removeOverlay(overlay);
+    }
 
     return function cleanup() {
       if (map) {
         map.removeOverlay(overlay);
       }
     };
-  }, [map, position]);
+  }, [map, position, children]);
 
   return (
     <Box

--- a/src/common/hooks/useDebouncedMutation.test.tsx
+++ b/src/common/hooks/useDebouncedMutation.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '../../testUtils/render';
+import useDebouncedMutation from './useDebouncedMutation';
+
+const mutationFn = jest.fn(() => {
+  return Promise.resolve();
+});
+
+const buttonText = 'Test button';
+
+function TestComponent() {
+  const { mutate } = useDebouncedMutation(mutationFn);
+
+  function handleClick() {
+    mutate();
+  }
+
+  return <button onClick={handleClick}>{buttonText}</button>;
+}
+
+test('Should only call mutation function once even if trying to call it multiple times', async () => {
+  const { user } = render(<TestComponent />);
+  const testButton = screen.getByRole('button', { name: buttonText });
+  await user.click(testButton);
+  await user.click(testButton);
+  await user.click(testButton);
+
+  expect(mutationFn).toHaveBeenCalledTimes(1);
+});

--- a/src/common/hooks/useDebouncedMutation.ts
+++ b/src/common/hooks/useDebouncedMutation.ts
@@ -1,0 +1,33 @@
+import { debounce } from 'lodash';
+import { useMemo } from 'react';
+import { MutationFunction, UseMutationOptions, UseMutationResult, useMutation } from 'react-query';
+
+/**
+ * Wrapper for the react-query useMutation hook that debounces the mutate function.
+ */
+export default function useDebouncedMutation<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown,
+>(
+  mutationFn: MutationFunction<TData, TVariables>,
+  options?: Omit<UseMutationOptions<TData, TError, TVariables, TContext>, 'mutationKey'>,
+  debounceTime: number = 1000,
+): UseMutationResult<TData, TError, TVariables, TContext> {
+  const mutationResults = useMutation(mutationFn, options);
+
+  const debouncedMutation = useMemo(
+    () =>
+      debounce(mutationResults.mutate, debounceTime, {
+        leading: true,
+        trailing: false,
+      }),
+    [debounceTime, mutationResults.mutate],
+  );
+
+  return {
+    ...mutationResults,
+    mutate: debouncedMutation,
+  };
+}

--- a/src/domain/application/components/ApplicationCancel.tsx
+++ b/src/domain/application/components/ApplicationCancel.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useMutation } from 'react-query';
 import { Button } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { AxiosError } from 'axios';
@@ -11,6 +10,7 @@ import {
   useNavigateToApplicationList,
   useNavigateToHankeList,
 } from '../../hanke/hooks/useNavigateToApplicationList';
+import useDebouncedMutation from '../../../common/hooks/useDebouncedMutation';
 
 type Props = {
   applicationId: number | null;
@@ -41,7 +41,7 @@ export const ApplicationCancel: React.FC<Props> = ({
 
   const { setNotification } = useGlobalNotification();
 
-  const applicationCancelMutation = useMutation(cancelApplication, {
+  const applicationCancelMutation = useDebouncedMutation(cancelApplication, {
     onError(error: AxiosError) {
       let message = t('common:error');
       if (error.response?.status === 409) {

--- a/src/domain/application/components/ApplicationMap.tsx
+++ b/src/domain/application/components/ApplicationMap.tsx
@@ -203,16 +203,19 @@ export default function ApplicationMap({
               const hankeName = feature?.get('hankeName');
               const startDate = feature?.get('startDate');
               const endDate = feature?.get('endDate');
+              if (!areaName || !hankeName) {
+                return null;
+              }
               return (
-                <div>
+                <>
                   {hankeName && <p>{hankeName}</p>}
-                  {areaName && <h4 className="heading-xxs">{areaName}</h4>}
+                  {<h4 className="heading-xxs">{areaName}</h4>}
                   {startDate && endDate && (
                     <Box as="p" fontSize="var(--fontsize-body-s)">
                       {formatToFinnishDate(startDate)}–{formatToFinnishDate(endDate)}
                     </Box>
                   )}
-                </div>
+                </>
               );
             }}
           />

--- a/src/domain/application/hooks/useSaveApplication.ts
+++ b/src/domain/application/hooks/useSaveApplication.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useMutation } from 'react-query';
 import { createApplication, updateApplication } from '../utils';
 import { Application, JohtoselvitysData, KaivuilmoitusData } from '../types/application';
+import useDebouncedMutation from '../../../common/hooks/useDebouncedMutation';
 
 type SuccessFunction<ApplicationData> = (data: Application<ApplicationData>) => void;
 
@@ -20,15 +21,18 @@ export default function useSaveApplication<
     null,
   );
 
-  const applicationCreateMutation = useMutation(createApplication<ApplicationData, CreateData>, {
-    onMutate() {
-      setShowSaveNotification(null);
+  const applicationCreateMutation = useDebouncedMutation(
+    createApplication<ApplicationData, CreateData>,
+    {
+      onMutate() {
+        setShowSaveNotification(null);
+      },
+      onSuccess: onCreateSuccess,
+      onSettled() {
+        setShowSaveNotification('create');
+      },
     },
-    onSuccess: onCreateSuccess,
-    onSettled() {
-      setShowSaveNotification('create');
-    },
-  });
+  );
 
   const applicationUpdateMutation = useMutation(updateApplication<ApplicationData, UpdateData>, {
     onMutate() {

--- a/src/domain/application/hooks/useSaveApplication.ts
+++ b/src/domain/application/hooks/useSaveApplication.ts
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useMutation } from 'react-query';
 import { createApplication, updateApplication } from '../utils';
 import { Application, JohtoselvitysData, KaivuilmoitusData } from '../types/application';
 import useDebouncedMutation from '../../../common/hooks/useDebouncedMutation';
@@ -34,15 +33,18 @@ export default function useSaveApplication<
     },
   );
 
-  const applicationUpdateMutation = useMutation(updateApplication<ApplicationData, UpdateData>, {
-    onMutate() {
-      setShowSaveNotification(null);
+  const applicationUpdateMutation = useDebouncedMutation(
+    updateApplication<ApplicationData, UpdateData>,
+    {
+      onMutate() {
+        setShowSaveNotification(null);
+      },
+      onSuccess: onUpdateSuccess,
+      onSettled() {
+        setShowSaveNotification('update');
+      },
     },
-    onSuccess: onUpdateSuccess,
-    onSettled() {
-      setShowSaveNotification('update');
-    },
-  });
+  );
 
   return {
     applicationCreateMutation,

--- a/src/domain/application/hooks/useSendApplication.ts
+++ b/src/domain/application/hooks/useSendApplication.ts
@@ -1,7 +1,8 @@
-import { useMutation, useQueryClient } from 'react-query';
+import { useQueryClient } from 'react-query';
 import { sendApplication } from '../utils';
 import useApplicationSendNotification from './useApplicationSendNotification';
 import { Application } from '../types/application';
+import useDebouncedMutation from '../../../common/hooks/useDebouncedMutation';
 
 type Options = {
   onSuccess: (data: Application) => void;
@@ -12,7 +13,7 @@ export default function useSendApplication(options?: Options) {
   const queryClient = useQueryClient();
   const { showSendSuccess, showSendError } = useApplicationSendNotification();
 
-  return useMutation(sendApplication, {
+  return useDebouncedMutation(sendApplication, {
     onError() {
       showSendError();
     },

--- a/src/domain/forms/components/NewContactPersonForm.tsx
+++ b/src/domain/forms/components/NewContactPersonForm.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { FormProvider, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useMutation } from 'react-query';
 import { Button, Fieldset, IconCheck, IconCross, Notification } from 'hds-react';
 import ResponsiveGrid from '../../../common/components/grid/ResponsiveGrid';
 import TextInput from '../../../common/components/textInput/TextInput';
@@ -10,6 +9,7 @@ import { yhteyshenkiloSchema } from '../../hanke/edit/hankeSchema';
 import { Yhteyshenkilo, YHTEYSHENKILO_FORMFIELD } from '../../hanke/edit/types';
 import styles from './NewContactPersonForm.module.scss';
 import { HankeUser } from '../../hanke/hankeUsers/hankeUser';
+import useDebouncedMutation from '../../../common/hooks/useDebouncedMutation';
 
 export type ContactPersonAddedNotification = 'success' | 'error' | null;
 
@@ -33,7 +33,7 @@ function NewContactPersonForm({
     context: { hankeUsers: hankeUsers, errorMessageKey: 'emailAlreadyUsedInContacts' },
   });
   const { getValues, trigger } = formContext;
-  const { mutate } = useMutation(createHankeUser);
+  const { mutate, isLoading } = useDebouncedMutation(createHankeUser);
 
   async function saveContact() {
     const isFormValid = await trigger(undefined, { shouldFocus: true });
@@ -102,7 +102,7 @@ function NewContactPersonForm({
           />
         </ResponsiveGrid>
         <div className={styles.formButtons}>
-          <Button iconLeft={<IconCheck />} onClick={saveContact}>
+          <Button iconLeft={<IconCheck />} onClick={saveContact} isLoading={isLoading}>
             {t('form:yhteystiedot:buttons:saveAndAddContactPerson')}
           </Button>
           <Button iconLeft={<IconCross />} variant="secondary" onClick={cancelContactAdd}>

--- a/src/domain/hanke/hankeUsers/UserDeleteDialog.tsx
+++ b/src/domain/hanke/hankeUsers/UserDeleteDialog.tsx
@@ -2,9 +2,9 @@ import { Button, Dialog, IconInfoCircle, IconTrash, Notification } from 'hds-rea
 import { Box } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 import { DeleteInfo, HankeUser } from './hankeUser';
-import { useMutation } from 'react-query';
 import { deleteUser } from './hankeUsersApi';
 import { isApplicationPending } from '../../application/utils';
+import useDebouncedMutation from '../../../common/hooks/useDebouncedMutation';
 
 type Props = {
   isOpen: boolean;
@@ -28,7 +28,11 @@ export default function UserDeleteDialog({
     ? t('hankeUsers:deleteDialog:title:canDelete')
     : t('hankeUsers:deleteDialog:title:cannotDelete');
 
-  const { mutate, isLoading, isError, reset } = useMutation(deleteUser);
+  const { mutate, isLoading, isError, reset } = useDebouncedMutation(deleteUser, {
+    onSuccess() {
+      onDelete(userToDelete!);
+    },
+  });
 
   function getDialogText() {
     if (onlyOmistajanYhteyshenkilo) {
@@ -67,11 +71,7 @@ export default function UserDeleteDialog({
   }
 
   function confirmDeleteUser() {
-    mutate(userToDelete?.id, {
-      onSuccess() {
-        onDelete(userToDelete!);
-      },
-    });
+    mutate(userToDelete?.id);
   }
 
   return (

--- a/src/domain/johtoselvitys/johtoselvitysCreateDialog/JohtoselvitysCreateDialog.tsx
+++ b/src/domain/johtoselvitys/johtoselvitysCreateDialog/JohtoselvitysCreateDialog.tsx
@@ -3,7 +3,6 @@ import { Button, Dialog, IconCheck, IconCross, IconInfoCircle, Notification } fr
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useMutation } from 'react-query';
 import { yupResolver } from '@hookform/resolvers/yup';
 import TextInput from '../../../common/components/textInput/TextInput';
 import useLinkPath from '../../../common/hooks/useLinkPath';
@@ -12,6 +11,7 @@ import { NewJohtoselvitysData } from '../../application/types/application';
 import { newJohtoselvitysSchema } from '../validationSchema';
 import { createJohtoselvitys } from '../../application/utils';
 import OwnInformationFields from '../../forms/components/OwnInformationFields';
+import useDebouncedMutation from '../../../common/hooks/useDebouncedMutation';
 
 type Props = {
   isOpen: boolean;
@@ -27,7 +27,20 @@ function JohtoselvitysCreateDialog({ isOpen, onClose }: Readonly<Props>) {
     resolver: yupResolver(newJohtoselvitysSchema),
   });
   const { handleSubmit, reset: resetForm } = formContext;
-  const { mutate, reset: resetMutation, isLoading, isError } = useMutation(createJohtoselvitys);
+  const {
+    mutate,
+    reset: resetMutation,
+    isLoading,
+    isError,
+  } = useDebouncedMutation(createJohtoselvitys, {
+    onSuccess({ id }) {
+      resetForm();
+      onClose();
+      if (id) {
+        navigate(getEditJohtoselvitysPath({ id: id.toString() }));
+      }
+    },
+  });
   const dialogTitle = t('johtoselvitysForm:createNewJohtoselvitys');
 
   function handleClose() {
@@ -37,14 +50,7 @@ function JohtoselvitysCreateDialog({ isOpen, onClose }: Readonly<Props>) {
   }
 
   async function submitForm(data: NewJohtoselvitysData) {
-    mutate(data, {
-      onSuccess({ id }) {
-        handleClose();
-        if (id) {
-          navigate(getEditJohtoselvitysPath({ id: id.toString() }));
-        }
-      },
-    });
+    mutate(data);
   }
 
   return (

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -41,6 +41,11 @@ export const handlers = [
     },
   ),
 
+  http.get<PathParams, undefined, HankeDataDraft[]>(`${apiUrl}/hankkeet`, async () => {
+    const hankkeet = await hankkeetDB.readAll();
+    return HttpResponse.json(hankkeet);
+  }),
+
   http.post<PathParams, HankeDataDraft, Partial<HankeDataDraft>>(
     `${apiUrl}/hankkeet`,
     async ({ request }) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,17 +34,21 @@ const container = document.getElementById('root');
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const root = createRoot(container!);
 
-if (window._env_.REACT_APP_MOCK_API === 'use') {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
-  const { worker } = require('./domain/mocks/browser');
-  worker.start();
+async function enableMocking() {
+  if (window._env_.REACT_APP_MOCK_API !== 'use') {
+    return;
+  }
+  const { worker } = await import('./domain/mocks/browser');
+  return worker.start();
 }
 
 if (process.env.NODE_ENV !== 'production') {
   import('@axe-core/react').then((axe) => {
     // https://github.com/dequelabs/axe-core-npm/issues/176
     axe.default(React, ReactDOM, 1000, {}, undefined);
-    root.render(<App />);
+    enableMocking().then(() => {
+      root.render(<App />);
+    });
   });
 } else {
   root.render(<App />);


### PR DESCRIPTION
# Description

There was a problem with adding a new contact for hanke where clicking "Tallenna ja lisää yhteyshenkilö" button multiple times would send requests and the ones after the first one would fail because the same user was already created with the first request and an error would be shown to user.

Fixed the problem by creating a wrapper for react-query useMutation hook where the mutate function is debounced, preveting multiple consecutive mutations happening in short succession.

Also applied that hook to places where there might be a risk for multiple consecutive requests.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2652

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

1. Add new contact person in hanke form, johtoselvitys form or kaivuilmoitus form
2. When adding contact person try to click "Tallenna ja lisää yhteyshenkilö" button many times in a row
3. Check that only one POST request for that is made

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
