### PR TITLE
HAI-2627 Group work areas by hanke areas in kaivuilmoitus page sidebar

### DIFF
--- a/src/common/components/customAccordion/CustomAccordion.tsx
+++ b/src/common/components/customAccordion/CustomAccordion.tsx
@@ -3,8 +3,10 @@ import { IconAngleDown, IconAngleUp, useAccordion } from 'hds-react';
 import React from 'react';
 
 type Props = {
+  accordionBorderBottom?: boolean;
   heading: React.ReactNode;
   headingType?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  subHeading?: React.ReactNode;
   headingBorderBottom?: boolean;
   headingBackgroundColor?: string;
   headingElement?: React.ReactNode;
@@ -16,8 +18,10 @@ type Props = {
 };
 
 export default function CustomAccordion({
+  accordionBorderBottom = false,
   heading,
   headingType = 'h2',
+  subHeading,
   headingBorderBottom = true,
   headingBackgroundColor,
   headingElement,
@@ -33,13 +37,18 @@ export default function CustomAccordion({
     contentProps: accordionContentProps,
   } = useAccordion({ initiallyOpen });
   const headingButtonIcon = isOpen ? <IconAngleUp size="s" /> : <IconAngleDown size="s" />;
+  const showHeadingBorderBottom =
+    (headingBorderBottom && !accordionBorderBottom) || (accordionBorderBottom && isOpen);
 
   return (
-    <div className={className}>
+    <Box
+      borderBottom={accordionBorderBottom ? '1px solid var(--color-black-60)' : undefined}
+      className={className}
+    >
       <Box
         padding="var(--spacing-s)"
         backgroundColor={headingBackgroundColor}
-        borderBottom={headingBorderBottom ? '1px solid var(--color-black-30)' : undefined}
+        borderBottom={showHeadingBorderBottom ? '1px solid var(--color-black-30)' : undefined}
         {...accordionButtonProps}
       >
         <Grid
@@ -54,19 +63,22 @@ export default function CustomAccordion({
             alignItems="center"
             flexWrap={{ base: 'wrap', sm: 'nowrap' }}
           >
-            <Box
-              as={headingType}
-              className={headingSize === 'm' ? 'heading-s' : 'heading-xs'}
-              textAlign="start"
-            >
-              {strong ? <strong>{heading}</strong> : heading}
-            </Box>
+            <div>
+              <Box
+                as={headingType}
+                className={headingSize === 'm' ? 'heading-s' : 'heading-xs'}
+                textAlign="start"
+              >
+                {strong ? <strong>{heading}</strong> : heading}
+              </Box>
+              {subHeading}
+            </div>
             {headingElement}
           </Flex>
           {headingButtonIcon}
         </Grid>
       </Box>
       <div {...accordionContentProps}>{children}</div>
-    </div>
+    </Box>
   );
 }

--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -250,6 +250,14 @@ describe('Excavation announcement application view', () => {
     expect(queryByText('10-99 m')).toBeInTheDocument();
   });
 
+  test('Shows correct information in sidebar', async () => {
+    render(<ApplicationViewContainer id={5} />);
+    await waitForLoadingToFinish();
+    const sidebar = screen.getByTestId('application-view-sidebar');
+
+    expect(sidebar).toMatchSnapshot();
+  });
+
   describe('Report excavation announcement in operational condition', () => {
     const setup = async (id: number = 8) => {
       const { user } = render(<ApplicationViewContainer id={id} />);

--- a/src/domain/application/applicationView/__snapshots__/ApplicationView.test.tsx.snap
+++ b/src/domain/application/applicationView/__snapshots__/ApplicationView.test.tsx.snap
@@ -1,0 +1,140 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Excavation announcement application view Shows correct information in sidebar 1`] = `
+<div
+  class="sideBar"
+  data-testid="application-view-sidebar"
+>
+  <div
+    class="css-11yjvs7"
+  >
+    <header
+      class="mapHeader"
+    >
+      <div
+        class="mapHeader__inner"
+      >
+        <svg
+          aria-hidden="true"
+          aria-label="location"
+          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+          role="img"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M11.9669 1.5C14.0265 1.5 16.0869 2.27765 17.6579 3.83367C20.8001 6.945 20.5878 11.7938 17.6579 15.1017L17.0345 15.8107C14.4235 18.8021 12.9688 20.7706 11.9669 22.7477C10.8937 20.6185 9.28527 18.4993 6.27797 15.1017C3.34814 11.7938 3.13508 6.945 6.27797 3.83367C7.84906 2.27765 9.90869 1.5 11.9669 1.5ZM11.999 3.5C10.3743 3.5 8.84685 4.12598 7.69956 5.26179C6.56645 6.38341 5.97897 7.81769 6.00058 9.41066C6.02151 10.984 6.64884 12.5453 7.76709 13.8087L8.42773 14.5606C10.0167 16.3842 11.1442 17.8 12.0004 19.0644C12.9748 17.6274 14.2916 16.0006 16.233 13.8087C17.3512 12.5453 17.9786 10.984 17.9995 9.41066C18.0198 7.81769 17.4323 6.38341 16.3005 5.26179C15.1519 4.12598 13.6251 3.5 11.999 3.5ZM12.0004 6C13.9338 6 15.5 7.56702 15.5 9.50039C15.5 11.433 13.9338 13 12.0004 13C10.067 13 8.5 11.433 8.5 9.50039C8.5 7.56702 10.067 6 12.0004 6ZM12.0003 8C11.1725 8 10.5 8.67319 10.5 9.50034C10.5 10.3268 11.1725 11 12.0003 11C12.8275 11 13.5 10.3268 13.5 9.50034C13.5 8.67319 12.8275 8 12.0003 8Z"
+            fill="currentColor"
+            fill-rule="evenodd"
+          />
+        </svg>
+        <h3
+          class="text--bold text--h5"
+        >
+          Alueiden sijainti
+        </h3>
+      </div>
+    </header>
+    <div
+      class="mapContainer"
+    >
+      <div
+        class="mapContainer__inner"
+        id="ol-map"
+      />
+    </div>
+  </div>
+  <div
+    class="css-zkgtxt"
+  >
+    <div
+      aria-expanded="false"
+      class="css-1ka79lz"
+    >
+      <button
+        class="css-12ax0h3"
+        type="button"
+      >
+        <div
+          class="css-usczae"
+        >
+          <div>
+            <h2
+              class="heading-xs css-1eif5ff"
+            >
+              Hankealue 2
+            </h2>
+            <div
+              class="css-aslqeu"
+            >
+              <p>
+                15.5.2023
+                –
+                30.9.2023
+              </p>
+            </div>
+          </div>
+        </div>
+        <svg
+          aria-hidden="true"
+          aria-label="angle-down"
+          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+          role="img"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M12 13.5L17 8.5L18.5 10L12 16.5L5.5 10L7 8.5L12 13.5Z"
+            fill="currentColor"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      style="display: none;"
+    >
+      <div
+        class="css-r09jf8"
+      >
+        <div
+          class="css-1evobf6"
+        >
+          <p
+            class="text--bold text--body-m text--spacing-bottom-2-xs"
+          >
+            Työalue 1
+             (
+            158 m²
+            )
+          </p>
+          <p>
+            12.1.2023
+            –
+            12.11.2024
+          </p>
+        </div>
+        <div
+          class="css-1evobf6"
+        >
+          <p
+            class="text--bold text--body-m text--spacing-bottom-2-xs"
+          >
+            Työalue 2
+             (
+            30 m²
+            )
+          </p>
+          <p>
+            12.1.2023
+            –
+            12.11.2024
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
# Description

Work areas are found under hanke area accordions which are closed by default.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2627

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check in kaivuilmoitus page that work areas are grouped in sidebar under hanke area accordions.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
