### PR TITLE
HAI-2842 Fix enabling confirm button on send dialog

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -730,7 +730,6 @@ function ApplicationView({ application, hanke, signedInUser, onEditApplication }
         isLoading={applicationSendMutation.isLoading}
         onClose={closeSendDialog}
         onSend={onSendApplication}
-        applicationId={application.id as number}
       />
     </InformationViewContainer>
   );

--- a/src/domain/application/components/ApplicationSendDialog.test.tsx
+++ b/src/domain/application/components/ApplicationSendDialog.test.tsx
@@ -4,13 +4,7 @@ import { waitFor } from '@testing-library/react';
 
 test('Shows correct information when opened', async () => {
   render(
-    <ApplicationSendDialog
-      isOpen={true}
-      isLoading={false}
-      onClose={() => {}}
-      onSend={() => {}}
-      applicationId={1}
-    />,
+    <ApplicationSendDialog isOpen={true} isLoading={false} onClose={() => {}} onSend={() => {}} />,
   );
 
   expect(screen.getByText(/lähetä hakemus\?/i)).toBeInTheDocument();
@@ -34,13 +28,7 @@ test('Shows correct information when opened', async () => {
 
 test('Shows correct information when ordering paper decision', async () => {
   const { user } = render(
-    <ApplicationSendDialog
-      isOpen={true}
-      isLoading={false}
-      onClose={() => {}}
-      onSend={() => {}}
-      applicationId={1}
-    />,
+    <ApplicationSendDialog isOpen={true} isLoading={false} onClose={() => {}} onSend={() => {}} />,
   );
 
   const orderPaperDecisionButton = screen.getByRole('button', {
@@ -73,13 +61,7 @@ test('Shows correct information when ordering paper decision', async () => {
 
 test('Enables confirmation button when form is filled', async () => {
   const { user } = render(
-    <ApplicationSendDialog
-      isOpen={true}
-      isLoading={false}
-      onClose={() => {}}
-      onSend={() => {}}
-      applicationId={1}
-    />,
+    <ApplicationSendDialog isOpen={true} isLoading={false} onClose={() => {}} onSend={() => {}} />,
   );
 
   const confirmButton = screen.getByRole('button', { name: 'Vahvista' });
@@ -106,13 +88,7 @@ test('Enables confirmation button when form is filled', async () => {
 test('Confirm calls onSend', async () => {
   const onSend = jest.fn();
   const { user } = render(
-    <ApplicationSendDialog
-      isOpen={true}
-      isLoading={false}
-      onClose={() => {}}
-      onSend={onSend}
-      applicationId={1}
-    />,
+    <ApplicationSendDialog isOpen={true} isLoading={false} onClose={() => {}} onSend={onSend} />,
   );
 
   const orderPaperDecisionButton = screen.getByRole('button', {
@@ -136,13 +112,7 @@ test('Confirm calls onSend', async () => {
 test('Cancel calls onClose', async () => {
   const onClose = jest.fn();
   const { user } = render(
-    <ApplicationSendDialog
-      isOpen={true}
-      isLoading={false}
-      onClose={onClose}
-      onSend={() => {}}
-      applicationId={1}
-    />,
+    <ApplicationSendDialog isOpen={true} isLoading={false} onClose={onClose} onSend={() => {}} />,
   );
 
   const cancelButton = screen.getByRole('button', { name: 'Peruuta' });

--- a/src/domain/application/components/ApplicationSendDialog.tsx
+++ b/src/domain/application/components/ApplicationSendDialog.tsx
@@ -12,7 +12,7 @@ import { ApplicationSendData, PaperDecisionReceiver } from '../types/application
 import { FormProvider, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { sendSchema } from '../yupSchemas';
-import { Box, Grid, GridItem, VisuallyHiddenInput } from '@chakra-ui/react';
+import { Box, Grid, GridItem } from '@chakra-ui/react';
 import Text from '../../../common/components/text/Text';
 import TextInput from '../../../common/components/textInput/TextInput';
 
@@ -21,21 +21,13 @@ type Props = {
   isLoading: boolean;
   onClose: () => void;
   onSend: (paperDecisionReceiver?: PaperDecisionReceiver | null) => void;
-  applicationId: number;
 };
 
-const ApplicationSendDialog: React.FC<Props> = ({
-  isOpen,
-  isLoading,
-  onClose,
-  onSend,
-  applicationId,
-}) => {
+const ApplicationSendDialog: React.FC<Props> = ({ isOpen, isLoading, onClose, onSend }) => {
   const { t } = useTranslation();
   const formContext = useForm<ApplicationSendData>({
     resolver: yupResolver(sendSchema),
     defaultValues: {
-      applicationId: applicationId,
       orderPaperDecision: false,
       paperDecisionReceiver: null,
     },
@@ -86,12 +78,6 @@ const ApplicationSendDialog: React.FC<Props> = ({
       <FormProvider {...formContext}>
         <form onSubmit={handleSubmit(submitForm)}>
           <Dialog.Content>
-            <VisuallyHiddenInput
-              name="applicationId"
-              value={applicationId}
-              aria-hidden="true"
-              readOnly
-            />
             <Text tag="p" spacingBottom="s">
               {t('hakemus:sendDialog:instructions')}
             </Text>

--- a/src/domain/application/yupSchemas.ts
+++ b/src/domain/application/yupSchemas.ts
@@ -122,7 +122,6 @@ export const areaSchema = yup.object({
 export const applicationTypeSchema = yup.mixed<ApplicationType>().defined().required();
 
 export const sendSchema = yup.object().shape({
-  applicationId: yup.number().defined().required(),
   orderPaperDecision: yup.boolean().required(),
   paperDecisionReceiver: yup.lazy((_value, context) => {
     // Checking the value of `orderPaperDecision` from the context

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -499,7 +499,6 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
         isLoading={applicationSendMutation.isLoading}
         onClose={closeSendDialog}
         onSend={onSendApplication}
-        applicationId={getValues('id') as number}
       />
     </FormProvider>
   );

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -451,7 +451,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
         isLoading={applicationSendMutation.isLoading}
         onClose={closeSendDialog}
         onSend={onSendApplication}
-        applicationId={getValues('id') as number}
       />
     </FormProvider>
   );


### PR DESCRIPTION
# Description

Fix enabling confirm button on send dialog when trying to send after filling a new application on its last page.
Fix is implemented by removing applicationId from the dialog - it was null when a new application form was filled. ApplicationId is not needed in the dialog because the id is handled in the caller of the send confirmation.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2842

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create a new johtoselvityshakemus or kaivuilmoitus, fill it until the last page
2. On the last page click "Lähetä"
3. "Vahvista" button should be enabled in the send dialog
4. Sending to Allu should work

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
