### PR TITLE
HAI-2626 Fix: Send empty strings as nulls

### DIFF
--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -120,6 +120,13 @@ const CustomerFields: React.FC<{
       }
     }
 
+    if (registryKey === '') {
+      // set the registry key to null when it is empty
+      setValue(`applicationData.${customerType}.customer.registryKey`, null, {
+        shouldValidate: true,
+      });
+    }
+
     // mark the component as mounted
     isMounted.current = true;
   }, [customerType, registryKey, setValue]);

--- a/src/domain/application/components/ApplicationContacts.tsx
+++ b/src/domain/application/components/ApplicationContacts.tsx
@@ -93,6 +93,7 @@ const CustomerFields: React.FC<{
     if (registryKey === HIDDEN_FIELD_VALUE) {
       setOriginalRegistryKeyIsHidden(true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -129,6 +130,7 @@ const CustomerFields: React.FC<{
 
     // mark the component as mounted
     isMounted.current = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [customerType, registryKey, setValue]);
 
   function handleUserSelect(user: HankeUser) {

--- a/src/domain/application/utils.test.ts
+++ b/src/domain/application/utils.test.ts
@@ -184,6 +184,32 @@ describe('modifyDataBeforeSend', () => {
       expect(modifiedApplicationData).toEqual(applicationData);
     },
   );
+
+  test('nullifies blank invoicing customer fields', () => {
+    const applicationData = {
+      ...hakemukset[7].applicationData,
+      invoicingCustomer: {
+        type: ContactType.PERSON,
+        name: 'Laskutushenkilö',
+        registryKey: null,
+        registryKeyHidden: true,
+        ovt: '',
+        invoicingOperator: '',
+        customerReference: '',
+        postalAddress: {
+          streetAddress: { streetName: 'Laskutuskuja 1' },
+          postalCode: '00100',
+          city: 'Helsinki',
+        },
+      },
+    };
+
+    const modifiedApplicationData = modifyDataBeforeSend(applicationData);
+
+    expect(modifiedApplicationData.invoicingCustomer?.ovt).toBeNull();
+    expect(modifiedApplicationData.invoicingCustomer?.invoicingOperator).toBeNull();
+    expect(modifiedApplicationData.invoicingCustomer?.customerReference).toBeNull();
+  });
 });
 
 describe('modifyDataAfterReceive', () => {

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -226,8 +226,18 @@ export function modifyDataBeforeSend<T extends JohtoselvitysUpdateData | Kaivuil
         kaivuilmoitusData.invoicingCustomer.registryKeyHidden = false;
       }
     }
+    if (kaivuilmoitusData?.invoicingCustomer?.ovt === '') {
+      kaivuilmoitusData.invoicingCustomer.ovt = null;
+    }
+    if (kaivuilmoitusData?.invoicingCustomer?.invoicingOperator === '') {
+      kaivuilmoitusData.invoicingCustomer.invoicingOperator = null;
+    }
+    if (kaivuilmoitusData?.invoicingCustomer?.customerReference === '') {
+      kaivuilmoitusData.invoicingCustomer.customerReference = null;
+    }
   }
 
+  console.log('modifyDataBeforeSend', kaivuilmoitusData);
   modifyKaivuilmoitusCustomerDataBeforeSend();
   modifyKaivuilmoitusInvoicingDataBeforeSend();
 

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -221,7 +221,10 @@ export function modifyDataBeforeSend<T extends JohtoselvitysUpdateData | Kaivuil
       if (kaivuilmoitusData?.invoicingCustomer?.registryKey === HIDDEN_FIELD_VALUE) {
         kaivuilmoitusData.invoicingCustomer.registryKey = null;
         kaivuilmoitusData.invoicingCustomer.registryKeyHidden = true;
-      } else if (kaivuilmoitusData?.invoicingCustomer?.registryKey === '') {
+      } else if (
+        kaivuilmoitusData?.invoicingCustomer?.registryKey === '' ||
+        kaivuilmoitusData?.invoicingCustomer?.registryKey == null
+      ) {
         kaivuilmoitusData.invoicingCustomer.registryKey = null;
         kaivuilmoitusData.invoicingCustomer.registryKeyHidden = false;
       }
@@ -237,7 +240,6 @@ export function modifyDataBeforeSend<T extends JohtoselvitysUpdateData | Kaivuil
     }
   }
 
