### PR TITLE
HAI-2626 Validate registry keys

### DIFF
--- a/src/common/utils/isValidPersonalId.test.ts
+++ b/src/common/utils/isValidPersonalId.test.ts
@@ -1,0 +1,45 @@
+import isValidPersonalId from './isValidPersonalId';
+
+test.each([
+  ['190950+016X'], // First valid year of 1800s
+  ['200299+703R'], // Last year of 1800s
+  ['180800V5272'], // First year of 1900s
+  ['090626-885W'], // Classic separator of 1900s
+  ['230577U869S'], // The different separators of 1900s
+  ['260570V398P'],
+  ['080720W894T'],
+  ['140288X700X'],
+  ['240411Y748N'],
+  ['110699W216E'], // The last year of 1900s
+  ['230500D7546'], // First year of 2000s
+  ['120621A3731'], // Classic separator of 2000s
+  ['120413B621B'], // The different separators of 2000s
+  ['130723C4416'],
+  ['241003D605U'],
+  ['100703E622X'],
+  ['060623F6387'],
+  ['180524E0426'], // As of writing, the last valid year of 2000s
+  ['290204A000B'], // Leap day on a leap year
+  ['110166-8080'], // Zero as check digit
+])('Should return true with valid personal id', (id) => {
+  expect(isValidPersonalId(id)).toBeTruthy();
+});
+
+test.each([
+  ['260570V398'], // Missing check digit
+  ['080720W84T'], // Missing one index digit
+  ['140288700X'], // Missing separator
+  ['24041Y748N'], // Missing one date digit
+  ['080720W8942T'], // Extra digit
+  ['190949+016N'], // Before 1850
+  ['120333B054D'], // In the future
+  ['120621K3731'], // Invalid separator
+  ['260570V398I'], // Invalid check digits
+  ['080720W8944'],
+  ['241003D605D'],
+  ['100703E6220'],
+  ['290204A000K'],
+  ['290203A0003'], // Leap day in a non-leap year
+])('Should return false with invalid personal id', (id) => {
+  expect(isValidPersonalId(id)).toBeFalsy();
+});

