### PR TITLE
HAI-1740 Confirmation dialog for sending application

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -82,6 +82,7 @@ import { calculateLiikennehaittaindeksienYhteenveto } from '../../kaivuilmoitus/
 import styles from './ApplicationView.module.scss';
 import CustomAccordion from '../../../common/components/customAccordion/CustomAccordion';
 import useFilterHankeAlueetByApplicationDates from '../hooks/useFilterHankeAlueetByApplicationDates';
+import ApplicationSendDialog from '../components/ApplicationSendDialog';
 
 function SidebarTyoalueet({
   tyoalueet,
@@ -285,6 +286,7 @@ type Props = {
 function ApplicationView({ application, hanke, signedInUser, onEditApplication }: Readonly<Props>) {
   const { t } = useTranslation();
   const [isSendButtonDisabled, setIsSendButtonDisabled] = useState(false);
+  const [showSendDialog, setShowSendDialog] = useState(false);
   const [showReportOperationalConditionDialog, setShowReportOperationalConditionDialog] =
     useState(false);
   const [showReportWorkFinishedDialog, setShowReportWorkFinishedDialog] = useState(false);
@@ -342,9 +344,21 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
     applicationEndDate: endTime,
   });
 
-  async function onSendApplication() {
+  async function onSendApplication(pdr: PaperDecisionReceiver | undefined | null) {
+    applicationSendMutation.mutate({
+      id: id as number,
+      paperDecisionReceiver: pdr,
+    });
     setIsSendButtonDisabled(true);
-    applicationSendMutation.mutate(id as number);
+    setShowSendDialog(false);
+  }
+
+  function openSendDialog() {
+    setShowSendDialog(true);
+  }
+
+  function closeSendDialog() {
+    setShowSendDialog(false);
   }
 
   function openReportOperationalConditionDialog() {
@@ -445,9 +459,7 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
               <Button
                 theme="coat"
                 iconLeft={<IconEnvelope aria-hidden="true" />}
-                onClick={onSendApplication}
-                isLoading={applicationSendMutation.isLoading}
-                loadingText={t('common:buttons:sendingText')}
+                onClick={openSendDialog}
                 disabled={disableSendButton || isSendButtonDisabled}
               >
                 {t('hakemus:buttons:sendApplication')}
@@ -657,6 +669,13 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
           applicationId={application.id as number}
         />
       )}
+      <ApplicationSendDialog
+        isOpen={showSendDialog}
+        isLoading={applicationSendMutation.isLoading}
+        onClose={closeSendDialog}
+        onSend={onSendApplication}
+        applicationId={application.id as number}
+      />
     </InformationViewContainer>
   );
 }

