### PR TITLE
HAI-2695 Only show hanke areas in kaivuilmoitus and johtoselvitys that are fully inside work time period

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -81,6 +81,7 @@ import HaittaIndexes from '../../common/haittaIndexes/HaittaIndexes';
 import { calculateLiikennehaittaindeksienYhteenveto } from '../../kaivuilmoitus/utils';
 import styles from './ApplicationView.module.scss';
 import CustomAccordion from '../../../common/components/customAccordion/CustomAccordion';
+import useFilterHankeAlueetByApplicationDates from '../hooks/useFilterHankeAlueetByApplicationDates';
 
 function SidebarTyoalueet({
   tyoalueet,
@@ -336,6 +337,11 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
   );
   const applicationSendMutation = useSendApplication();
 
+  const filterHankeAlueet = useFilterHankeAlueetByApplicationDates({
+    applicationStartDate: startTime,
+    applicationEndDate: endTime,
+  });
+
   async function onSendApplication() {
     setIsSendButtonDisabled(true);
     applicationSendMutation.mutate(id as number);
@@ -355,6 +361,13 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
 
   function closeReportWorkFinishedDialog() {
     setShowReportWorkFinishedDialog(false);
+  }
+
+  function getHankeWithAlueetFilteredByDates(hankeData: HankeData): HankeData {
+    return {
+      ...hankeData,
+      alueet: filterHankeAlueet(hankeData.alueet),
+    };
   }
 
   return (
@@ -586,7 +599,10 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
             <>
               <Box mb="var(--spacing-s)">
                 <OwnHankeMapHeader hankeTunnus={hanke.hankeTunnus} showLink={false} />
-                <OwnHankeMap hanke={hanke} application={application} />
+                <OwnHankeMap
+                  hanke={getHankeWithAlueetFilteredByDates(hanke)}
+                  application={application}
+                />
               </Box>
               {applicationType === 'CABLE_REPORT' && (
                 <SidebarTyoalueet tyoalueet={tyoalueet} startTime={startTime} endTime={endTime} />

--- a/src/domain/application/hooks/useFilterHankeAlueetByApplicationDates.ts
+++ b/src/domain/application/hooks/useFilterHankeAlueetByApplicationDates.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+import { HankeAlue } from '../../types/hanke';
+import { areDatesWithinInterval } from '../../map/utils';
+import { toStartOfDayUTCISO, toEndOfDayUTCISO } from '../../../common/utils/date';
+
+export default function useFilterHankeAlueetByApplicationDates({
+  applicationStartDate,
+  applicationEndDate,
+}: {
+  applicationStartDate: Date | null;
+  applicationEndDate: Date | null;
+}) {
+  return useCallback(
+    (alueet: HankeAlue[]) => {
+      return alueet.filter((alue) =>
+        areDatesWithinInterval({
+          start: alue.haittaAlkuPvm && toStartOfDayUTCISO(alue.haittaAlkuPvm),
+          end: alue.haittaLoppuPvm && toEndOfDayUTCISO(alue.haittaLoppuPvm),
+        })({
+          start: applicationStartDate && toStartOfDayUTCISO(applicationStartDate),
+          end: applicationEndDate && toEndOfDayUTCISO(applicationEndDate),
+        }),
+      );
+    },
+    [applicationStartDate, applicationEndDate],
+  );
+}

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -28,7 +28,7 @@ import styles from './HankePortfolio.module.scss';
 import { formatToFinnishDate } from '../../../common/utils/date';
 import DateRangeControl from '../../../common/components/map/controls/DateRangeControl';
 import { usePortfolioFilter } from './hooks/usePortfolioFilter';
-import { hankeIsBetweenDates } from '../../map/utils';
+import { areDatesWithinInterval } from '../../map/utils';
 import useLinkPath from '../../../common/hooks/useLinkPath';
 import { ROUTES } from '../../../common/types/route';
 import HankeVaiheTag from '../vaiheTag/HankeVaiheTag';
@@ -315,9 +315,12 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
       if (dateStart) {
         if (hankeFilterEndDate) {
           return dateStartRows.filter((hanke) =>
-            hankeIsBetweenDates({ startDate: dateStart, endDate: hankeFilterEndDate })({
-              startDate: hanke.values.alkuPvm,
-              endDate: hanke.values.loppuPvm,
+            areDatesWithinInterval(
+              { start: dateStart, end: hankeFilterEndDate },
+              { allowOverlapping: true },
+            )({
+              start: hanke.values.alkuPvm,
+              end: hanke.values.loppuPvm,
             }),
           );
         }
@@ -330,9 +333,12 @@ const PaginatedPortfolio: React.FC<React.PropsWithChildren<PagedRowsProps>> = ({
       if (dateEnd) {
         if (hankeFilterStartDate) {
           return dateEndRows.filter((hanke) =>
-            hankeIsBetweenDates({ startDate: hankeFilterStartDate, endDate: dateEnd })({
-              startDate: hanke.values.alkuPvm,
-              endDate: hanke.values.loppuPvm,
+            areDatesWithinInterval(
+              { start: hankeFilterStartDate, end: dateEnd },
+              { allowOverlapping: true },
+            )({
+              start: hanke.values.alkuPvm,
+              end: hanke.values.loppuPvm,
             }),
           );
         }

--- a/src/domain/johtoselvitys/Geometries.tsx
+++ b/src/domain/johtoselvitys/Geometries.tsx
@@ -24,6 +24,7 @@ import DrawProvider from '../../common/components/map/modules/draw/DrawProvider'
 import useDrawContext from '../../common/components/map/modules/draw/useDrawContext';
 import ApplicationMap from '../application/components/ApplicationMap';
 import useAddressCoordinate from '../map/hooks/useAddressCoordinate';
+import useFilterHankeAlueetByApplicationDates from '../application/hooks/useFilterHankeAlueetByApplicationDates';
 
 function AreaList({
   applicationAreas,
@@ -144,6 +145,11 @@ export function Geometries({ hankeData }: Readonly<Props>) {
     getValues('applicationData.postalAddress.streetAddress.streetName'),
   );
 
+  const filterHankeAlueet = useFilterHankeAlueetByApplicationDates({
+    applicationStartDate: startTime,
+    applicationEndDate: endTime,
+  });
+
   function handleAddArea(feature: Feature<Geometry>) {
     append(getEmptyArea(feature));
   }
@@ -219,9 +225,8 @@ export function Geometries({ hankeData }: Readonly<Props>) {
           {!hankeData?.generated && (
             <HankeLayer
               hankeData={hankeData && [hankeData]}
-              startDate={startTime?.toString() ?? hankeData?.alkuPvm}
-              endDate={endTime?.toString() ?? hankeData?.loppuPvm}
               fitSource
+              filterHankeAlueet={filterHankeAlueet}
             />
           )}
         </ApplicationMap>

--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -41,6 +41,7 @@ import { getAreaDefaultName } from '../application/utils';
 import HaittaIndexes from '../common/haittaIndexes/HaittaIndexes';
 import useHaittaIndexes from '../hanke/hooks/useHaittaIndexes';
 import { calculateLiikennehaittaindeksienYhteenveto } from './utils';
+import useFilterHankeAlueetByApplicationDates from '../application/hooks/useFilterHankeAlueetByApplicationDates';
 
 function getEmptyArea(
   hankeData: HankeData,
@@ -126,6 +127,11 @@ export default function Areas({ hankeData }: Readonly<Props>) {
   const minEndDate = startTime ? new Date(startTime) : undefined;
   const maxDate = hankeData.loppuPvm ? new Date(hankeData.loppuPvm) : undefined;
   const workTimesSet = startTime && endTime;
+
+  const filterHankeAlueet = useFilterHankeAlueetByApplicationDates({
+    applicationStartDate: startTime,
+    applicationEndDate: endTime,
+  });
 
   const refreshHaittaIndexes = useCallback(
     (kaivuilmoitusalueIndex?: number) => {
@@ -386,9 +392,8 @@ export default function Areas({ hankeData }: Readonly<Props>) {
         >
           <HankeLayer
             hankeData={hankeData && [hankeData]}
-            startDate={startTime?.toString()}
-            endDate={endTime?.toString()}
             fitSource
+            filterHankeAlueet={filterHankeAlueet}
           />
         </ApplicationMap>
 

--- a/src/domain/map/HankeMap.tsx
+++ b/src/domain/map/HankeMap.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import Map from '../../common/components/map/Map';
 import Controls from '../../common/components/map/controls/Controls';
 import LayerControl from '../../common/components/map/controls/LayerControl';
@@ -19,6 +19,8 @@ import MapGuide from './components/MapGuide/MapGuide';
 import HankkeetProvider from './HankkeetProvider';
 import OverviewMapControl from '../../common/components/map/controls/OverviewMapControl';
 import AddressSearchContainer from './components/AddressSearch/AddressSearchContainer';
+import { HankeAlue } from '../types/hanke';
+import { areDatesWithinInterval } from './utils';
 
 const HankeMap: React.FC<React.PropsWithChildren<unknown>> = () => {
   const [zoom] = useState(9); // TODO: also take zoom into consideration
@@ -30,6 +32,24 @@ const HankeMap: React.FC<React.PropsWithChildren<unknown>> = () => {
     setHankeFilterStartDate,
     setHankeFilterEndDate,
   } = useDateRangeFilter();
+
+  const filterHankeAlueet = useCallback(
+    (alueet: HankeAlue[]) => {
+      return alueet.filter((alue) =>
+        areDatesWithinInterval(
+          {
+            start: hankeFilterStartDate,
+            end: hankeFilterEndDate,
+          },
+          { allowOverlapping: true },
+        )({
+          start: alue.haittaAlkuPvm,
+          end: alue.haittaLoppuPvm,
+        }),
+      );
+    },
+    [hankeFilterStartDate, hankeFilterEndDate],
+  );
 
   return (
     <div className={styles.mapContainer} id="hankemap">
@@ -46,12 +66,7 @@ const HankeMap: React.FC<React.PropsWithChildren<unknown>> = () => {
           <FeatureClick />
           <GeometryHover>
             <HankeHoverBox />
-            <HankeLayer
-              startDate={hankeFilterStartDate}
-              endDate={hankeFilterEndDate}
-              centerOnMap
-              highlightFeatures
-            />
+            <HankeLayer filterHankeAlueet={filterHankeAlueet} centerOnMap highlightFeatures />
           </GeometryHover>
         </HankkeetProvider>
 

--- a/src/domain/map/components/OwnHankeMap/OwnHankeMap.tsx
+++ b/src/domain/map/components/OwnHankeMap/OwnHankeMap.tsx
@@ -55,7 +55,9 @@ const OwnHankeMap: React.FC<Props> = ({ hanke, application }) => {
           className="applicationGeometryLayer"
           style={(feature: FeatureLike) => styleFunction(feature, undefined, true)}
         />
-        <FitSource source={application ? applicationSource.current : hankeSource.current} />
+        <FitSource
+          source={application && tyoalueet.length ? applicationSource.current : hankeSource.current}
+        />
       </Map>
     </div>
   );

--- a/src/domain/map/types.ts
+++ b/src/domain/map/types.ts
@@ -44,3 +44,8 @@ export type MapTilelayerState = {
   id: MapTileLayerId;
   visible: boolean;
 };
+
+export type DateInterval = {
+  start: Date | string | number | null | undefined;
+  end: Date | string | number | null | undefined;
+};

--- a/src/domain/map/utils.test.ts
+++ b/src/domain/map/utils.test.ts
@@ -1,0 +1,45 @@
+import { areDatesWithinInterval } from './utils';
+
+describe('areDatesWithinInterval', () => {
+  test('returns true if date range is within the given interval', () => {
+    const interval = { start: new Date('2023-01-01'), end: new Date('2023-12-31') };
+    const dateRange = { start: new Date('2023-06-01'), end: new Date('2023-06-30') };
+    expect(areDatesWithinInterval(interval)(dateRange)).toBe(true);
+  });
+
+  test('returns false if date range is completely outside the interval', () => {
+    const interval = { start: new Date('2023-01-01'), end: new Date('2023-12-31') };
+    const dateRange = { start: new Date('2024-01-01'), end: new Date('2024-01-31') };
+    expect(areDatesWithinInterval(interval)(dateRange)).toBe(false);
+  });
+
+  test('returns true if date range starts before and ends within the interval with allowOverlapping option', () => {
+    const interval = { start: new Date('2023-01-01'), end: new Date('2023-12-31') };
+    const dateRange = { start: new Date('2022-12-01'), end: new Date('2023-01-15') };
+    expect(areDatesWithinInterval(interval, { allowOverlapping: true })(dateRange)).toBe(true);
+  });
+
+  test('returns true if date range starts within and ends after the interval with allowOverlapping option', () => {
+    const interval = { start: new Date('2023-01-01'), end: new Date('2023-12-31') };
+    const dateRange = { start: new Date('2023-12-15'), end: new Date('2024-01-15') };
+    expect(areDatesWithinInterval(interval, { allowOverlapping: true })(dateRange)).toBe(true);
+  });
+
+  test('returns false if date range starts before and ends after the interval without allowOverlapping option', () => {
+    const interval = { start: new Date('2023-01-01'), end: new Date('2023-12-31') };
+    const dateRange = { start: new Date('2022-12-01'), end: new Date('2024-01-15') };
+    expect(areDatesWithinInterval(interval)(dateRange)).toBe(false);
+  });
+
+  test('returns true if date range exactly matches the interval', () => {
+    const interval = { start: new Date('2023-01-01'), end: new Date('2023-12-31') };
+    const dateRange = { start: new Date('2023-01-01'), end: new Date('2023-12-31') };
+    expect(areDatesWithinInterval(interval)(dateRange)).toBe(true);
+  });
+
+  test('returns false if date range is partially outside the interval without allowOverlapping option', () => {
+    const interval = { start: new Date('2023-01-01'), end: new Date('2023-12-31') };
+    const dateRange = { start: new Date('2022-12-15'), end: new Date('2023-01-15') };
+    expect(areDatesWithinInterval(interval)(dateRange)).toBe(false);
+  });
+});


### PR DESCRIPTION
# Description

When user has entered work start and end dates in kaivuilmoitus or johtoselvitys form only show hanke areas which have duration completely within given work dates.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2695

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

1. Create or edit existing kaivuilmoitus or johtoselvitys.
2. Check that when setting work dates in areas page that only hanke areas which have duration completely within given work dates are shown.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
