### PR TITLE
HAI-2756 Add missing 'required' for work purpose selection

### DIFF
--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -446,6 +446,7 @@ export default function Areas({ hankeData }: Readonly<Props>) {
                       label={t('hakemus:labels:tyonTarkoitus')}
                       mapValueToLabel={(value) => t(`hanke:tyomaaTyyppi:${value}`)}
                       errorMsg={t('hankeForm:insertFieldError')}
+                      required
                     />
                   </Box>
 


### PR DESCRIPTION
# Description

In kaivuilmoitus areas form page the symbol for required field was missing from work purpose selection. This adds it.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2756

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Open an existing or create a new kaivuilmoitus
2. Go to areas page
3. "Työn tarkoitus" selection should have the required symbol

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
