### PR TITLE
HAI-2829 Remove rounding of hanke area coordinates

### DIFF
--- a/src/domain/map/utils.ts
+++ b/src/domain/map/utils.ts
@@ -11,9 +11,7 @@ import { getSurfaceArea } from '../../common/components/map/utils';
 
 export const formatFeaturesToHankeGeoJSON = (features: GeometryData): HankeGeoJSON => {
   const format = new GeoJSON();
-  const json = format.writeFeatures(features, {
-    decimals: 2, // Not sure if this is correct
-  });
+  const json = format.writeFeatures(features);
   const data = JSON.parse(json);
 
   return {
@@ -24,23 +22,6 @@ export const formatFeaturesToHankeGeoJSON = (features: GeometryData): HankeGeoJS
         name: 'urn:ogc:def:crs:EPSG::3879',
       },
     },
-  };
-};
-
-export const formatFeaturesToAlluGeoJSON = (features: GeometryData): unknown => {
-  const geoJson = new GeoJSON().writeFeaturesObject(features, {
-    decimals: 2, // Not sure if this is correct
-  });
-
-  return {
-    type: 'GeometryCollection',
-    crs: {
-      type: 'name',
-      properties: {
-        name: 'EPSG:3879',
-      },
-    },
-    geometries: geoJson.features.map((feature) => feature.geometry),
   };
 };
 


### PR DESCRIPTION
# Description

Rounding of hanke area coordinates was causing problems in some cases as hakemus area coordinates are not rounded, so removed rounding from hanke areas.

Also removed formatFeaturesToAlluGeoJSON function which is not used.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2829

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