--- a/src/common/utils/isValidPersonalId.ts
+++ b/src/common/utils/isValidPersonalId.ts
@@ -1,0 +1,58 @@
+import { isValid, parse } from 'date-fns';
+
+const hetuRegex =
+  /^(?<day>\d{2})(?<month>\d{2})(?<year>\d{2})(?<separator>[-+U-YA-F])(?<index>\d{3})(?<checkDigit>[\dA-FHJ-NPR-Y])$/;
+const eighteens = ['+'];
+const nineteens = ['-', 'U', 'V', 'W', 'X', 'Y'];
+const twenties = ['A', 'B', 'C', 'D', 'E', 'F'];
+const checkDigits = '0123456789ABCDEFHJKLMNPRSTUVWXY'.split('');
+
+function isValidDate(day: string, month: string, year: string, century: number): boolean {
+  try {
+    const fullDate = `${century}${year}-${month}-${day}`;
+    const parsedDate = parse(fullDate, 'yyyy-MM-dd', new Date());
+
+    return isValid(parsedDate) && parsedDate > new Date('1850-01-01') && parsedDate < new Date();
+  } catch (e) {
+    return false;
+  }
+}
+
+function isValidCheckDigit(parts: string, checkDigit: string): boolean {
+  const index = parseInt(parts, 10) % 31;
+  return checkDigits[index] === checkDigit;
+}
+
+function toCentury(separator: string): number | null {
+  if (eighteens.includes(separator)) return 18;
+  if (nineteens.includes(separator)) return 19;
+  if (twenties.includes(separator)) return 20;
+  return null; // Invalid separator
+}
+
+export default function isValidPersonalId(value: string | null | undefined): boolean {
+  if (value === null || value === '') return true;
+  if (value === undefined) return false;
+
+  const match = hetuRegex.exec(value.toUpperCase());
+  if (!match || !match.groups) {
+    return false;
+  }
+
+  const { day, month, year, separator, index, checkDigit } = match.groups;
+
+  const century = toCentury(separator);
+  if (century === null) {
+    return false;
+  }
+
+  if (!isValidDate(day, month, year, century)) {
+    return false;
+  }
+
+  if (!isValidCheckDigit(`${day}${month}${year}${index}`, checkDigit)) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/common/utils/yup.ts
+++ b/src/common/utils/yup.ts
@@ -7,6 +7,7 @@ import { HankeDataFormState } from '../../domain/hanke/edit/types';
 import { Application } from '../../domain/application/types/application';
 import { format } from 'date-fns/format';
 import { fi } from 'date-fns/locale';
+import isValidPersonalId from './isValidPersonalId';
 
 // https://github.com/jquense/yup/blob/master/src/locale.ts
 yup.setLocale({
@@ -46,6 +47,14 @@ yup.addMethod(
   'businessId',
   function validBusinessId(message: yup.Message = { key: 'default', values: {} }) {
     return this.test('is-business-id', message, isValidBusinessId);
+  },
+);
+
+yup.addMethod(
+  yup.string,
+  'personalId',
+  function validPersonalId(message: yup.Message = { key: 'default', values: {} }) {
+    return this.test('is-personal-id', message, isValidPersonalId);
   },
 );
 

--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Accordion, Button, Fieldset, IconPlusCircle } from 'hds-react';
 import { $enum } from 'ts-enum-util';
 import { useTranslation } from 'react-i18next';
@@ -81,18 +81,26 @@ const CustomerFields: React.FC<{
     selectedContactType,
     applicationType,
   );
+  const isMounted = useRef(false);
 
   useEffect(() => {
-    // If setting contact type disables the registry key, set it to null
-    if (!isRegistryKeyInputEnabled(customerType, selectedContactType, applicationType)) {
+    // If setting contact type disables the registry key or contact type is changed (after mount), clear the registry key
+    if (
+      !isRegistryKeyInputEnabled(customerType, selectedContactType, applicationType) ||
+      isMounted.current
+    ) {
       setValue(`applicationData.${customerType}.customer.registryKey`, null, {
         shouldValidate: true,
       });
     }
+
     // always set registry key hidden to false when changing the contact type
     setValue(`applicationData.${customerType}.customer.registryKeyHidden`, false, {
       shouldValidate: true,
     });
+
+    // mark the component as mounted
+    isMounted.current = true;
   }, [selectedContactType, customerType, applicationType, setValue]);
 
   function handleUserSelect(user: HankeUser) {

--- a/src/domain/application/yupSchemas.ts
+++ b/src/domain/application/yupSchemas.ts
@@ -19,6 +19,10 @@ export const registryKeySchema = yup
   .when('type', {
     is: (value: string) => value === 'COMPANY' || value === 'ASSOCIATION',
     then: (schema) => schema.businessId(),
+  })
+  .when('type', {
+    is: (value: string) => value === 'PERSON',
+    then: (schema) => schema.personalId(),
   });
 
 export const customerSchema = contactSchema.omit(['firstName', 'lastName']).shape({

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -887,6 +887,45 @@ describe('Show correct registry key label', () => {
         screen.queryByText('Y-tunnus, henkilötunnus tai muu yksilöivä tunnus'),
       ).not.toBeInTheDocument();
     });
+
+    test('Registry key is not required for company and association customer types and disabled for others', async () => {
+      const { user } = render(
+        <JohtoselvitysContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      // private person
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yksityishenkilö')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.customerWithContacts.customer.registryKey'),
+      ).toBeDisabled();
+
+      // company
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yritys')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.customerWithContacts.customer.registryKey'),
+      ).not.toBeRequired();
+
+      // association
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yhdistys')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.customerWithContacts.customer.registryKey'),
+      ).not.toBeRequired();
+
+      // other
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Muu')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.customerWithContacts.customer.registryKey'),
+      ).toBeDisabled();
+    });
   });
 
   describe('Contractor', () => {
@@ -942,6 +981,45 @@ describe('Show correct registry key label', () => {
       expect(
         screen.queryByText('Y-tunnus, henkilötunnus tai muu yksilöivä tunnus'),
       ).not.toBeInTheDocument();
+    });
+
+    test('Registry key is not required for company and association customer types and disabled for others', async () => {
+      const { user } = render(
+        <JohtoselvitysContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      // private person
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yksityishenkilö')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.contractorWithContacts.customer.registryKey'),
+      ).toBeDisabled();
+
+      // company
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yritys')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.contractorWithContacts.customer.registryKey'),
+      ).not.toBeRequired();
+
+      // association
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yhdistys')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.contractorWithContacts.customer.registryKey'),
+      ).not.toBeRequired();
+
+      // other
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Muu')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.contractorWithContacts.customer.registryKey'),
+      ).toBeDisabled();
     });
   });
 });

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1138,6 +1138,45 @@ describe('Show correct registry key label', () => {
         screen.getByText('Y-tunnus, henkilötunnus tai muu yksilöivä tunnus'),
       ).toBeInTheDocument();
     });
