### PR TITLE
HAI2742 Bugfix for operational condition date not shown

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -371,10 +371,10 @@ describe('Excavation notification application view', () => {
     render(<ApplicationViewContainer id={10} />);
     await waitForLoadingToFinish();
 
-    const reportedDate = new Date('2024-08-01T15:15:00.000Z');
+    const reportedDate = new Date('2024-08-02T15:15:00.000Z');
     expect(
       screen.getByText(
-        `Ilmoitettu valmiiksi 1.8.2024 ${format(reportedDate, 'HH:mm')} päivämäärälle 1.8.2024`,
+        `Ilmoitettu valmiiksi 2.8.2024 ${format(reportedDate, 'HH:mm')} päivämäärälle 2.8.2024`,
       ),
     ).toBeInTheDocument();
   });

--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -355,7 +355,19 @@ describe('Cable report application view', () => {
 });
 
 describe('Excavation notification application view', () => {
-  test('Shows last completion date', async () => {
+  test('Shows last completion date for operational condition', async () => {
+    render(<ApplicationViewContainer id={12} />);
+    await waitForLoadingToFinish();
+
+    const reportedDate = new Date('2024-08-01T15:15:00.000Z');
+    expect(
+      screen.getByText(
+        `Ilmoitettu toiminnalliseen kuntoon 1.8.2024 ${format(reportedDate, 'HH:mm')} päivämäärälle 1.8.2024`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('Shows last completion date for work finished', async () => {
     render(<ApplicationViewContainer id={10} />);
     await waitForLoadingToFinish();
 

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -1202,8 +1202,8 @@ const hakemukset: Application[] = [
       TYO_VALMIS: [
         {
           type: 'TYO_VALMIS',
-          dateReported: new Date('2024-08-01'),
-          reportedAt: new Date('2024-08-01T15:15:15Z'),
+          dateReported: new Date('2024-08-02'),
+          reportedAt: new Date('2024-08-02T15:15:15Z'),
         },
       ],
     },

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -1330,6 +1330,213 @@ const hakemukset: Application[] = [
       ],
     },
   } as Application<JohtoselvitysData>,
+  {
+    id: 12,
+    alluStatus: 'OPERATIONAL_CONDITION',
+    applicationType: 'EXCAVATION_NOTIFICATION',
+    hankeTunnus: 'HAI22-2',
+    applicationIdentifier: 'KP2400003',
+    applicationData: {
+      applicationType: 'EXCAVATION_NOTIFICATION',
+      name: 'Aidasmäentien valmiit kaivuut',
+      startTime: new Date('2023-01-12T00:00:00Z'),
+      endTime: new Date('2024-11-12T00:00:00Z'),
+      workDescription: 'Kaivetaan Aidasmäentiellä',
+      constructionWork: true,
+      maintenanceWork: false,
+      emergencyWork: false,
+      propertyConnectivity: false,
+      rockExcavation: false,
+      cableReportDone: false,
+      requiredCompetence: true,
+      cableReports: ['JS2300002'],
+      placementContracts: ['SL1234567'],
+      areas: [
+        {
+          name: 'Hankealue 2',
+          hankealueId: 2,
+          tyoalueet: [
+            {
+              geometry: {
+                type: 'Polygon',
+                crs: {
+                  type: 'name',
+                  properties: {
+                    name: 'urn:ogc:def:crs:EPSG::3879',
+                  },
+                },
+                coordinates: [
+                  [
+                    [25498585.50387858, 6679353.862125141],
+                    [25498588.30930639, 6679372.671835153],
+                    [25498578.30073113, 6679371.404998987],
+                    [25498577.10224065, 6679355.728613365],
+                    [25498585.50387858, 6679353.862125141],
+                  ],
+                ],
+              },
+              area: 158.4294946899533,
+            },
+            {
+              geometry: {
+                type: 'Polygon',
+                crs: {
+                  type: 'name',
+                  properties: {
+                    name: 'urn:ogc:def:crs:EPSG::3879',
+                  },
+                },
+                coordinates: [
+                  [
+                    [25498581.440262634, 6679345.526261961],
+                    [25498582.233686976, 6679350.99321805],
+                    [25498576.766730886, 6679351.786642391],
+                    [25498575.973306544, 6679346.319686302],
+                    [25498581.440262634, 6679345.526261961],
+                  ],
+                ],
+              },
+              area: 30.345726208334995,
+            },
+          ],
+          katuosoite: 'Aidasmäentie 5',
+          tyonTarkoitukset: ['VESI'],
+          meluhaitta: 'TOISTUVA_MELUHAITTA',
+          polyhaitta: 'JATKUVA_POLYHAITTA',
+          tarinahaitta: 'SATUNNAINEN_TARINAHAITTA',
+          kaistahaitta: 'VAHENTAA_KAISTAN_YHDELLA_AJOSUUNNALLA',
+          kaistahaittojenPituus: 'PITUUS_10_99_METRIA',
+          lisatiedot: '',
+        },
+      ],
+      customerWithContacts: {
+        customer: {
+          type: 'COMPANY',
+          name: 'Yritys Oy',
+          country: 'FI',
+          email: 'yritys@test.com',
+          phone: '0000000000',
+          registryKey: '1164243-9',
+          registryKeyHidden: false,
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            email: 'matti.meikalainen@test.com',
+            firstName: 'Matti',
+            lastName: 'Meikäläinen',
+            orderer: true,
+            phone: '0401234567',
+          },
+        ],
+      },
+      contractorWithContacts: {
+        customer: {
+          type: 'COMPANY',
+          name: 'Yritys 2 Oy',
+          country: 'FI',
+          email: 'yritys2@test.com',
+          phone: '040123456',
+          registryKey: null,
+          registryKeyHidden: false,
+          ovt: null,
+          invoicingOperator: null,
+          sapCustomerNumber: null,
+        },
+        contacts: [
+          {
+            hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afb1',
+            email: 'tauno@test.com',
+            firstName: 'Tauno',
+            lastName: 'Testinen',
+            orderer: false,
+            phone: '0401234567',
+          },
+        ],
+      },
+      representativeWithContacts: null,
+      propertyDeveloperWithContacts: null,
+      invoicingCustomer: {
+        type: 'COMPANY',
+        name: 'Laskutus Oy',
+        registryKey: '1234567-1',
+        registryKeyHidden: false,
+        postalAddress: {
+          streetAddress: { streetName: 'Laskutuskuja 1' },
+          postalCode: '00100',
+          city: 'Helsinki',
+        },
+      },
+      paperDecisionReceiver: {
+        name: 'Pekka Paperinen',
+        streetAddress: 'Paperipolku 3 A 4',
+        postalCode: '00451',
+        city: 'Helsinki',
+      },
+    },
+    paatokset: {
+      KP2400002: [
+        {
+          id: '4567652f-85fd-4ae1-b7f0-1694a93bddaa',
+          hakemusId: 8,
+          hakemustunnus: 'KP2400002',
+          tyyppi: 'TOIMINNALLINEN_KUNTO',
+          tila: 'KORVATTU',
+          nimi: 'KI 2024-06-27',
+          alkupaiva: new Date('2024-05-28'),
+          loppupaiva: new Date('2024-05-31'),
+          size: 35764,
+        },
+        {
+          id: '404e0300-db95-4c65-9d27-eff8930fef23',
+          hakemusId: 8,
+          hakemustunnus: 'KP2400002',
+          tyyppi: 'PAATOS',
+          tila: 'KORVATTU',
+          nimi: 'KI 2024-06-27',
+          alkupaiva: new Date('2024-05-28'),
+          loppupaiva: new Date('2024-05-31'),
+          size: 35764,
+        },
+      ],
+      'KP240002-2': [
+        {
+          id: '6a24e4a6-8f87-4da7-96f9-5f6b54ea6834',
+          hakemusId: 8,
+          hakemustunnus: 'KP2400002-2',
+          tyyppi: 'PAATOS',
+          tila: 'NYKYINEN',
+          nimi: 'KI 2024-06-27',
+          alkupaiva: new Date('2024-05-28'),
+          loppupaiva: new Date('2024-05-31'),
+          size: 35764,
+        },
+        {
+          id: '59e202c4-7571-4b16-96d0-2945d689bedf',
+          hakemusId: 8,
+          hakemustunnus: 'KP2400002-2',
+          tyyppi: 'TOIMINNALLINEN_KUNTO',
+          tila: 'NYKYINEN',
+          nimi: 'KI 2024-06-27',
+          alkupaiva: new Date('2024-05-28'),
+          loppupaiva: new Date('2024-05-31'),
+          size: 35764,
+        },
+      ],
+    },
+    valmistumisilmoitukset: {
+      TOIMINNALLINEN_KUNTO: [
+        {
+          type: 'TOIMINNALLINEN_KUNTO',
+          dateReported: new Date('2024-08-01'),
+          reportedAt: new Date('2024-08-01T15:15:15Z'),
+        },
+      ],
+    },
+  } as Application<KaivuilmoitusData>,
 ];
 
 export default hakemukset;


### PR DESCRIPTION
# Description

Before the latest timestamp of operational condition or work finised notice was shown only if the `alluStatus` of the application was something specific. Now, the latest timestamp of either type is shown always if there are any of these notices made in Haitaton.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2742

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create a kaivuilmoitus and send it to Allu or use an existing kaivuilmoitus with some non-null `alluStatus`
2. Buttons "Ilmoita toiminnalliseen kuntoon" and "Ilmoita valmiiksi" should be shown
3. Create some notices of both types - the latest notice timestamp should be shown on the application page

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
