### PR TITLE
HAI-2730 Use the same map levels as kartta.hel.fi

### DIFF
--- a/src/domain/map/components/Layers/Kantakartta.tsx
+++ b/src/domain/map/components/Layers/Kantakartta.tsx
@@ -18,40 +18,21 @@ const Kantakartta = () => {
   };
 
   return (
-    <>
-      <TileLayer
-        minZoom={9}
-        source={
-          new TileWMS({
-            ...sourceOptions,
-            params: {
-              LAYERS: 'Kantakartta',
-              FORMAT: 'image/jpeg',
-              WIDTH: 256,
-              HEIGHT: 256,
-              VERSION: '1.1.1',
-              TRANSPARENT: 'false',
-            },
-          })
-        }
-      />
-      <TileLayer
-        maxZoom={9}
-        source={
-          new TileWMS({
-            ...sourceOptions,
-            params: {
-              LAYERS: 'Opaskartta_Helsinki',
-              FORMAT: 'image/jpeg',
-              WIDTH: 256,
-              HEIGHT: 256,
-              VERSION: '1.1.1',
-              TRANSPARENT: 'false',
-            },
-          })
-        }
-      />
-    </>
+    <TileLayer
+      source={
+        new TileWMS({
+          ...sourceOptions,
+          params: {
+            LAYERS: 'Karttasarja',
+            FORMAT: 'image/png',
+            WIDTH: 256,
+            HEIGHT: 256,
+            VERSION: '1.1.1',
+            TRANSPARENT: 'false',
+          },
+        })
+      }
+    />
   );
 };
 


### PR DESCRIPTION
# Description

There's a simple way to use the same map levels as kartta.hel.fi when zooming in and out. Kartta.hel.fi exposes the 'Karttasarja' map layer, which has different maps for different zoom levels.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2730

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Open any map view and zoom in.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Some refactoring (at least renaming the TileLayer) should be done before merging.