-  console.log('modifyDataBeforeSend', kaivuilmoitusData);
   modifyKaivuilmoitusCustomerDataBeforeSend();
   modifyKaivuilmoitusInvoicingDataBeforeSend();
 

--- a/src/domain/kaivuilmoitus/Contacts.tsx
+++ b/src/domain/kaivuilmoitus/Contacts.tsx
@@ -61,6 +61,7 @@ export default function Contacts() {
     if (registryKey === HIDDEN_FIELD_VALUE) {
       setOriginalRegistryKeyIsHidden(true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -93,6 +94,7 @@ export default function Contacts() {
 
     // mark the component as mounted
     isMounted.current = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [registryKey, setValue]);
 
   useEffect(() => {

--- a/src/domain/kaivuilmoitus/Contacts.tsx
+++ b/src/domain/kaivuilmoitus/Contacts.tsx
@@ -65,13 +65,13 @@ export default function Contacts() {
 
   useEffect(() => {
     if (selectedContactType === 'PERSON' || selectedContactType === 'OTHER') {
-      resetField('applicationData.invoicingCustomer.ovt', { defaultValue: '' });
-      resetField('applicationData.invoicingCustomer.invoicingOperator', { defaultValue: '' });
+      resetField('applicationData.invoicingCustomer.ovt', { defaultValue: null });
+      resetField('applicationData.invoicingCustomer.invoicingOperator', { defaultValue: null });
     }
 
     if (isMounted.current) {
       // if the contact type is changed (after mount), clear the registry key
-      resetField('applicationData.invoicingCustomer.registryKey', { defaultValue: '' });
+      resetField('applicationData.invoicingCustomer.registryKey', { defaultValue: null });
       setOriginalRegistryKeyIsHidden(false);
     }
   }, [selectedContactType, setValue, resetField]);

--- a/src/domain/kaivuilmoitus/Contacts.tsx
+++ b/src/domain/kaivuilmoitus/Contacts.tsx
@@ -65,12 +65,12 @@ export default function Contacts() {
   }, []);
 
   useEffect(() => {
-    if (selectedContactType === 'PERSON' || selectedContactType === 'OTHER') {
-      resetField('applicationData.invoicingCustomer.ovt', { defaultValue: null });
-      resetField('applicationData.invoicingCustomer.invoicingOperator', { defaultValue: null });
-    }
-
     if (isMounted.current) {
+      if (selectedContactType === 'PERSON' || selectedContactType === 'OTHER') {
+        resetField('applicationData.invoicingCustomer.ovt', { defaultValue: null });
+        resetField('applicationData.invoicingCustomer.invoicingOperator', { defaultValue: null });
+      }
+
       // if the contact type is changed (after mount), clear the registry key
       resetField('applicationData.invoicingCustomer.registryKey', { defaultValue: null });
       setOriginalRegistryKeyIsHidden(false);
@@ -90,6 +90,13 @@ export default function Contacts() {
           shouldValidate: true,
         });
       }
+    }
+
+    if (registryKey === '' || registryKey === undefined) {
+      // set the registry key to null when it is empty or undefined
+      setValue(`applicationData.invoicingCustomer.registryKey`, null, {
+        shouldValidate: true,
+      });
     }
 
     // mark the component as mounted


### PR DESCRIPTION
# Description

Make sure that no empty string is sent in kaivuilmoitus invoicing customer: ovt, invoicingOperator, customerReference.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2626

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Fill kaivuilmoitus
2. In contacts page, set first the invoicing customer as a company, fills its data and then change the type to private person and fill the registry key and address to make it valid.
3. When changing the page, the API call should contain nulls instead of empty strings for the fields mentioned above

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
