### PR TITLE
HAI-1740 Use confirmation dialog on sending on application forms

### DIFF
--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -229,6 +229,10 @@ test('Cable report application form can be filled and saved and sent to Allu', a
   expect(await screen.findByText('Vaihe 5/5: Yhteenveto')).toBeInTheDocument();
 
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
+
+  expect(await screen.findByText(/lähetä hakemus\?/i)).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: /vahvista/i }));
+
   expect(await screen.findByText(/hakemus lähetetty/i)).toBeInTheDocument();
   expect(window.location.pathname).toBe('/fi/hakemus/10');
 });

--- a/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysForm.test.tsx
@@ -299,6 +299,9 @@ test('Should show error message when sending fails', async () => {
 
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
 
+  expect(await screen.findByText(/lähetä hakemus\?/i)).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: /vahvista/i }));
+
   expect(await screen.findByText(/lähettäminen epäonnistui/i)).toBeInTheDocument();
 });
 

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { FieldPath, FormProvider, useForm } from 'react-hook-form';
 import { merge } from 'lodash';
 import {
@@ -34,6 +34,7 @@ import {
   KaivuilmoitusCreateData,
   KaivuilmoitusData,
   KaivuilmoitusUpdateData,
+  PaperDecisionReceiver,
 } from '../application/types/application';
 import { useGlobalNotification } from '../../common/components/globalNotification/GlobalNotificationContext';
 import {
@@ -50,6 +51,7 @@ import useNavigateToApplicationView from '../application/hooks/useNavigateToAppl
 import { isApplicationDraft, isContactIn } from '../application/utils';
 import { usePermissionsForHanke } from '../hanke/hankeUsers/hooks/useUserRightsForHanke';
 import useSendApplication from '../application/hooks/useSendApplication';
+import ApplicationSendDialog from '../application/components/ApplicationSendDialog';
 
 type Props = {
   hankeData: HankeData;
@@ -63,11 +65,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
   const [attachmentUploadErrors, setAttachmentUploadErrors] = useState<JSX.Element[]>([]);
   const { data: hankkeenHakemukset } = useApplicationsForHanke(hankeData.hankeTunnus);
   const { data: signedInUser } = usePermissionsForHanke(hankeData.hankeTunnus);
-  const applicationSendMutation = useSendApplication({
-    onSuccess(data) {
-      navigateToApplicationView(data.id?.toString());
-    },
-  });
   const johtoselvitysIds = hankkeenHakemukset?.applications
     .filter(
       (hakemus) =>
@@ -119,6 +116,9 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
   );
 
   const [attachmentsUploading, setAttachmentsUploading] = useState(false);
+
+  const [isSendButtonDisabled, setIsSendButtonDisabled] = useState(false);
+  const [showSendDialog, setShowSendDialog] = useState(false);
 
   const {
     applicationCreateMutation,
@@ -208,12 +208,28 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
     }
   }
 
-  async function sendApplication() {
+  const applicationSendMutation = useSendApplication({
+    onSuccess(data) {
+      navigateToApplicationView(data.id?.toString());
+    },
+  });
+
+  async function onSendApplication(pdr: PaperDecisionReceiver | undefined | null) {
     const data = getValues();
     applicationSendMutation.mutate({
-      id: data.id!,
-      paperDecisionReceiver: null, // TODO: use dialog instead or direct call
+      id: data.id as number,
+      paperDecisionReceiver: pdr,
     });
+    setIsSendButtonDisabled(true);
+    setShowSendDialog(false);
+  }
+
+  function openSendDialog() {
+    setShowSendDialog(true);
+  }
+
+  function closeSendDialog() {
+    setShowSendDialog(false);
   }
 
   function handleStepChange() {
@@ -320,7 +336,7 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
         isLoading={attachmentsUploading}
         isLoadingText={attachmentsUploadingText}
         stepChangeValidator={validateStepChange}
-        onSubmit={handleSubmit(sendApplication)}
+        onSubmit={handleSubmit(openSendDialog)}
       >
         {function renderFormActions(activeStepIndex, handlePrevious, handleNext) {
           async function handleSaveAndQuit() {
@@ -381,9 +397,8 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
                 <Button
                   type="submit"
                   iconLeft={<IconEnvelope />}
-                  isLoading={applicationSendMutation.isLoading}
                   loadingText={t('common:buttons:sendingText')}
-                  disabled={disableSendButton}
+                  disabled={disableSendButton || isSendButtonDisabled}
                 >
                   {t('hakemus:buttons:sendApplication')}
                 </Button>
@@ -427,6 +442,14 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
         mainAction={closeAttachmentUploadErrorDialog}
         mainBtnLabel={t('common:ariaLabels:closeButtonLabelText')}
         variant="primary"
+      />
+
+      <ApplicationSendDialog
+        isOpen={showSendDialog}
+        isLoading={applicationSendMutation.isLoading}
+        onClose={closeSendDialog}
+        onSend={onSendApplication}
+        applicationId={getValues('id') as number}
       />
     </FormProvider>
   );

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1004,6 +1004,9 @@ test('Should be able to send application', async () => {
   await user.click(await screen.findByRole('button', { name: /yhteenveto/i }));
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
 
+  expect(await screen.findByText(/lähetä hakemus\?/i)).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: /vahvista/i }));
+
   expect(await screen.findByText(/hakemus lähetetty/i)).toBeInTheDocument();
 });
 
@@ -1021,6 +1024,9 @@ test('Should show error message when sending fails', async () => {
   );
   await user.click(await screen.findByRole('button', { name: /yhteenveto/i }));
   await user.click(screen.getByRole('button', { name: /lähetä hakemus/i }));
+
+  expect(await screen.findByText(/lähetä hakemus\?/i)).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: /vahvista/i }));
 
   expect(await screen.findByText(/lähettäminen epäonnistui/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
# Description

Use the new send confirmation dialog on application forms.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1740

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing
1. Create a johtoselvityshakemus or kaivulupailmoitus and fill it so that it can be sent to Allu
2. Onk the last page of the  form, click the "Lähetä hakemus" button
3. A dialog should be opened where the user can choose to order a paper decision or not
4. Clicking "Vahvista" button sends the application - see that the network call contains paperDecisionReceiver data if it was selected and if it was not selected, the API call has a null body
5. If you choosed to have a paper decision, see that there is information about it on the "Yhteystiedot" tab (and if you did not choose the paper decision there should not be any information about it)


# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