--- a/src/domain/application/components/ApplicationSendDialog.test.tsx
+++ b/src/domain/application/components/ApplicationSendDialog.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from '../../../testUtils/render';
+import ApplicationSendDialog from './ApplicationSendDialog';
+import { waitFor } from '@testing-library/react';
+
+test('Shows correct information when opened', async () => {
+  render(
+    <ApplicationSendDialog
+      isOpen={true}
+      isLoading={false}
+      onClose={() => {}}
+      onSend={() => {}}
+      applicationId={1}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByText(/lähetä hakemus\?/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Hakemuksen päätös ja mahdolliset täydennyspyynnöt tulevat Haitaton-järjestelmään. Lähettämällä hakemuksen, sitoudut sähköiseen tiedoksiantoon. Halutessasi voit tilata päätöksen myös paperisena ilmoittamaasi osoitteeseen.',
+      ),
+    ).toBeInTheDocument();
+    const orderPaperDecisionButton = screen.getByRole('button', {
+      name: 'Tilaan päätöksen myös paperisena',
+    });
+    expect(orderPaperDecisionButton).toBeInTheDocument();
+    expect(orderPaperDecisionButton).toBeEnabled();
+    const confirmButton = screen.getByRole('button', { name: 'Vahvista' });
+    expect(confirmButton).toBeInTheDocument();
+    expect(confirmButton).toBeEnabled();
+    const cancelButton = screen.getByRole('button', { name: 'Peruuta' });
+    expect(cancelButton).toBeInTheDocument();
+    expect(cancelButton).toBeEnabled();
+  });
+});
+
+test('Shows correct information when ordering paper decision', async () => {
+  const { user } = render(
+    <ApplicationSendDialog
+      isOpen={true}
+      isLoading={false}
+      onClose={() => {}}
+      onSend={() => {}}
+      applicationId={1}
+    />,
+  );
+
+  const orderPaperDecisionButton = screen.getByRole('button', {
+    name: 'Tilaan päätöksen myös paperisena',
+  });
+  await user.click(orderPaperDecisionButton);
+  expect(await screen.findByText('Täytä vastaanottajan tiedot')).toBeInTheDocument();
+  expect(
+    screen.getByText('Täytä vastaanottajan tiedot tilataksesi päätöksen myös paperisena.'),
+  ).toBeInTheDocument();
+  const nameInput = screen.getByText('Nimi');
+  expect(nameInput).toBeInTheDocument();
+  expect(nameInput).toBeEnabled();
+  const streetAddressInput = screen.getByText('Katuosoite');
+  expect(streetAddressInput).toBeInTheDocument();
+  expect(streetAddressInput).toBeEnabled();
+  const postalCodeInput = screen.getByText('Postinumero');
+  expect(postalCodeInput).toBeInTheDocument();
+  expect(postalCodeInput).toBeEnabled();
+  const cityInput = screen.getByText('Postitoimipaikka');
+  expect(cityInput).toBeInTheDocument();
+  expect(cityInput).toBeEnabled();
+  const confirmButton = screen.getByRole('button', { name: 'Vahvista' });
+  expect(confirmButton).toBeInTheDocument();
+  expect(confirmButton).toBeDisabled();
+  const cancelButton = screen.getByRole('button', { name: 'Peruuta' });
+  expect(cancelButton).toBeInTheDocument();
+  expect(cancelButton).toBeEnabled();
+});
+
+test('Enables confirmation button when form is filled', async () => {
+  const { user } = render(
+    <ApplicationSendDialog
+      isOpen={true}
+      isLoading={false}
+      onClose={() => {}}
+      onSend={() => {}}
+      applicationId={1}
+    />,
+  );
+
+  const confirmButton = screen.getByRole('button', { name: 'Vahvista' });
+  const orderPaperDecisionButton = screen.getByRole('button', {
+    name: 'Tilaan päätöksen myös paperisena',
+  });
+  await user.click(orderPaperDecisionButton);
+  await screen.findByText('Täytä vastaanottajan tiedot');
+  expect(confirmButton).toBeDisabled();
+  const nameInput = screen.getByText('Nimi');
+  await user.type(nameInput, 'Pekka Paperinen');
+  expect(confirmButton).toBeDisabled();
+  const streetAddressInput = screen.getByText('Katuosoite');
+  await user.type(streetAddressInput, 'Paperitie 1');
+  expect(confirmButton).toBeDisabled();
+  const postalCodeInput = screen.getByText('Postinumero');
+  await user.type(postalCodeInput, '00100');
+  expect(confirmButton).toBeDisabled();
+  const cityInput = screen.getByText('Postitoimipaikka');
+  await user.type(cityInput, 'Helsinki');
+  expect(confirmButton).toBeEnabled();
+});
+
+test('Confirm calls onSend', async () => {
+  const onSend = jest.fn();
+  const { user } = render(
+    <ApplicationSendDialog
+      isOpen={true}
+      isLoading={false}
+      onClose={() => {}}
+      onSend={onSend}
+      applicationId={1}
+    />,
+  );
+
+  const orderPaperDecisionButton = screen.getByRole('button', {
+    name: 'Tilaan päätöksen myös paperisena',
+  });
+  await user.click(orderPaperDecisionButton);
+  await screen.findByText('Täytä vastaanottajan tiedot');
+  const nameInput = screen.getByText('Nimi');
+  await user.type(nameInput, 'Pekka Paperinen');
+  const streetAddressInput = screen.getByText('Katuosoite');
+  await user.type(streetAddressInput, 'Paperitie 1');
+  const postalCodeInput = screen.getByText('Postinumero');
+  await user.type(postalCodeInput, '00100');
+  const cityInput = screen.getByText('Postitoimipaikka');
+  await user.type(cityInput, 'Helsinki');
+  const confirmButton = screen.getByRole('button', { name: 'Vahvista' });
+  await user.click(confirmButton);
+  expect(onSend).toHaveBeenCalled();
+});
+
+test('Cancel calls onClose', async () => {
+  const onClose = jest.fn();
+  const { user } = render(
+    <ApplicationSendDialog
+      isOpen={true}
+      isLoading={false}
+      onClose={onClose}
+      onSend={() => {}}
+      applicationId={1}
+    />,
+  );
+
+  const cancelButton = screen.getByRole('button', { name: 'Peruuta' });
+  await user.click(cancelButton);
+  expect(onClose).toHaveBeenCalled();
+});