+
+    test('Registry key is required for all customer types', async () => {
+      const { user } = render(
+        <KaivuilmoitusContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      // private person
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yksityishenkilö')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.customerWithContacts.customer.registryKey'),
+      ).toBeRequired();
+
+      // company
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yritys')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.customerWithContacts.customer.registryKey'),
+      ).toBeRequired();
+
+      // association
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Yhdistys')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.customerWithContacts.customer.registryKey'),
+      ).toBeRequired();
+
+      // other
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[0]);
+      fireEvent.click(screen.getAllByText('Muu')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.customerWithContacts.customer.registryKey'),
+      ).toBeRequired();
+    });
   });
 
   describe('Contractor', () => {
@@ -1161,7 +1200,7 @@ describe('Show correct registry key label', () => {
       await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
 
       fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
-      fireEvent.click(screen.getAllByText('Yritys')[0]);
+      fireEvent.click(screen.getAllByText('Yritys')[1]);
 
       expect(await screen.findAllByText('Y-tunnus')).toHaveLength(2);
       expect(screen.queryByText('Henkilötunnus')).not.toBeInTheDocument();
@@ -1193,6 +1232,45 @@ describe('Show correct registry key label', () => {
       expect(
         screen.queryByText('Y-tunnus, henkilötunnus tai muu yksilöivä tunnus'),
       ).not.toBeInTheDocument();
+    });
+
+    test('Registry key is required for company and association customer types and disabled for others', async () => {
+      const { user } = render(
+        <KaivuilmoitusContainer hankeData={hankeData} application={testApplication} />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      // private person
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yksityishenkilö')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.contractorWithContacts.customer.registryKey'),
+      ).toBeDisabled();
+
+      // company
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yritys')[1]);
+
+      expect(
+        await screen.findByTestId('applicationData.contractorWithContacts.customer.registryKey'),
+      ).toBeRequired();
+
+      // association
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Yhdistys')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.contractorWithContacts.customer.registryKey'),
+      ).toBeRequired();
+
+      // other
+      fireEvent.click(screen.getAllByRole('button', { name: /tyyppi/i })[1]);
+      fireEvent.click(screen.getAllByText('Muu')[0]);
+
+      expect(
+        await screen.findByTestId('applicationData.contractorWithContacts.customer.registryKey'),
+      ).toBeDisabled();
     });
   });
 });

--- a/src/domain/kaivuilmoitus/validationSchema.ts
+++ b/src/domain/kaivuilmoitus/validationSchema.ts
@@ -1,5 +1,5 @@
 import yup from '../../common/utils/yup';
-import { AlluStatus } from '../application/types/application';
+import { AlluStatus, ContactType } from '../application/types/application';
 import {
   applicationTypeSchema,
   customerSchema,
@@ -39,11 +39,22 @@ const kaivuilmoitusAlueSchema = yup.object({
   lisatiedot: yup.string(),
 });
 
-const customerWithContactsSchemaForKaivuilmoitus = customerWithContactsSchema
+const customerWithContactsSchemaForKaivuilmoitusForTyostaVastaava = customerWithContactsSchema
   .omit(['customer'])
   .shape({
     customer: customerSchema.omit(['registryKey']).shape({
       registryKey: registryKeySchema.required(),
+    }),
+  });
+
+const customerWithContactsSchemaForKaivuilmoitus = customerWithContactsSchema
+  .omit(['customer'])
+  .shape({
+    customer: customerSchema.omit(['registryKey']).shape({
+      registryKey: registryKeySchema.when('type', {
+        is: (value: string) => value === ContactType.COMPANY || value === ContactType.ASSOCIATION,
+        then: (schema) => schema.required(),
+      }),
     }),
   });
 
@@ -76,7 +87,7 @@ const applicationDataSchema = yup.object().shape(
       }),
     requiredCompetence: yup.boolean().required(),
     contractorWithContacts: customerWithContactsSchemaForKaivuilmoitus,
-    customerWithContacts: customerWithContactsSchemaForKaivuilmoitus,
+    customerWithContacts: customerWithContactsSchemaForKaivuilmoitusForTyostaVastaava,
     propertyDeveloperWithContacts: customerWithContactsSchemaForKaivuilmoitus.nullable(),
     representativeWithContacts: customerWithContactsSchemaForKaivuilmoitus.nullable(),
     invoicingCustomer: invoicingCustomerSchema,

--- a/src/domain/kaivuilmoitus/validationSchema.ts
+++ b/src/domain/kaivuilmoitus/validationSchema.ts
@@ -1,5 +1,5 @@
 import yup from '../../common/utils/yup';
-import { AlluStatus, ContactType } from '../application/types/application';
+import { AlluStatus } from '../application/types/application';
 import {
   applicationTypeSchema,
   customerSchema,
@@ -43,10 +43,7 @@ const customerWithContactsSchemaForKaivuilmoitus = customerWithContactsSchema
   .omit(['customer'])
   .shape({
     customer: customerSchema.omit(['registryKey']).shape({
-      registryKey: registryKeySchema.when('type', {
-        is: (value: string) => value === ContactType.COMPANY || value === ContactType.ASSOCIATION,
-        then: (schema) => schema.required(),
-      }),
+      registryKey: registryKeySchema.required(),
     }),
   });
 

--- a/src/types/yup-extensions.d.ts
+++ b/src/types/yup-extensions.d.ts
@@ -5,6 +5,7 @@ declare module 'yup' {
   interface StringSchema {
     phone(message?: Message): this;
     businessId(message?: Message): this;
+    personalId(message?: Message): this;
     uniqueEmail(): this;
     detectedTrafficNuisance(type: HAITTOJENHALLINTATYYPPI): this;
   }


### PR DESCRIPTION
# Description

Validate kaivuilmoitus customer ("Työstä vastaava") registry keys correctly for each contact type.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2626

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Open kaivuilmoitus and go to contacts form page
2. Try different invalid registry keys for the customer ("Työstä vastaava")
3. Try to remove registry key
4. Validation should work for invalid or missing registry keys

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
