### PR TITLE
HAI-2622 Show johtoselvitys work areas in kaivuilmoitus form areas page

### DIFF
--- a/src/common/components/map/overlay/Overlay.tsx
+++ b/src/common/components/map/overlay/Overlay.tsx
@@ -38,7 +38,6 @@ export default function MapOverlay({ position, children }: Readonly<Props>) {
     <Box
       ref={overlayElementRef}
       backgroundColor="var(--color-white)"
-      padding="var(--spacing-2-xs)"
       border="1px solid var(--color-black)"
     >
       {children}

--- a/src/common/components/map/types.ts
+++ b/src/common/components/map/types.ts
@@ -1,3 +1,19 @@
 import * as ol from 'ol';
 
 export type MapInstance = ol.Map | null;
+
+export class OverlayProps {
+  heading?: string | null;
+  subHeading?: string | null;
+  startDate?: Date | string | null;
+  endDate?: Date | string | null;
+  backgroundColor?: string;
+
+  constructor(props: OverlayProps) {
+    this.heading = props.heading;
+    this.subHeading = props.subHeading;
+    this.startDate = props.startDate;
+    this.endDate = props.endDate;
+    this.backgroundColor = props.backgroundColor;
+  }
+}

--- a/src/domain/application/components/ApplicationMap.tsx
+++ b/src/domain/application/components/ApplicationMap.tsx
@@ -8,7 +8,6 @@ import { Feature, Map as OlMap, MapBrowserEvent } from 'ol';
 import { Geometry, Point, Polygon } from 'ol/geom';
 import { FeatureLike } from 'ol/Feature';
 import { Coordinate } from 'ol/coordinate';
-import { Box } from '@chakra-ui/react';
 import { Layer } from 'ol/layer';
 import { ModifyEvent } from 'ol/interaction/Modify';
 import { createEditingStyle } from 'ol/style/Style';
@@ -28,9 +27,10 @@ import styles from './ApplicationMap.module.scss';
 import useForceUpdate from '../../../common/hooks/useForceUpdate';
 import FeatureInfoOverlay from '../../map/components/FeatureInfoOverlay/FeatureInfoOverlay';
 import FitSource from '../../map/components/interations/FitSource';
-import { formatToFinnishDate } from '../../../common/utils/date';
 import isFeatureWithinFeatures from '../../map/utils/isFeatureWithinFeatures';
 import { styleFunction } from '../../map/utils/geometryStyle';
+import { OverlayProps } from '../../../common/components/map/types';
+import AreaOverlay from '../../map/components/AreaOverlay/AreaOverlay';
 
 type Props = {
   drawSource: VectorSource;
@@ -160,9 +160,9 @@ export default function ApplicationMap({
           layerFilter: hankeLayerFilter,
         })
         .filter((hankeAreaFeature) => {
-          const relatedHankeAreaName = modifiedFeature.get('relatedHankeAreaName');
-          if (relatedHankeAreaName) {
-            return hankeAreaFeature.get('areaName') === relatedHankeAreaName;
+          const relatedHankeAreaId = modifiedFeature.get('relatedHankeAreaId');
+          if (relatedHankeAreaId) {
+            return hankeAreaFeature.get('id') === relatedHankeAreaId;
           }
           return true;
         });
@@ -200,24 +200,8 @@ export default function ApplicationMap({
 
           <FeatureInfoOverlay
             render={(feature) => {
-              const areaName = feature?.get('areaName');
-              const hankeName = feature?.get('hankeName');
-              const startDate = feature?.get('startDate');
-              const endDate = feature?.get('endDate');
-              if (!areaName || !hankeName) {
-                return null;
-              }
-              return (
-                <>
-                  {hankeName && <p>{hankeName}</p>}
-                  {<h4 className="heading-xxs">{areaName}</h4>}
-                  {startDate && endDate && (
-                    <Box as="p" fontSize="var(--fontsize-body-s)">
-                      {formatToFinnishDate(startDate)}–{formatToFinnishDate(endDate)}
-                    </Box>
-                  )}
-                </>
-              );
+              const overlayProperties = feature?.get('overlayProps') as OverlayProps | undefined;
+              return <AreaOverlay overlayProps={overlayProperties} />;
             }}
           />
 

--- a/src/domain/common/utils/liikennehaittaindeksi.ts
+++ b/src/domain/common/utils/liikennehaittaindeksi.ts
@@ -10,6 +10,8 @@ const getColorWithOpacity = (color: LIIKENNEHAITTA_STATUS | null, opacity = 1) =
       return `rgba(0, 146, 70, ${opacity})`;
     case 'GREY':
       return `rgba(176, 184, 191, ${opacity})`;
+    case 'LAVENDER_BLUE':
+      return `rgba(204, 204, 255, ${opacity})`;
     default:
       return `rgba(0, 98, 185, ${opacity})`;
   }
@@ -23,6 +25,7 @@ export enum LIIKENNEHAITTA_STATUS {
   GREEN = 'GREEN',
   GREY = 'GREY',
   BLUE = 'BLUE',
+  LAVENDER_BLUE = 'LAVENDER_BLUE',
 }
 
 export const getStatusByIndex = (index: TormaysIndex | undefined) => {
@@ -40,4 +43,8 @@ export const getColorByStatus = (status: LIIKENNEHAITTA_STATUS, opacity = 1) =>
     [LIIKENNEHAITTA_STATUS.GREEN]: getColorWithOpacity(LIIKENNEHAITTA_STATUS.GREEN, opacity),
     [LIIKENNEHAITTA_STATUS.YELLOW]: getColorWithOpacity(LIIKENNEHAITTA_STATUS.YELLOW, opacity),
     [LIIKENNEHAITTA_STATUS.RED]: getColorWithOpacity(LIIKENNEHAITTA_STATUS.RED, opacity),
+    [LIIKENNEHAITTA_STATUS.LAVENDER_BLUE]: getColorWithOpacity(
+      LIIKENNEHAITTA_STATUS.LAVENDER_BLUE,
+      opacity,
+    ),
   });

--- a/src/domain/johtoselvitys/Geometries.tsx
+++ b/src/domain/johtoselvitys/Geometries.tsx
@@ -25,6 +25,7 @@ import useDrawContext from '../../common/components/map/modules/draw/useDrawCont
 import ApplicationMap from '../application/components/ApplicationMap';
 import useAddressCoordinate from '../map/hooks/useAddressCoordinate';
 import useFilterHankeAlueetByApplicationDates from '../application/hooks/useFilterHankeAlueetByApplicationDates';
+import { OverlayProps } from '../../common/components/map/types';
 
 function AreaList({
   applicationAreas,
@@ -49,12 +50,19 @@ function AreaList({
         const surfaceArea = geometry && `(${formatSurfaceArea(geometry)})`;
         const areaName = getAreaDefaultName(t, index, applicationAreas.length);
 
-        area.feature?.setProperties({
-          areaName,
-          hankeName,
-          endDate: getValues('applicationData.endTime'),
-          startDate: getValues('applicationData.startTime'),
-        });
+        area.feature?.setProperties(
+          {
+            areaName,
+            hankeName,
+            overlayProps: new OverlayProps({
+              heading: areaName,
+              startDate: getValues('applicationData.startTime'),
+              endDate: getValues('applicationData.endTime'),
+              backgroundColor: 'var(--color-suomenlinna-light)',
+            }),
+          },
+          true,
+        );
 
         return (
           <li key={area.id}>

--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -26,7 +26,7 @@ import {
 } from '../types/hanke';
 import styles from './Kaivuilmoitus.module.scss';
 import ApplicationMap from '../application/components/ApplicationMap';
-import { KaivuilmoitusAlue, Tyoalue } from '../application/types/application';
+import { HankkeenHakemus, KaivuilmoitusAlue, Tyoalue } from '../application/types/application';
 import useSelectableTabs from '../../common/hooks/useSelectableTabs';
 import TextInput from '../../common/components/textInput/TextInput';
 import Dropdown from '../../common/components/dropdown/Dropdown';
@@ -42,6 +42,8 @@ import HaittaIndexes from '../common/haittaIndexes/HaittaIndexes';
 import useHaittaIndexes from '../hanke/hooks/useHaittaIndexes';
 import { calculateLiikennehaittaindeksienYhteenveto } from './utils';
 import useFilterHankeAlueetByApplicationDates from '../application/hooks/useFilterHankeAlueetByApplicationDates';
+import { STYLES } from '../map/utils/geometryStyle';
+import HakemusLayer from '../map/components/Layers/HakemusLayer';
 
 function getEmptyArea(
   hankeData: HankeData,
@@ -68,9 +70,10 @@ function getEmptyArea(
 
 type Props = {
   hankeData: HankeData;
+  hankkeenHakemukset: HankkeenHakemus[];
 };
 
-export default function Areas({ hankeData }: Readonly<Props>) {
+export default function Areas({ hankeData, hankkeenHakemukset }: Readonly<Props>) {
   const { t } = useTranslation();
   const locale = useLocale();
   const [multipleHankeAreaSpanningFeature, setMultipleHankeAreaSpanningFeature] =
@@ -116,6 +119,8 @@ export default function Areas({ hankeData }: Readonly<Props>) {
     );
     return new VectorSource({ features });
   });
+
+  const selectedJohtoselvitysTunnukset = getValues('applicationData.cableReports');
 
   const { tabRefs, setSelectedTabIndex } = useSelectableTabs(applicationAreas, {
     selectLastTabOnChange: true,
@@ -390,11 +395,20 @@ export default function Areas({ hankeData }: Readonly<Props>) {
           onChangeArea={handleChangeArea}
           restrictDrawingToHankeAreas
         >
+          {/* Hanke areas */}
           <HankeLayer
             hankeData={hankeData && [hankeData]}
             fitSource
             filterHankeAlueet={filterHankeAlueet}
           />
+          {/* Johtoselvitys areas */}
+          {hankkeenHakemukset
+            .filter((hakemus) =>
+              selectedJohtoselvitysTunnukset?.includes(hakemus.applicationIdentifier!),
+            )
+            .map((hakemus) => (
+              <HakemusLayer hakemusId={hakemus.id!} layerStyle={STYLES.PURPLE} />
+            ))}
         </ApplicationMap>
 
         {!workTimesSet && (

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -287,7 +287,9 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
       validationSchema: perustiedotSchema,
     },
     {
-      element: <Areas hankeData={hankeData} />,
+      element: (
+        <Areas hankeData={hankeData} hankkeenHakemukset={hankkeenHakemukset?.applications ?? []} />
+      ),
       label: t('form:headers:alueet'),
       state: StepState.available,
       validationSchema: alueetSchema,

--- a/src/domain/kaivuilmoitus/components/TyoalueTable.tsx
+++ b/src/domain/kaivuilmoitus/components/TyoalueTable.tsx
@@ -13,6 +13,7 @@ import { getAreaDefaultName } from '../../application/utils';
 import ConfirmationDialog from '../../../common/components/HDSConfirmationDialog/ConfirmationDialog';
 import './TyoalueTable.css';
 import { getSurfaceArea } from '../../../common/components/map/utils';
+import { OverlayProps } from '../../../common/components/map/types';
 
 type Props = {
   alueIndex: number;
@@ -52,7 +53,14 @@ export default function TyoalueTable({
 
   const tableRows: TableData[] = tyoalueet.map((alue, index) => {
     const areaName = getAreaDefaultName(t, index, tyoalueet.length);
-    alue.openlayersFeature?.set('areaName', areaName);
+    const previousOverlayProps = alue.openlayersFeature?.get('overlayProps') as OverlayProps;
+    alue.openlayersFeature?.setProperties(
+      {
+        areaName,
+        overlayProps: new OverlayProps({ ...previousOverlayProps, heading: areaName }),
+      },
+      true,
+    );
     return {
       id: alue.id,
       nimi: areaName,

--- a/src/domain/map/components/AreaOverlay/AreaOverlay.tsx
+++ b/src/domain/map/components/AreaOverlay/AreaOverlay.tsx
@@ -1,0 +1,31 @@
+import { Box } from '@chakra-ui/react';
+import { OverlayProps } from '../../../../common/components/map/types';
+import { formatToFinnishDate } from '../../../../common/utils/date';
+
+type Props = {
+  overlayProps?: OverlayProps;
+};
+
+export default function AreaOverlay({ overlayProps }: Props) {
+  if (!overlayProps) {
+    return null;
+  }
+
+  const { heading, subHeading, startDate, endDate, backgroundColor } = overlayProps;
+
+  if (!heading && !subHeading) {
+    return null;
+  }
+
+  return (
+    <Box backgroundColor={backgroundColor} padding="var(--spacing-2-xs)">
+      {subHeading && <p>{subHeading}</p>}
+      {<h4 className="heading-xxs">{heading}</h4>}
+      {startDate && endDate && (
+        <Box as="p" fontSize="var(--fontsize-body-s)">
+          {formatToFinnishDate(startDate)}–{formatToFinnishDate(endDate)}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/domain/map/components/Layers/HakemusLayer.tsx
+++ b/src/domain/map/components/Layers/HakemusLayer.tsx
@@ -1,0 +1,25 @@
+import { useRef } from 'react';
+import VectorSource from 'ol/source/Vector';
+import { StyleLike } from 'ol/style/Style';
+import { useApplication } from '../../../application/hooks/useApplication';
+import { ApplicationArea } from '../../../application/types/application';
+import VectorLayer from '../../../../common/components/map/layers/VectorLayer';
+import useApplicationFeatures from '../../hooks/useApplicationFeatures';
+
+type Props = { hakemusId: number; layerStyle?: StyleLike };
+
+export default function HakemusLayer({ hakemusId, layerStyle }: Readonly<Props>) {
+  const source = useRef(new VectorSource());
+  const { data } = useApplication(hakemusId);
+  const tyoalueet = (data?.applicationData.areas as ApplicationArea[]) ?? [];
+  useApplicationFeatures(source.current, tyoalueet);
+
+  return (
+    <VectorLayer
+      source={source.current}
+      zIndex={1}
+      className="hakemusGeometryLayer"
+      style={layerStyle}
+    />
+  );
+}

--- a/src/domain/map/components/Layers/HakemusLayer.tsx
+++ b/src/domain/map/components/Layers/HakemusLayer.tsx
@@ -5,14 +5,31 @@ import { useApplication } from '../../../application/hooks/useApplication';
 import { ApplicationArea } from '../../../application/types/application';
 import VectorLayer from '../../../../common/components/map/layers/VectorLayer';
 import useApplicationFeatures from '../../hooks/useApplicationFeatures';
+import { OverlayProps } from '../../../../common/components/map/types';
 
-type Props = { hakemusId: number; layerStyle?: StyleLike };
+type Props = {
+  hakemusId: number;
+  layerStyle?: StyleLike;
+  featureProperties?: { [x: string]: unknown };
+};
 
-export default function HakemusLayer({ hakemusId, layerStyle }: Readonly<Props>) {
+export default function HakemusLayer({
+  hakemusId,
+  layerStyle,
+  featureProperties = {},
+}: Readonly<Props>) {
   const source = useRef(new VectorSource());
   const { data } = useApplication(hakemusId);
   const tyoalueet = (data?.applicationData.areas as ApplicationArea[]) ?? [];
-  useApplicationFeatures(source.current, tyoalueet);
+  useApplicationFeatures(source.current, tyoalueet, {
+    overlayProps: new OverlayProps({
+      heading: data ? `${data.applicationData.name} (${data.applicationIdentifier})` : null,
+      startDate: data?.applicationData.startTime,
+      endDate: data?.applicationData.endTime,
+      backgroundColor: 'var(--color-suomenlinna-light)',
+    }),
+    ...featureProperties,
+  });
 
   return (
     <VectorLayer

--- a/src/domain/map/hooks/useApplicationFeatures.ts
+++ b/src/domain/map/hooks/useApplicationFeatures.ts
@@ -8,7 +8,11 @@ import { ApplicationArea } from '../../application/types/application';
 /**
  * Add features from application areas to map
  */
-export default function useApplicationFeatures(source: Vector, areas?: ApplicationArea[]) {
+export default function useApplicationFeatures(
+  source: Vector,
+  areas?: ApplicationArea[],
+  featureProperties: { [x: string]: unknown } = {},
+) {
   useEffect(() => {
     if (areas && areas.length > 0) {
       const applicationFeatures = areas.map((area) => {
@@ -19,6 +23,7 @@ export default function useApplicationFeatures(source: Vector, areas?: Applicati
             liikennehaittaindeksi: area.tormaystarkasteluTulos
               ? area.tormaystarkasteluTulos.liikennehaittaindeksi.indeksi
               : null,
+            ...featureProperties,
           },
           true,
         );
@@ -31,5 +36,5 @@ export default function useApplicationFeatures(source: Vector, areas?: Applicati
     return function cleanup() {
       source.clear();
     };
-  }, [source, areas]);
+  }, [source, areas, featureProperties]);
 }

--- a/src/domain/map/hooks/useHankeFeatures.ts
+++ b/src/domain/map/hooks/useHankeFeatures.ts
@@ -4,6 +4,7 @@ import GeoJSON from 'ol/format/GeoJSON';
 import { Feature } from 'ol';
 import { Geometry } from 'ol/geom';
 import { HankeData } from '../../types/hanke';
+import { OverlayProps } from '../../../common/components/map/types';
 
 /**
  * Add features from hanke areas to map
@@ -31,8 +32,14 @@ export default function useHankeFeatures(source: Vector, hankkeet: HankeData[]) 
                 : null,
               areaName: alue.nimi,
               hankeName: hanke.nimi,
-              startDate: alue.haittaAlkuPvm,
-              endDate: alue.haittaLoppuPvm,
+              id: alue.id,
+              overlayProps: new OverlayProps({
+                heading: alue.nimi,
+                subHeading: `${hanke.nimi} (${hanke.hankeTunnus})`,
+                startDate: alue.haittaAlkuPvm,
+                endDate: alue.haittaLoppuPvm,
+                backgroundColor: 'var(--color-summer-light)',
+              }),
             },
             true,
           );

--- a/src/domain/map/utils/geometryStyle.test.tsx
+++ b/src/domain/map/utils/geometryStyle.test.tsx
@@ -14,8 +14,22 @@ describe('styleFunction', () => {
     [4, STYLES.RED],
     [5, STYLES.RED],
   ])('when liikennehaittaindeksi is %s, style is %s', (liikennehaittaindeksi, expectedStyle) => {
-    expect(styleFunction({ get: () => liikennehaittaindeksi }, undefined, false)).toBe(
-      expectedStyle,
-    );
+    expect(
+      styleFunction(
+        { getProperties: () => ({ liikennehaittaindeksi, statusKey: undefined }) },
+        undefined,
+        false,
+      ),
+    ).toBe(expectedStyle);
+  });
+
+  it('when statusKey is LAVENDER_BLUE, style is STYLES.LAVENDER_BLUE', () => {
+    expect(
+      styleFunction(
+        { getProperties: () => ({ liikennehaittaindeksi: undefined, statusKey: 'LAVENDER_BLUE' }) },
+        undefined,
+        false,
+      ),
+    ).toBe(STYLES.LAVENDER_BLUE);
   });
 });

--- a/src/domain/map/utils/geometryStyle.ts
+++ b/src/domain/map/utils/geometryStyle.ts
@@ -74,16 +74,25 @@ export const STYLES = {
     }),
     stroke: strokeHL,
   }),
-  PURPLE: new Style({
+  LAVENDER_BLUE: new Style({
     fill: new Fill({
-      color: '#ccccff',
+      color: getColorByStatus(LIIKENNEHAITTA_STATUS.LAVENDER_BLUE, opacity),
     }),
     stroke: stroke,
+  }),
+  LAVENDER_BLUE_HL: new Style({
+    fill: new Fill({
+      color: getColorByStatus(LIIKENNEHAITTA_STATUS.LAVENDER_BLUE, opacityHL),
+    }),
+    stroke: strokeHL,
   }),
 };
 
 export const getStyleByStatus = (status: LIIKENNEHAITTA_STATUS, highlight = false): Style =>
   $enum.mapValue(status).with({
+    [LIIKENNEHAITTA_STATUS.LAVENDER_BLUE]: highlight
+      ? STYLES.LAVENDER_BLUE_HL
+      : STYLES.LAVENDER_BLUE,
     [LIIKENNEHAITTA_STATUS.BLUE]: highlight ? STYLES.BLUE_HL : STYLES.BLUE,
     [LIIKENNEHAITTA_STATUS.GREY]: highlight ? STYLES.GREY_HL : STYLES.GREY,
     [LIIKENNEHAITTA_STATUS.GREEN]: highlight ? STYLES.GREEN_HL : STYLES.GREEN,
@@ -94,8 +103,8 @@ export const getStyleByStatus = (status: LIIKENNEHAITTA_STATUS, highlight = fals
 // Performance tips: https://github.com/openlayers/openlayers/issues/8392
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const styleFunction: any = (feature: FeatureLike, renderFeature: any, highlight = false) => {
-  const liikennehaittaindeksi: number | null = feature.get('liikennehaittaindeksi');
-  const status = getStatusByIndex(liikennehaittaindeksi);
+  const { statusKey, liikennehaittaindeksi } = feature.getProperties();
+  const status = (statusKey as LIIKENNEHAITTA_STATUS) ?? getStatusByIndex(liikennehaittaindeksi);
 
   return getStyleByStatus(status, highlight);
 };

--- a/src/domain/map/utils/geometryStyle.ts
+++ b/src/domain/map/utils/geometryStyle.ts
@@ -74,6 +74,12 @@ export const STYLES = {
     }),
     stroke: strokeHL,
   }),
+  PURPLE: new Style({
+    fill: new Fill({
+      color: '#ccccff',
+    }),
+    stroke: stroke,
+  }),
 };
 
 export const getStyleByStatus = (status: LIIKENNEHAITTA_STATUS, highlight = false): Style =>


### PR DESCRIPTION
# Description

Show areas for johtoselvitys applications that user has selected in basic information page. Johtoselvitys areas are lavender blue by color.

Also modified area overlays to match design so that hanke area overlays have background color of summer-light and application area overlays have background color of suomenlinna-light.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2622

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Have a johtoselvitys in hanke that has been sent to Allu
2. Create new kaivuilmoitus or edit existing one that is under same hanke than the johtoselvitys
3. In basic information page select that johtoselvitys as previously made johtoselvitys
4. Go to areas page and check that johtoselvitys areas for the selected johtoselvitys are shown in the map

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