--- a/src/domain/application/components/ApplicationSendDialog.tsx
+++ b/src/domain/application/components/ApplicationSendDialog.tsx
@@ -4,10 +4,9 @@ import {
   IconCheck,
   IconQuestionCircle,
   Notification,
-  TextInput,
   ToggleButton,
 } from 'hds-react';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ApplicationSendData, PaperDecisionReceiver } from '../types/application';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -15,6 +14,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { sendSchema } from '../yupSchemas';
 import { Box, Grid, GridItem, VisuallyHiddenInput } from '@chakra-ui/react';
 import Text from '../../../common/components/text/Text';
+import TextInput from '../../../common/components/textInput/TextInput';
 
 type Props = {
   isOpen: boolean;
@@ -45,10 +45,6 @@ const ApplicationSendDialog: React.FC<Props> = ({
   const [orderPaperDecisionChecked] = watch(['orderPaperDecision']);
   const isConfirmButtonEnabled = formState.isValid;
   const dialogTitle = t('hakemus:sendDialog:title');
-
-  useEffect(() => {
-    formContext.setValue('applicationId', applicationId);
-  }, [formContext, applicationId, setValue]);
 
   async function submitForm(data: ApplicationSendData) {
     const paperDecisionReceiver = data.orderPaperDecision
@@ -123,7 +119,6 @@ const ApplicationSendDialog: React.FC<Props> = ({
                   <GridItem colSpan={2}>
                     <TextInput
                       {...register('paperDecisionReceiver.name')}
-                      id="paperDecisionReceiver.name"
                       name="paperDecisionReceiver.name"
                       label={t('hakemus:sendDialog:name')}
                       required={orderPaperDecisionChecked}
@@ -132,7 +127,6 @@ const ApplicationSendDialog: React.FC<Props> = ({
                   <GridItem colSpan={2}>
                     <TextInput
                       {...register('paperDecisionReceiver.streetAddress')}
-                      id="paperDecisionReceiver.streetAddress"
                       name="paperDecisionReceiver.streetAddress"
                       label={t('hakemus:sendDialog:streetAddress')}
                       required={orderPaperDecisionChecked}
@@ -141,7 +135,6 @@ const ApplicationSendDialog: React.FC<Props> = ({
                   <GridItem colSpan={{ sm: 1, xs: 2 }} colStart={{ sm: 1, xs: 1 }}>
                     <TextInput
                       {...register('paperDecisionReceiver.postalCode')}
-                      id="paperDecisionReceiver.postalCode"
                       name="paperDecisionReceiver.postalCode"
                       label={t('hakemus:sendDialog:postalCode')}
                       required={orderPaperDecisionChecked}
@@ -150,7 +143,6 @@ const ApplicationSendDialog: React.FC<Props> = ({
                   <GridItem colSpan={2} colStart={{ sm: 2, xs: 1 }}>
                     <TextInput
                       {...register('paperDecisionReceiver.city')}
-                      id="paperDecisionReceiver.city"
                       name="paperDecisionReceiver.city"
                       label={t('hakemus:sendDialog:city')}
                       required={orderPaperDecisionChecked}

--- a/src/domain/application/components/ApplicationSendDialog.tsx
+++ b/src/domain/application/components/ApplicationSendDialog.tsx
@@ -1,0 +1,184 @@
+import {
+  Button,
+  Dialog,
+  IconCheck,
+  IconQuestionCircle,
+  Notification,
+  TextInput,
+  ToggleButton,
+} from 'hds-react';
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ApplicationSendData, PaperDecisionReceiver } from '../types/application';
+import { FormProvider, useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { sendSchema } from '../yupSchemas';
+import { Box, Grid, GridItem, VisuallyHiddenInput } from '@chakra-ui/react';
+import Text from '../../../common/components/text/Text';
+
+type Props = {
+  isOpen: boolean;
+  isLoading: boolean;
+  onClose: () => void;
+  onSend: (paperDecisionReceiver?: PaperDecisionReceiver | null) => void;
+  applicationId: number;
+};
+
+const ApplicationSendDialog: React.FC<Props> = ({
+  isOpen,
+  isLoading,
+  onClose,
+  onSend,
+  applicationId,
+}) => {
+  const { t } = useTranslation();
+  const formContext = useForm<ApplicationSendData>({
+    resolver: yupResolver(sendSchema),
+    defaultValues: {
+      applicationId: applicationId,
+      orderPaperDecision: false,
+      paperDecisionReceiver: null,
+    },
+  });
+
+  const { handleSubmit, formState, register, watch, setValue, resetField, reset } = formContext;
+  const [orderPaperDecisionChecked] = watch(['orderPaperDecision']);
+  const isConfirmButtonEnabled = formState.isValid;
+  const dialogTitle = t('hakemus:sendDialog:title');
+
+  useEffect(() => {
+    formContext.setValue('applicationId', applicationId);
+  }, [formContext, applicationId, setValue]);
+
+  async function submitForm(data: ApplicationSendData) {
+    const paperDecisionReceiver = data.orderPaperDecision
+      ? (data.paperDecisionReceiver as PaperDecisionReceiver)
+      : null;
+    onSend(paperDecisionReceiver);
+    onClose();
+  }
+
+  function handleOrderPaperDecisionChange() {
+    const newValue = !orderPaperDecisionChecked;
+    setValue('orderPaperDecision', newValue, {
+      shouldDirty: true,
+    });
+    if (!newValue) {
+      resetField('paperDecisionReceiver', { defaultValue: null });
+    }
+  }
+
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  return (
+    <Dialog
+      id="application-send"
+      isOpen={isOpen}
+      aria-labelledby={dialogTitle}
+      variant="primary"
+      close={onClose}
+      closeButtonLabelText={t('common:ariaLabels:closeButtonLabelText')}
+    >
+      <Dialog.Header
+        id="application-send-title"
+        title={dialogTitle}
+        iconLeft={<IconQuestionCircle aria-hidden="true" />}
+      />
+      <FormProvider {...formContext}>
+        <form onSubmit={handleSubmit(submitForm)}>
+          <Dialog.Content>
+            <VisuallyHiddenInput
+              name="applicationId"
+              value={applicationId}
+              aria-hidden="true"
+              readOnly
+            />
+            <Text tag="p" spacingBottom="s">
+              {t('hakemus:sendDialog:instructions')}
+            </Text>
+            <Box marginLeft="var(--spacing-xs)" marginBottom="var(--spacing-s)">
+              <ToggleButton
+                {...register('orderPaperDecision')}
+                id="orderPaperDecision"
+                label={t('hakemus:sendDialog:orderPaperDecision')}
+                checked={orderPaperDecisionChecked}
+                onChange={handleOrderPaperDecisionChange}
+              />
+            </Box>
+            {orderPaperDecisionChecked && (
+              <Box>
+                <Notification label={t('hakemus:sendDialog:paperDecisionNotificationLabel')}>
+                  {t('hakemus:sendDialog:paperDecisionNotificationText')}
+                </Notification>
+                <Grid
+                  templateRows="repeat(3, 1fr)"
+                  templateColumns={{ sm: 'repeat(3, 1fr)', xs: 'repeat(1, 1fr)' }}
+                  marginTop="var(--spacing-s)"
+                  columnGap={4}
+                  rowGap={3}
+                >
+                  <GridItem colSpan={2}>
+                    <TextInput
+                      {...register('paperDecisionReceiver.name')}
+                      id="paperDecisionReceiver.name"
+                      name="paperDecisionReceiver.name"
+                      label={t('hakemus:sendDialog:name')}
+                      required={orderPaperDecisionChecked}
+                    />
+                  </GridItem>
+                  <GridItem colSpan={2}>
+                    <TextInput
+                      {...register('paperDecisionReceiver.streetAddress')}
+                      id="paperDecisionReceiver.streetAddress"
+                      name="paperDecisionReceiver.streetAddress"
+                      label={t('hakemus:sendDialog:streetAddress')}
+                      required={orderPaperDecisionChecked}
+                    />
+                  </GridItem>
+                  <GridItem colSpan={{ sm: 1, xs: 2 }} colStart={{ sm: 1, xs: 1 }}>
+                    <TextInput
+                      {...register('paperDecisionReceiver.postalCode')}
+                      id="paperDecisionReceiver.postalCode"
+                      name="paperDecisionReceiver.postalCode"
+                      label={t('hakemus:sendDialog:postalCode')}
+                      required={orderPaperDecisionChecked}
+                    />
+                  </GridItem>
+                  <GridItem colSpan={2} colStart={{ sm: 2, xs: 1 }}>
+                    <TextInput
+                      {...register('paperDecisionReceiver.city')}
+                      id="paperDecisionReceiver.city"
+                      name="paperDecisionReceiver.city"
+                      label={t('hakemus:sendDialog:city')}
+                      required={orderPaperDecisionChecked}
+                    />
+                  </GridItem>
+                </Grid>
+              </Box>
+            )}
+          </Dialog.Content>
+
+          <Dialog.ActionButtons>
+            <Button
+              type="submit"
+              iconLeft={<IconCheck />}
+              isLoading={isLoading}
+              loadingText={t('common:buttons:sendingText')}
+              disabled={!isConfirmButtonEnabled}
+            >
+              {t('common:confirmationDialog:confirmButton')}
+            </Button>
+            <Button variant="secondary" onClick={handleClose}>
+              {t('common:confirmationDialog:cancelButton')}
+            </Button>
+          </Dialog.ActionButtons>
+        </form>
+      </FormProvider>
+    </Dialog>
+  );
+};
+
+export default ApplicationSendDialog;

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -17,6 +17,7 @@ import { Geometry, Polygon as OlPolygon } from 'ol/geom';
 import { getSurfaceArea } from '../../../common/components/map/utils';
 import { HaittaIndexData } from '../../common/haittaIndexes/types';
 import { reportCompletionDateSchema } from '../../kaivuilmoitus/validationSchema';
+import { sendSchema } from '../yupSchemas';
 
 export type ApplicationType = 'CABLE_REPORT' | 'EXCAVATION_NOTIFICATION';
 
@@ -373,3 +374,5 @@ export interface KaivuilmoitusUpdateData
 }
 
 export type ReportCompletionDateData = yup.InferType<typeof reportCompletionDateSchema>;
+
+export type ApplicationSendData = yup.InferType<typeof sendSchema>;

--- a/src/domain/application/utils.ts
+++ b/src/domain/application/utils.ts
@@ -15,6 +15,7 @@ import {
   PaatosTila,
   PaatosTyyppi,
   ReportCompletionDateData,
+  PaperDecisionReceiver,
 } from './types/application';
 import { SignedInUser } from '../hanke/hankeUsers/hankeUser';
 import { HIDDEN_FIELD_VALUE } from './constants';
@@ -53,8 +54,18 @@ export async function updateApplication<ApplicationData, UpdateData>({
 /**
  * Send application to Allu
  */
-export async function sendApplication(applicationId: number) {
-  const response = await api.post<Application>(`/hakemukset/${applicationId}/laheta`, {});
+export async function sendApplication(
+  applicationId: number,
+  paperDecisionReceiver: PaperDecisionReceiver | null | undefined,
+) {
+  const response = await api.post<Application>(
+    `/hakemukset/${applicationId}/laheta`,
+    paperDecisionReceiver
+      ? {
+          paperDecisionReceiver: paperDecisionReceiver,
+        }
+      : null,
+  );
   return response.data;
 }
 

--- a/src/domain/application/yupSchemas.ts
+++ b/src/domain/application/yupSchemas.ts
@@ -120,3 +120,22 @@ export const areaSchema = yup.object({
 });
 
 export const applicationTypeSchema = yup.mixed<ApplicationType>().defined().required();
+
+export const sendSchema = yup.object().shape({
+  applicationId: yup.number().defined().required(),
+  orderPaperDecision: yup.boolean().required(),
+  paperDecisionReceiver: yup.lazy((_value, context) => {
+    // Checking the value of `orderPaperDecision` from the context
+    if (context.parent.orderPaperDecision) {
+      return yup
+        .object({
+          name: yup.string().trim().max(100).required(),
+          streetAddress: yup.string().trim().max(100).required(),
+          postalCode: yup.string().trim().max(10).required(),
+          city: yup.string().trim().max(100).required(),
+        })
+        .required();
+    }
+    return yup.mixed().nullable();
+  }),
+});

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -214,7 +214,10 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
 
   async function sendCableApplication() {
     const data = getValues();
-    applicationSendMutation.mutate(data.id!);
+    applicationSendMutation.mutate({
+      id: data.id!,
+      paperDecisionReceiver: null, // TODO: use dialog instead or direct call
+    });
   }
 
   function handleStepChange() {

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -182,7 +182,7 @@ function fillContactsInformation() {
   });
 }
 
-test('Cable report application form can be filled and saved and sent to Allu', async () => {
+test('Cable report application form can be filled', async () => {
   server.use(
     http.get('/api/hankkeet/:hankeTunnus/whoami', async () => {
       return HttpResponse.json<SignedInUser>({
@@ -227,10 +227,6 @@ test('Cable report application form can be filled and saved and sent to Allu', a
   // Move to summary page
   await user.click(screen.getByTestId('hds-stepper-step-4'));
   expect(await screen.findByText('Vaihe 5/5: Yhteenveto')).toBeInTheDocument();
-
-  await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
-  expect(await screen.findByText(/hakemus lähetetty/i)).toBeInTheDocument();
-  expect(window.location.pathname).toBe('/fi/hakemus/10');
 });
 
 test('Should show error message when saving fails', async () => {
@@ -256,48 +252,35 @@ test('Should show error message when saving fails', async () => {
   );
 });
 
+test('Should be able to send application', async () => {
+  const hankeData = hankkeet[1] as HankeData;
+  const hakemus = cloneDeep(applications[0] as Application<JohtoselvitysData>);
+  const { user } = render(<JohtoselvitysContainer hankeData={hankeData} application={hakemus} />);
+  await user.click(await screen.findByRole('button', { name: /yhteenveto/i }));
+  await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
+
+  expect(await screen.findByText(/lähetä hakemus\?/i)).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: /vahvista/i }));
+
+  expect(await screen.findByText(/hakemus lähetetty/i)).toBeInTheDocument();
+});
+
 test('Should show error message when sending fails', async () => {
   server.use(
-    http.get('/api/hankkeet/:hankeTunnus/whoami', async () => {
-      return HttpResponse.json<SignedInUser>({
-        hankeKayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-        kayttooikeustaso: 'KATSELUOIKEUS',
-        kayttooikeudet: ['VIEW'],
-      });
-    }),
     http.post('/api/hakemukset/:id/laheta', async () => {
       return HttpResponse.json({ errorMessage: 'Failed for testing purposes' }, { status: 500 });
     }),
   );
 
   const hankeData = hankkeet[1] as HankeData;
+  const hakemus = cloneDeep(applications[0] as Application<JohtoselvitysData>);
+  const { user } = render(<JohtoselvitysContainer hankeData={hankeData} application={hakemus} />);
 
-  const { user } = render(
-    <JohtoselvitysContainer hankeData={hankeData} application={application} />,
-  );
-
-  // Fill basic information page
-  fillBasicInformation();
-
-  // Move to areas page
-  await user.click(screen.getByRole('button', { name: /seuraava/i }));
-  expect(await screen.findByText('Vaihe 2/5: Alueet')).toBeInTheDocument();
-
-  // Fill areas page
-  fillAreasInformation();
-
-  // Move to contacts page
-  await user.click(screen.getByRole('button', { name: /seuraava/i }));
-  expect(await screen.findByText('Vaihe 3/5: Yhteystiedot')).toBeInTheDocument();
-
-  // Fill contacts page
-  fillContactsInformation();
-
-  // Move to summary page
-  await user.click(screen.getByTestId('hds-stepper-step-4'));
-  expect(await screen.findByText('Vaihe 5/5: Yhteenveto')).toBeInTheDocument();
-
+  await user.click(await screen.findByRole('button', { name: /yhteenveto/i }));
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
+
+  expect(await screen.findByText(/lähetä hakemus\?/i)).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: /vahvista/i }));
 
   expect(await screen.findByText(/lähettäminen epäonnistui/i)).toBeInTheDocument();
 });
@@ -313,7 +296,7 @@ test('Save and quit works', async () => {
   await user.click(screen.getByRole('button', { name: /tallenna ja keskeytä/i }));
 
   expect(await screen.findAllByText(/hakemus tallennettu/i)).toHaveLength(2);
-  expect(window.location.pathname).toBe('/fi/hakemus/12');
+  expect(window.location.pathname).toBe('/fi/hakemus/11');
 });
 
 test('Should not save and quit if current form page is not valid', async () => {

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -210,7 +210,10 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
 
   async function sendApplication() {
     const data = getValues();
-    applicationSendMutation.mutate(data.id!);
+    applicationSendMutation.mutate({
+      id: data.id!,
+      paperDecisionReceiver: null, // TODO: use dialog instead or direct call
+    });
   }
 
   function handleStepChange() {

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { FieldPath, FormProvider, useForm } from 'react-hook-form';
 import { merge } from 'lodash';
 import {
@@ -34,6 +34,7 @@ import {
   KaivuilmoitusCreateData,
   KaivuilmoitusData,
   KaivuilmoitusUpdateData,
+  PaperDecisionReceiver,
 } from '../application/types/application';
 import { useGlobalNotification } from '../../common/components/globalNotification/GlobalNotificationContext';
 import {
@@ -50,6 +51,7 @@ import useNavigateToApplicationView from '../application/hooks/useNavigateToAppl
 import { isApplicationDraft, isContactIn } from '../application/utils';
 import { usePermissionsForHanke } from '../hanke/hankeUsers/hooks/useUserRightsForHanke';
 import useSendApplication from '../application/hooks/useSendApplication';
+import ApplicationSendDialog from '../application/components/ApplicationSendDialog';
 
 type Props = {
   hankeData: HankeData;
@@ -63,11 +65,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
   const [attachmentUploadErrors, setAttachmentUploadErrors] = useState<JSX.Element[]>([]);
   const { data: hankkeenHakemukset } = useApplicationsForHanke(hankeData.hankeTunnus);
   const { data: signedInUser } = usePermissionsForHanke(hankeData.hankeTunnus);
-  const applicationSendMutation = useSendApplication({
-    onSuccess(data) {
-      navigateToApplicationView(data.id?.toString());
-    },
-  });
   const johtoselvitysIds = hankkeenHakemukset?.applications
     .filter(
       (hakemus) =>
@@ -119,6 +116,9 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
   );
 
   const [attachmentsUploading, setAttachmentsUploading] = useState(false);
+
+  const [isSendButtonDisabled, setIsSendButtonDisabled] = useState(false);
+  const [showSendDialog, setShowSendDialog] = useState(false);
 
   const {
     applicationCreateMutation,
@@ -208,12 +208,28 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
     }
   }
 
-  async function sendApplication() {
+  const applicationSendMutation = useSendApplication({
+    onSuccess(data) {
+      navigateToApplicationView(data.id?.toString());
+    },
+  });
+
+  async function onSendApplication(pdr: PaperDecisionReceiver | undefined | null) {
     const data = getValues();
     applicationSendMutation.mutate({
-      id: data.id!,
-      paperDecisionReceiver: null, // TODO: use dialog instead or direct call
+      id: data.id as number,
+      paperDecisionReceiver: pdr,
     });
+    setIsSendButtonDisabled(true);
+    setShowSendDialog(false);
+  }
+
+  function openSendDialog() {
+    setShowSendDialog(true);
+  }
+
+  function closeSendDialog() {
+    setShowSendDialog(false);
   }
 
   function handleStepChange() {
@@ -320,7 +336,7 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
         isLoading={attachmentsUploading}
         isLoadingText={attachmentsUploadingText}
         stepChangeValidator={validateStepChange}
-        onSubmit={handleSubmit(sendApplication)}
+        onSubmit={handleSubmit(openSendDialog)}
       >
         {function renderFormActions(activeStepIndex, handlePrevious, handleNext) {
           async function handleSaveAndQuit() {
@@ -381,9 +397,8 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
                 <Button
                   type="submit"
                   iconLeft={<IconEnvelope />}
-                  isLoading={applicationSendMutation.isLoading}
                   loadingText={t('common:buttons:sendingText')}
-                  disabled={disableSendButton}
+                  disabled={disableSendButton || isSendButtonDisabled}
                 >
                   {t('hakemus:buttons:sendApplication')}
                 </Button>
@@ -427,6 +442,14 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
         mainAction={closeAttachmentUploadErrorDialog}
         mainBtnLabel={t('common:ariaLabels:closeButtonLabelText')}
         variant="primary"
+      />
+
+      <ApplicationSendDialog
+        isOpen={showSendDialog}
+        isLoading={applicationSendMutation.isLoading}
+        onClose={closeSendDialog}
+        onSend={onSendApplication}
+        applicationId={getValues('id') as number}
       />
     </FormProvider>
   );

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1004,6 +1004,9 @@ test('Should be able to send application', async () => {
   await user.click(await screen.findByRole('button', { name: /yhteenveto/i }));
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
 
+  expect(await screen.findByText(/lähetä hakemus\?/i)).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: /vahvista/i }));
+
   expect(await screen.findByText(/hakemus lähetetty/i)).toBeInTheDocument();
 });
 
@@ -1021,6 +1024,9 @@ test('Should show error message when sending fails', async () => {
   );
   await user.click(await screen.findByRole('button', { name: /yhteenveto/i }));
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
+
+  expect(await screen.findByText(/lähetä hakemus\?/i)).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: /vahvista/i }));
 
   expect(await screen.findByText(/lähettäminen epäonnistui/i)).toBeInTheDocument();
 });

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1140,6 +1140,17 @@
       "reportCompletionDateErrorLabel": "Ilmoituksen lähettäminen epäonnistui",
       "reportCompletionDateErrorText": "<0>Lähettämisessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>"
     },
+    "sendDialog": {
+      "title": "Lähetä hakemus?",
+      "instructions": "Hakemuksen päätös ja mahdolliset täydennyspyynnöt tulevat Haitaton-järjestelmään. Lähettämällä hakemuksen, sitoudut sähköiseen tiedoksiantoon. Halutessasi voit tilata päätöksen myös paperisena ilmoittamaasi osoitteeseen.",
+      "orderPaperDecision": "Tilaan päätöksen myös paperisena",
+      "paperDecisionNotificationLabel": "Täytä vastaanottajan tiedot",
+      "paperDecisionNotificationText": "Täytä vastaanottajan tiedot tilataksesi päätöksen myös paperisena.",
+      "name": "Nimi",
+      "streetAddress": "Katuosoite",
+      "postalCode": "Postinumero",
+      "city": "Postitoimipaikka"
+    },
     "sentDialog": {
       "title": "Hakemus lähetetty",
       "description": "Hakemus on lähetetty, eikä sitä voi enää muokata. Tarkastele hakemuksen tietoja hakemussivulla.",


### PR DESCRIPTION
# Description

On application view, "Lähetä hakemus" button opens a dialog where the user can choose to request for a paper decision.
NOTE! Implementing the same behaviour in the last page of the application form is in another PR.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1740

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing
1. Create a johtoselvityshakemus or kaivulupailmoitus and fill it so that it can be sent to Allu
2. In application view, click the "Lähetä hakemus" button
3. A dialog should be opened where the user can choose to order a paper decision or not
4. Clicking "Vahvista" button sends the application - see that the network call contains `paperDecisionReceiver` data if it was selected and if it was not selected, the API call has a `null` body
5. If you choosed to have a paper decision, see that there is information about it on the "Yhteystiedot" tab (and if you did not choose the paper decision there should not be any information about it)


# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
