### PR TITLE
HAI-2626 Show info text when the registry key is hidden

### DIFF
--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -46,6 +46,7 @@ function isRegistryKeyInputEnabled(
   applicationType: ApplicationType,
 ) {
   return (
+    selectedContactType === undefined ||
     selectedContactType === 'COMPANY' ||
     selectedContactType === 'ASSOCIATION' ||
     (applicationType === 'EXCAVATION_NOTIFICATION' && customerType === 'customerWithContacts')

--- a/src/domain/application/yupSchemas.ts
+++ b/src/domain/application/yupSchemas.ts
@@ -22,7 +22,11 @@ export const registryKeySchema = yup
   })
   .when('type', {
     is: (value: string) => value === 'PERSON',
-    then: (schema) => schema.personalId(),
+    then: (schema) =>
+      schema.when('registryKeyHidden', {
+        is: (value: boolean) => !value,
+        then: (personalIdSchema) => personalIdSchema.personalId(),
+      }),
   });
 
 export const customerSchema = contactSchema.omit(['firstName', 'lastName']).shape({

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -142,6 +142,14 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
           'applicationData.customerWithContacts.customer.yhteystietoId',
           customerWithContacts.customer.yhteystietoId,
         );
+        setValue(
+          'applicationData.customerWithContacts.customer.registryKey',
+          customerWithContacts.customer.registryKey,
+        );
+        setValue(
+          'applicationData.customerWithContacts.customer.registryKeyHidden',
+          customerWithContacts.customer.registryKeyHidden,
+        );
       }
       if (contractorWithContacts) {
         setValue(

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1177,6 +1177,38 @@ describe('Show correct registry key label', () => {
         await screen.findByTestId('applicationData.customerWithContacts.customer.registryKey'),
       ).toBeRequired();
     });
+
+    test('Should show info text for hidden registry key', async () => {
+      const { user } = render(
+        <KaivuilmoitusContainer
+          hankeData={hankeData}
+          application={{
+            ...testApplication,
+            applicationData: {
+              ...testApplication.applicationData,
+              customerWithContacts: {
+                customer: {
+                  type: 'PERSON',
+                  name: 'Testi Testinen',
+                  registryKey: null,
+                  registryKeyHidden: true,
+                  email: 'testi@testi.fi',
+                  phone: '0401234567',
+                },
+                contacts: [],
+              },
+            },
+          }}
+        />,
+      );
+      await user.click(screen.getByRole('button', { name: /yhteystiedot/i }));
+
+      expect(
+        await screen.findByText(
+          'Tunnus on piilotettu tietosuojasyistä. Voit halutessasi tallentaa uuden tunnuksen korvaamalla ******** tekstin uudella tunnuksella.',
+        ),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('Contractor', () => {

--- a/src/domain/kaivuilmoitus/validationSchema.ts
+++ b/src/domain/kaivuilmoitus/validationSchema.ts
@@ -1,5 +1,5 @@
 import yup from '../../common/utils/yup';
-import { AlluStatus, ContactType } from '../application/types/application';
+import { AlluStatus } from '../application/types/application';
 import {
   applicationTypeSchema,
   customerSchema,
@@ -51,10 +51,7 @@ const customerWithContactsSchemaForKaivuilmoitus = customerWithContactsSchema
   .omit(['customer'])
   .shape({
     customer: customerSchema.omit(['registryKey']).shape({
-      registryKey: registryKeySchema.when('type', {
-        is: (value: string) => value === ContactType.COMPANY || value === ContactType.ASSOCIATION,
-        then: (schema) => schema.required(),
-      }),
+      registryKey: registryKeySchema.required(),
     }),
   });
 

--- a/src/domain/kaivuilmoitus/validationSchema.ts
+++ b/src/domain/kaivuilmoitus/validationSchema.ts
@@ -1,5 +1,5 @@
 import yup from '../../common/utils/yup';
-import { AlluStatus } from '../application/types/application';
+import { AlluStatus, ContactType } from '../application/types/application';
 import {
   applicationTypeSchema,
   customerSchema,
@@ -51,7 +51,10 @@ const customerWithContactsSchemaForKaivuilmoitus = customerWithContactsSchema
   .omit(['customer'])
   .shape({
     customer: customerSchema.omit(['registryKey']).shape({
-      registryKey: registryKeySchema.required(),
+      registryKey: registryKeySchema.when('type', {
+        is: (value: string) => value === ContactType.COMPANY || value === ContactType.ASSOCIATION,
+        then: (schema) => schema.required(),
+      }),
     }),
   });
 

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -243,7 +243,8 @@
       },
       "helperTexts": {
         "otherPartyRole": "Tahon rooli hankkeessa",
-        "yhteyshenkilo": "Voit etsiä jo lisättyä henkilöä kirjoittamalla tai valitsemalla pudotusvalikosta, tai lisätä uuden yhteyshenkilön."
+        "yhteyshenkilo": "Voit etsiä jo lisättyä henkilöä kirjoittamalla tai valitsemalla pudotusvalikosta, tai lisätä uuden yhteyshenkilön.",
+        "registryKey": "Tunnus on piilotettu tietosuojasyistä. Voit halutessasi tallentaa uuden tunnuksen korvaamalla ******** tekstin uudella tunnuksella."
       },
       "contactType": {
         "YKSITYISHENKILO": "Yksityishenkilö",


### PR DESCRIPTION
# Description

Show info text when registry key is hidden.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2626

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Open kaivuilmoitus and go to contacts form page
2. If the registry key is hidden there should be an info text under the text input field

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
