### PR TITLE
HAI-2630 Color kaivuilmoitus work areas based on their nuisance index

### DIFF
--- a/src/domain/application/components/ApplicationMap.tsx
+++ b/src/domain/application/components/ApplicationMap.tsx
@@ -30,6 +30,7 @@ import FeatureInfoOverlay from '../../map/components/FeatureInfoOverlay/FeatureI
 import FitSource from '../../map/components/interations/FitSource';
 import { formatToFinnishDate } from '../../../common/utils/date';
 import isFeatureWithinFeatures from '../../map/utils/isFeatureWithinFeatures';
+import { styleFunction } from '../../map/utils/geometryStyle';
 
 type Props = {
   drawSource: VectorSource;
@@ -191,7 +192,7 @@ export default function ApplicationMap({
 
           {children}
 
-          <VectorLayer source={drawSource} zIndex={2} className="drawLayer" />
+          <VectorLayer source={drawSource} zIndex={2} className="drawLayer" style={styleFunction} />
 
           <OverviewMapControl />
 

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -140,6 +140,7 @@ export class Tyoalue {
     this.geometry = new ApplicationGeometry((feature.getGeometry() as OlPolygon).getCoordinates());
     this.area = getSurfaceArea(feature.getGeometry()!);
     this.openlayersFeature = feature;
+    this.tormaystarkasteluTulos = feature.get('tormaystarkasteluTulos');
   }
 }
 

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -127,6 +127,7 @@ export class ApplicationGeometry implements PolygonWithCRS {
 export type ApplicationArea = {
   name?: string;
   geometry: ApplicationGeometry;
+  tormaystarkasteluTulos?: HaittaIndexData | null;
 };
 
 export class Tyoalue {

--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -477,7 +477,7 @@ test('Should be able to delete user who has draft hakemuksia, but should notify 
     ),
   ).toBeInTheDocument();
 
-  await screen.findByRole('button', { name: 'Poista' });
+  await screen.findByRole('button', { name: 'Poista' }, { timeout: 5000 });
   await user.click(screen.getByRole('button', { name: 'Poista' }));
 
   expect(screen.getByText('Käyttäjä poistettu')).toBeInTheDocument();

--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -104,6 +104,9 @@ export default function Areas({ hankeData }: Readonly<Props>) {
             relatedHankeAreaName: area.name,
             startDate: getValues('applicationData.startTime'),
             endDate: getValues('applicationData.endTime'),
+            liikennehaittaindeksi: tyoalue.tormaystarkasteluTulos
+              ? tyoalue.tormaystarkasteluTulos.liikennehaittaindeksi.indeksi
+              : null,
           });
           return tyoalue.openlayersFeature;
         }

--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -208,7 +208,7 @@ export default function Areas({ hankeData }: Readonly<Props>) {
           liikennehaittaindeksi: data.liikennehaittaindeksi.indeksi,
         });
         if (!existingArea) {
-          const [emptyArea /*, newTyoalue*/] = getEmptyArea(hankeData, hankeArea, feature);
+          const [emptyArea] = getEmptyArea(hankeData, hankeArea, feature);
           append(emptyArea);
         } else {
           const existingAreaIndex = areas.indexOf(existingArea);

--- a/src/domain/map/hooks/useApplicationFeatures.ts
+++ b/src/domain/map/hooks/useApplicationFeatures.ts
@@ -11,8 +11,19 @@ import { ApplicationArea } from '../../application/types/application';
 export default function useApplicationFeatures(source: Vector, areas?: ApplicationArea[]) {
   useEffect(() => {
     if (areas && areas.length > 0) {
-      const applicationFeatures = areas.flatMap((area) => {
-        return new GeoJSON().readFeatures(area.geometry);
+      const applicationFeatures = areas.map((area) => {
+        const feature = new GeoJSON().readFeatures(area.geometry)[0] as Feature<Geometry>;
+
+        feature.setProperties(
+          {
+            liikennehaittaindeksi: area.tormaystarkasteluTulos
+              ? area.tormaystarkasteluTulos.liikennehaittaindeksi.indeksi
+              : null,
+          },
+          true,
+        );
+
+        return feature;
       }) as Feature<Geometry>[];
       source.addFeatures(applicationFeatures);
     }


### PR DESCRIPTION
# Description

Kaivuilmoitus work areas are colored based on their nuisance index. This also changes a bit how the summary (maximum) of nuisance indices is calculated.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2630

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create a new or open an existing kaivuilmoitus, add some work areas to it if there are not any initially
2. The color of the work areas (new or existing) on the application form should be according to its nuisance index
3. The color of the work areas in the application view should be according to its nuisance index
4. Changes to the area geometry or car traffix nuisances (kaistahaitta) should also update the area coloring

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
