### PR TITLE
HAI-2626 Show customer registry key label based on contact type

### DIFF
--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -21,6 +21,7 @@ import { HankeUser } from '../../hanke/hankeUsers/hankeUser';
 import { useHankeUsers } from '../../hanke/hankeUsers/hooks/useHankeUsers';
 import { mapHankeUserToContact } from '../../hanke/hankeUsers/utils';
 import UserSearchInput from '../../hanke/hankeUsers/UserSearchInput';
+import { TFunction } from 'i18next';
 
 function getEmptyCustomerWithContacts(): CustomerWithContacts {
   return {
@@ -36,6 +37,37 @@ function getEmptyCustomerWithContacts(): CustomerWithContacts {
   };
 }
 
+function isRegistryKeyInputEnabled(
+  customerType: string,
+  selectedContactType: string | null,
+  applicationType: string,
+) {
+  return (
+    selectedContactType === 'COMPANY' ||
+    selectedContactType === 'ASSOCIATION' ||
+    (applicationType === 'EXCAVATION_NOTIFICATION' && customerType === 'customerWithContacts')
+  );
+}
+
+function getRegistryKeyLabel(
+  t: TFunction<'translation', undefined>,
+  customerType: string,
+  selectedContactType: string | null,
+  applicationType: string,
+) {
+  if (selectedContactType === 'COMPANY' || selectedContactType === 'ASSOCIATION') {
+    return t('form:yhteystiedot:labels:ytunnus');
+  }
+  if (applicationType === 'EXCAVATION_NOTIFICATION' && customerType === 'customerWithContacts') {
+    if (selectedContactType === 'PERSON') {
+      return t('form:yhteystiedot:labels:henkilotunnus');
+    } else {
+      return t('form:yhteystiedot:labels:muuTunnus');
+    }
+  }
+  return t('form:yhteystiedot:labels:ytunnus');
+}
+
 const CustomerFields: React.FC<{
   customerType: CustomerType;
   hankeUsers?: HankeUser[];
@@ -44,19 +76,22 @@ const CustomerFields: React.FC<{
   const { watch, setValue, getValues } = useFormContext<Application>();
 
   const applicationType = getValues('applicationData.applicationType');
-
   const selectedContactType = watch(`applicationData.${customerType}.customer.type`);
-  const registryKeyInputDisabled =
-    selectedContactType === 'PERSON' || selectedContactType === 'OTHER';
+  const registryKeyInputEnabled = isRegistryKeyInputEnabled(
+    customerType,
+    selectedContactType,
+    applicationType,
+  );
+  const registryKeyInputDisabled = !registryKeyInputEnabled;
 
   useEffect(() => {
-    // If setting contact type to other than company or association, set null to registry key
-    if (selectedContactType === 'PERSON' || selectedContactType === 'OTHER') {
+    // If setting contact type disables the registry key, set it to null
+    if (!isRegistryKeyInputEnabled(customerType, selectedContactType, applicationType)) {
       setValue(`applicationData.${customerType}.customer.registryKey`, null, {
         shouldValidate: true,
       });
     }
-  }, [selectedContactType, customerType, setValue]);
+  }, [selectedContactType, customerType, applicationType, setValue]);
 
   function handleUserSelect(user: HankeUser) {
     setValue(`applicationData.${customerType}.customer.email`, user.sahkoposti, {
@@ -105,7 +140,7 @@ const CustomerFields: React.FC<{
         />
         <TextInput
           name={`applicationData.${customerType}.customer.registryKey`}
-          label={t('form:yhteystiedot:labels:ytunnus')}
+          label={getRegistryKeyLabel(t, customerType, selectedContactType, applicationType)}
           disabled={registryKeyInputDisabled}
           autoComplete="on"
           defaultValue={null}

--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -6,6 +6,7 @@ import { useFormContext } from 'react-hook-form';
 import { useQueryClient } from 'react-query';
 import {
   Application,
+  ApplicationType,
   Contact,
   ContactType,
   CustomerType,
@@ -38,9 +39,9 @@ function getEmptyCustomerWithContacts(): CustomerWithContacts {
 }
 
 function isRegistryKeyInputEnabled(
-  customerType: string,
-  selectedContactType: string | null,
-  applicationType: string,
+  customerType: CustomerType,
+  selectedContactType: keyof typeof ContactType | null,
+  applicationType: ApplicationType,
 ) {
   return (
     selectedContactType === 'COMPANY' ||
@@ -51,9 +52,9 @@ function isRegistryKeyInputEnabled(
 
 function getRegistryKeyLabel(
   t: TFunction<'translation', undefined>,
-  customerType: string,
-  selectedContactType: string | null,
-  applicationType: string,
+  customerType: CustomerType,
+  selectedContactType: keyof typeof ContactType | null,
+  applicationType: ApplicationType,
 ) {
   if (selectedContactType === 'COMPANY' || selectedContactType === 'ASSOCIATION') {
     return t('form:yhteystiedot:labels:ytunnus');

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -816,3 +816,130 @@ test('Work description should be limited to 2000 characters', async () => {
 
   expect(screen.getByLabelText(/työn kuvaus/i)).toHaveValue(initialDescription.concat('b'));
 });
+
+describe('Show correct registry key label', () => {
+  const hankeData = hankkeet[1] as HankeData;
+  const johtoselvitysApplication = cloneDeep(applications[0] as Application<JohtoselvitysData>);
+  const testApplication: Application<JohtoselvitysData> = {
+    ...johtoselvitysApplication,
+    applicationData: {
+      ...johtoselvitysApplication.applicationData,
+      customerWithContacts: null,
+      contractorWithContacts: null,
+      propertyDeveloperWithContacts: null,
+      representativeWithContacts: null,
+    },
+  };
+
+  describe('Customer', () => {
+    test('Should show y-tunnus label when type is private person', async () => {
+      const { user } = render(
+        <JohtoselvitysContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yksityishenkilö')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
+    });
+
+    test('Should show y-tunnus label when type is company', async () => {
+      const { user } = render(
+        <JohtoselvitysContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yritys')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
+    });
+
+    test('Should show y-tunnus label when type is association', async () => {
+      const { user } = render(
+        <JohtoselvitysContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yhdistys')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
+    });
+
+    test('Should show y-tunnus label when type is other', async () => {
+      const { user } = render(
+        <JohtoselvitysContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Muu')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(
+        screen.queryByText('Y-tunnus, henkilötunnus tai muu yksilöivä tunnus'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Contractor', () => {
+    test('Should show y-tunnus label when type is private person', async () => {
+      const { user } = render(
+        <JohtoselvitysContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yksityishenkilö')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
+    });
+
+    test('Should show y-tunnus label when type is company', async () => {
+      const { user } = render(
+        <JohtoselvitysContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yritys')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
+    });
+
+    test('Should show y-tunnus label when type is association', async () => {
+      const { user } = render(
+        <JohtoselvitysContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yhdistys')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
+    });
+
+    test('Should show y-tunnus label when type is other', async () => {
+      const { user } = render(
+        <JohtoselvitysContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Muu')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(
+        screen.queryByText('Y-tunnus, henkilötunnus tai muu yksilöivä tunnus'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1065,3 +1065,131 @@ test('Should be able to fill user email and phone by selecting existing user in 
     '0401234567',
   );
 });
+
+describe('Show correct registry key label', () => {
+  const hankeData = hankkeet[1] as HankeData;
+  const application = cloneDeep(applications[6] as Application<KaivuilmoitusData>);
+  const testApplication: Application<KaivuilmoitusData> = {
+    ...application,
+    applicationData: {
+      ...application.applicationData,
+      customerWithContacts: null,
+      contractorWithContacts: null,
+      propertyDeveloperWithContacts: null,
+      representativeWithContacts: null,
+      invoicingCustomer: null,
+    },
+  };
+
+  describe('Customer', () => {
+    test('Should show henkilotunnus label when type is private person', async () => {
+      const { user } = render(
+        <KaivuilmoitusContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yksityishenkilö')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(1);
+      expect(screen.getByText('Henkilötunnus')).toBeInTheDocument();
+    });
+
+    test('Should show y-tunnus label when type is company', async () => {
+      const { user } = render(
+        <KaivuilmoitusContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yritys')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
+    });
+
+    test('Should show y-tunnus label when type is association', async () => {
+      const { user } = render(
+        <KaivuilmoitusContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yhdistys')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
+    });
+
+    test('Should show general label when type is other', async () => {
+      const { user } = render(
+        <KaivuilmoitusContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Muu')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(1);
+      expect(
+        screen.getByText('Y-tunnus, henkilötunnus tai muu yksilöivä tunnus'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Contractor', () => {
+    test('Should show y-tunnus label when type is private person', async () => {
+      const { user } = render(
+        <KaivuilmoitusContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yksityishenkilö')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
+    });
+
+    test('Should show y-tunnus label when type is company', async () => {
+      const { user } = render(
+        <KaivuilmoitusContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yritys')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
+    });
+
+    test('Should show y-tunnus label when type is association', async () => {
+      const { user } = render(
+        <KaivuilmoitusContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yhdistys')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
+    });
+
+    test('Should show y-tunnus label when type is other', async () => {
+      const { user } = render(
+        <KaivuilmoitusContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Muu')[0]);
+
+      expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
+      expect(
+        screen.queryByText('Y-tunnus, henkilötunnus tai muu yksilöivä tunnus'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -221,6 +221,8 @@
         "sukunimi": "Sukunimi",
         "ytunnus": "Y-tunnus",
         "yTunnusTaiHetu": "Y-tunnus tai henkilötunnus",
+        "henkilotunnus": "Henkilötunnus",
+        "muuTunnus": "Y-tunnus, henkilötunnus tai muu yksilöivä tunnus",
         "osoite": "Katuosoite",
         "postinumero": "Postinumero",
         "postitoimipaikka": "Postitoimipaikka",


### PR DESCRIPTION
# Description

Show kaivuilmoitus customer ("Työstä vastaava") registry key label based on whether the field can take y-tunnus, hetu or general registry key.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2626

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Open a kaivuilmoitus and go to contacts form page
2. Change contact type for "Työstä vastaava"
3. Label for registry key should change based on contact type selection

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
