### PR TITLE
HAI-2818 Add map to select previous cable report applications to use in kaivuilmoitus form

### DIFF
--- a/src/domain/application/components/ApplicationMap.tsx
+++ b/src/domain/application/components/ApplicationMap.tsx
@@ -231,9 +231,7 @@ export default function ApplicationMap({
                   </Box>
                 );
               }
-              return (
-                <AreaOverlay overlayProps={overlayProperties} copyAreaElement={copyAreaElement} />
-              );
+              return <AreaOverlay overlayProps={overlayProperties}>{copyAreaElement}</AreaOverlay>;
             }}
           />
 

--- a/src/domain/kaivuilmoitus/BasicInfo.tsx
+++ b/src/domain/kaivuilmoitus/BasicInfo.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Box } from '@chakra-ui/react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useFormContext } from 'react-hook-form';
@@ -13,12 +13,21 @@ import TagInput from '../../common/components/tagInput/TagInput';
 import InputCombobox from '../../common/components/inputCombobox/InputCombobox';
 import { getInputErrorText } from '../../common/utils/form';
 import BooleanRadioButton from '../../common/components/radiobutton/BooleanRadioButton';
+import JohtoselvitysSelectionMap from '../map/components/JohtoselvitysSelectionMap/JohtoselvitysSelectionMap';
+import { HankeData } from '../types/hanke';
+import { HankkeenHakemus } from '../application/types/application';
 
 type Props = {
+  hankeData: HankeData;
+  hankkeenHakemukset: HankkeenHakemus[];
   johtoselvitysIds?: string[];
 };
 
-export default function BasicInfo({ johtoselvitysIds }: Readonly<Props>) {
+export default function BasicInfo({
+  johtoselvitysIds,
+  hankeData,
+  hankkeenHakemukset,
+}: Readonly<Props>) {
   const { t } = useTranslation();
   const {
     register,
@@ -68,6 +77,12 @@ export default function BasicInfo({ johtoselvitysIds }: Readonly<Props>) {
       { shouldDirty: true },
     );
   }
+
+  const handleJohtoselvitysSelection = useCallback(
+    (tunnukset: string[]) =>
+      setValue('applicationData.cableReports', tunnukset, { shouldDirty: true }),
+    [setValue],
+  );
 
   return (
     <div>
@@ -212,6 +227,12 @@ export default function BasicInfo({ johtoselvitysIds }: Readonly<Props>) {
           className={styles.formRow}
         >
           <Box marginTop="var(--spacing-3-xs)">
+            <JohtoselvitysSelectionMap
+              hankeData={hankeData}
+              hankkeenHakemukset={hankkeenHakemukset}
+              selectedJohtoselvitysTunnukset={getValues('applicationData.cableReports') ?? []}
+              onSelectJohtoselvitys={handleJohtoselvitysSelection}
+            />
             <InputCombobox
               id="applicationData.cableReports"
               name="applicationData.cableReports"

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -281,7 +281,13 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
 
   const formSteps = [
     {
-      element: <BasicInfo johtoselvitysIds={johtoselvitysIds} />,
+      element: (
+        <BasicInfo
+          hankeData={hankeData}
+          johtoselvitysIds={johtoselvitysIds}
+          hankkeenHakemukset={hankkeenHakemukset?.applications ?? []}
+        />
+      ),
       label: t('form:headers:perustiedot'),
       state: StepState.available,
       validationSchema: perustiedotSchema,

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -87,7 +87,7 @@ async function fillBasicInformation(
   }
 
   for (const cableReport of cableReports) {
-    fireEvent.change(screen.getByRole('combobox'), {
+    fireEvent.change(screen.getAllByRole('combobox')[1], {
       target: { value: cableReport },
     });
     await user.keyboard('{Enter}');
@@ -424,7 +424,7 @@ test('Should be able to fill form pages and show filled information in summary p
       cableReports: [],
       placementContracts: [],
       requiredCompetence: false,
-      areas: applications[4].applicationData.areas as KaivuilmoitusAlue[],
+      areas: cloneDeep(applications[4].applicationData.areas) as KaivuilmoitusAlue[],
       startTime: null,
       endTime: null,
       representativeWithContacts: null,
@@ -876,7 +876,7 @@ test('Should be able to upload attachments', async () => {
   const { user } = render(
     <KaivuilmoitusContainer
       hankeData={hankeData}
-      application={applications[4] as Application<KaivuilmoitusData>}
+      application={cloneDeep(applications[4]) as Application<KaivuilmoitusData>}
     />,
   );
   await user.click(screen.getByRole('button', { name: /liitteet/i }));
@@ -938,7 +938,7 @@ test('Should be able to delete attachments', async () => {
   const { user } = render(
     <KaivuilmoitusContainer
       hankeData={hankeData}
-      application={applications[4] as Application<KaivuilmoitusData>}
+      application={cloneDeep(applications[4]) as Application<KaivuilmoitusData>}
     />,
   );
   await user.click(screen.getByRole('button', { name: /liitteet/i }));
@@ -1004,7 +1004,7 @@ test('Should list existing attachments in the attachments page', async () => {
   const { user } = render(
     <KaivuilmoitusContainer
       hankeData={hankeData}
-      application={applications[4] as Application<KaivuilmoitusData>}
+      application={cloneDeep(applications[4]) as Application<KaivuilmoitusData>}
     />,
   );
   const button = await screen.findByRole('button', { name: /liitteet/i });
@@ -1244,7 +1244,7 @@ test('Should show and disable send button and show notification when user is not
 
 test('Should be able to fill user email and phone by selecting existing user in user name search input', async () => {
   const hankeData = hankkeet[1] as HankeData;
-  const application = applications[4] as Application<KaivuilmoitusData>;
+  const application = cloneDeep(applications[4]) as Application<KaivuilmoitusData>;
   const { user } = render(
     <KaivuilmoitusContainer hankeData={hankeData} application={application} />,
   );

--- a/src/domain/map/components/AreaOverlay/AreaOverlay.test.tsx
+++ b/src/domain/map/components/AreaOverlay/AreaOverlay.test.tsx
@@ -24,7 +24,7 @@ describe('AreaOverlay', () => {
 
   test('renders copyAreaElement if provided', () => {
     const copyAreaElement = <div>Copy Area Element</div>;
-    render(<AreaOverlay overlayProps={defaultProps} copyAreaElement={copyAreaElement} />);
+    render(<AreaOverlay overlayProps={defaultProps}>{copyAreaElement}</AreaOverlay>);
     expect(screen.getByText('Copy Area Element')).toBeInTheDocument();
   });
 

--- a/src/domain/map/components/AreaOverlay/AreaOverlay.tsx
+++ b/src/domain/map/components/AreaOverlay/AreaOverlay.tsx
@@ -5,10 +5,10 @@ import { formatToFinnishDate } from '../../../../common/utils/date';
 
 type Props = {
   overlayProps?: OverlayProps;
-  copyAreaElement?: React.ReactNode;
+  children?: React.ReactNode;
 };
 
-export default function AreaOverlay({ overlayProps, copyAreaElement }: Readonly<Props>) {
+export default function AreaOverlay({ overlayProps, children }: Readonly<Props>) {
   if (!overlayProps) {
     return null;
   }
@@ -32,7 +32,7 @@ export default function AreaOverlay({ overlayProps, copyAreaElement }: Readonly<
           {formatToFinnishDate(startDate)}–{formatToFinnishDate(endDate)}
         </Box>
       )}
-      {copyAreaElement && <Box marginTop="var(--spacing-3-xs)">{copyAreaElement}</Box>}
+      {children && <Box marginTop="var(--spacing-3-xs)">{children}</Box>}
     </Box>
   );
 }

--- a/src/domain/map/components/JohtoselvitysSelectionMap/JohtoselvitysSelectionMap.module.scss
+++ b/src/domain/map/components/JohtoselvitysSelectionMap/JohtoselvitysSelectionMap.module.scss
@@ -1,0 +1,18 @@
+.mapContainer {
+  position: relative;
+  width: 100%;
+  height: 500px;
+  margin-bottom: var(--spacing-m);
+
+  &__inner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+  }
+}
+
+.overviewMap {
+  bottom: 10px;
+}

--- a/src/domain/map/components/JohtoselvitysSelectionMap/JohtoselvitysSelectionMap.tsx
+++ b/src/domain/map/components/JohtoselvitysSelectionMap/JohtoselvitysSelectionMap.tsx
@@ -67,6 +67,7 @@ function JohtoselvitysSelect({
         .filter((feature) => {
           return selectedJohtoselvitysTunnukset.includes(feature.get('applicationIdentifier'));
         });
+      selectInteraction.current.getFeatures().clear();
       selectInteraction.current.getFeatures().extend(selectedJohtoselvitysFeatures ?? []);
     });
 

--- a/src/domain/map/components/JohtoselvitysSelectionMap/JohtoselvitysSelectionMap.tsx
+++ b/src/domain/map/components/JohtoselvitysSelectionMap/JohtoselvitysSelectionMap.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useContext, useEffect, useRef } from 'react';
+import { Button, IconMinusCircleFill, IconPlusCircle } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import VectorSource from 'ol/source/Vector';
+import { Select } from 'ol/interaction';
+import VectorLayer from 'ol/layer/Vector';
+import { Feature, MapBrowserEvent } from 'ol';
+import { Fill, Stroke, Style } from 'ol/style';
+import { never } from 'ol/events/condition';
+import Map from '../../../../common/components/map/Map';
+import OverviewMapControl from '../../../../common/components/map/controls/OverviewMapControl';
+import DrawProvider from '../../../../common/components/map/modules/draw/DrawProvider';
+import { OverlayProps } from '../../../../common/components/map/types';
+import { HankeData } from '../../../types/hanke';
+import AddressSearchContainer from '../AddressSearch/AddressSearchContainer';
+import AreaOverlay from '../AreaOverlay/AreaOverlay';
+import FeatureInfoOverlay from '../FeatureInfoOverlay/FeatureInfoOverlay';
+import HankeLayer from '../Layers/HankeLayer';
+import styles from './JohtoselvitysSelectionMap.module.scss';
+import Kantakartta from '../Layers/Kantakartta';
+import { HankkeenHakemus } from '../../../application/types/application';
+import HakemusLayer from '../Layers/HakemusLayer';
+import { styleFunction } from '../../utils/geometryStyle';
+import { LIIKENNEHAITTA_STATUS } from '../../../common/utils/liikennehaittaindeksi';
+import MapContext from '../../../../common/components/map/MapContext';
+
+type JohtoselvitysSelectProps = {
+  selectedJohtoselvitysTunnukset: string[];
+  onSelectFeature: (feature?: Feature) => void;
+};
+
+function JohtoselvitysSelect({
+  selectedJohtoselvitysTunnukset,
+  onSelectFeature,
+}: Readonly<JohtoselvitysSelectProps>) {
+  const { map } = useContext(MapContext);
+  const selectInteraction = useRef<Select>(
+    new Select({
+      style: new Style({
+        fill: new Fill({
+          color: 'rgba(0, 0, 94, 0.8)',
+        }),
+        stroke: new Stroke({ color: 'black', width: 3 }),
+      }),
+      condition: never,
+    }),
+  );
+
+  useEffect(() => {
+    if (!map) return;
+    const select = selectInteraction.current;
+
+    map.addInteraction(select);
+
+    return function cleanUp() {
+      map.removeInteraction(select);
+    };
+  }, [map]);
+
+  useEffect(() => {
+    // Add selected features to selected collection so they are highlighted
+    map?.once('rendercomplete', () => {
+      const selectedJohtoselvitysFeatures = map
+        .getAllLayers()
+        .filter((layer) => layer instanceof VectorLayer)
+        .flatMap((layer) => (layer.getSource() as VectorSource).getFeatures())
+        .filter((feature) => {
+          return selectedJohtoselvitysTunnukset.includes(feature.get('applicationIdentifier'));
+        });
+      selectInteraction.current.getFeatures().extend(selectedJohtoselvitysFeatures ?? []);
+    });
+
+    // Select/deselect features that are clicked
+    function handleMapClick(event: MapBrowserEvent<UIEvent>) {
+      const features = map?.getFeaturesAtPixel(event.pixel);
+      if (features) {
+        const feature = features[0] as Feature;
+        onSelectFeature(feature);
+      }
+    }
+
+    map?.on('singleclick', handleMapClick);
+
+    return function cleanup() {
+      map?.un('singleclick', handleMapClick);
+    };
+  }, [map, selectInteraction, selectedJohtoselvitysTunnukset, onSelectFeature]);
+
+  return null;
+}
+
+type JohtoselvitysSelectionMapProps = {
+  hankeData: HankeData;
+  hankkeenHakemukset: HankkeenHakemus[];
+  selectedJohtoselvitysTunnukset: string[];
+  onSelectJohtoselvitys: (tunnukset: string[]) => void;
+};
+
+export default function JohtoselvitysSelectionMap({
+  hankeData,
+  hankkeenHakemukset,
+  selectedJohtoselvitysTunnukset,
+  onSelectJohtoselvitys,
+}: Readonly<JohtoselvitysSelectionMapProps>) {
+  const { t } = useTranslation();
+  const vectorSource = useRef(new VectorSource());
+  const johtoselvitykset = hankkeenHakemukset.filter(
+    (hakemus) =>
+      hakemus.applicationType === 'CABLE_REPORT' && Boolean(hakemus.applicationIdentifier),
+  );
+
+  const handleFeatureSelection = useCallback(
+    (feature?: Feature) => {
+      if (feature) {
+        const applicationIdentifier = feature.get('applicationIdentifier') as string | undefined;
+        if (applicationIdentifier) {
+          const tunnusSelected = selectedJohtoselvitysTunnukset.includes(applicationIdentifier);
+          onSelectJohtoselvitys(
+            tunnusSelected
+              ? selectedJohtoselvitysTunnukset.filter((tunnus) => tunnus !== applicationIdentifier)
+              : selectedJohtoselvitysTunnukset.concat([applicationIdentifier]),
+          );
+        }
+      }
+    },
+    [onSelectJohtoselvitys, selectedJohtoselvitysTunnukset],
+  );
+
+  return (
+    <div className={styles.mapContainer}>
+      <Map zoom={9} mapClassName={styles.mapContainer__inner} showAttribution={false}>
+        <Kantakartta />
+        <AddressSearchContainer position={{ top: '1rem', left: '1rem' }} zIndex={2} />
+        <OverviewMapControl className={styles.overviewMap} />
+        <JohtoselvitysSelect
+          selectedJohtoselvitysTunnukset={selectedJohtoselvitysTunnukset}
+          onSelectFeature={handleFeatureSelection}
+        />
+        <DrawProvider source={vectorSource.current}>
+          <FeatureInfoOverlay
+            render={(feature) => {
+              const overlayProperties = feature?.get('overlayProps') as OverlayProps | undefined;
+              const applicationIdentifier = feature?.get('applicationIdentifier') as
+                | string
+                | undefined;
+
+              let selectionButton = null;
+              if (applicationIdentifier) {
+                const selectionButtonType = selectedJohtoselvitysTunnukset.includes(
+                  applicationIdentifier,
+                )
+                  ? 'remove'
+                  : 'add';
+
+                selectionButton = (
+                  <Button
+                    size="small"
+                    theme="coat"
+                    iconLeft={
+                      selectionButtonType === 'remove' ? (
+                        <IconMinusCircleFill />
+                      ) : (
+                        <IconPlusCircle />
+                      )
+                    }
+                    onClick={() => handleFeatureSelection(feature as Feature)}
+                  >
+                    {selectionButtonType === 'remove'
+                      ? t('hakemus:buttons:removeSelection')
+                      : t('hakemus:buttons:selectCableReport')}
+                  </Button>
+                );
+              }
+              return <AreaOverlay overlayProps={overlayProperties}>{selectionButton}</AreaOverlay>;
+            }}
+          />
+        </DrawProvider>
+        {/* Hanke areas */}
+        <HankeLayer hankeData={[hankeData]} fitSource />
+        {/* Johtoselvitys areas */}
+        {johtoselvitykset.map((hakemus) => (
+          <HakemusLayer
+            hakemusId={hakemus.id!}
+            layerStyle={styleFunction}
+            featureProperties={{
+              statusKey: LIIKENNEHAITTA_STATUS.LAVENDER_BLUE,
+              applicationIdentifier: hakemus.applicationIdentifier,
+            }}
+          />
+        ))}
+      </Map>
+    </div>
+  );
+}

--- a/src/domain/map/components/JohtoselvitysSelectionMap/JohtoselvitysSelectionMap.tsx
+++ b/src/domain/map/components/JohtoselvitysSelectionMap/JohtoselvitysSelectionMap.tsx
@@ -181,6 +181,7 @@ export default function JohtoselvitysSelectionMap({
         {/* Johtoselvitys areas */}
         {johtoselvitykset.map((hakemus) => (
           <HakemusLayer
+            key={hakemus.id}
             hakemusId={hakemus.id!}
             layerStyle={styleFunction}
             featureProperties={{

--- a/src/domain/map/components/Layers/HakemusLayer.tsx
+++ b/src/domain/map/components/Layers/HakemusLayer.tsx
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import VectorSource from 'ol/source/Vector';
 import { StyleLike } from 'ol/style/Style';
 import { useApplication } from '../../../application/hooks/useApplication';
-import { ApplicationArea } from '../../../application/types/application';
+import { ApplicationArea, KaivuilmoitusAlue } from '../../../application/types/application';
 import VectorLayer from '../../../../common/components/map/layers/VectorLayer';
 import useApplicationFeatures from '../../hooks/useApplicationFeatures';
 import { OverlayProps } from '../../../../common/components/map/types';
@@ -19,13 +19,24 @@ export default function HakemusLayer({
   featureProperties = {},
 }: Readonly<Props>) {
   const source = useRef(new VectorSource());
-  const { data } = useApplication(hakemusId);
-  const tyoalueet = (data?.applicationData.areas as ApplicationArea[]) ?? [];
+  const { data: application } = useApplication(hakemusId);
+  let tyoalueet: ApplicationArea[] = [];
+  if (application) {
+    tyoalueet =
+      application.applicationType === 'CABLE_REPORT'
+        ? (application.applicationData.areas as ApplicationArea[])
+        : (application.applicationData.areas as KaivuilmoitusAlue[]).flatMap(
+            (area) => area.tyoalueet,
+          );
+  }
+
   useApplicationFeatures(source.current, tyoalueet, {
     overlayProps: new OverlayProps({
-      heading: data ? `${data.applicationData.name} (${data.applicationIdentifier})` : null,
-      startDate: data?.applicationData.startTime,
-      endDate: data?.applicationData.endTime,
+      heading: application
+        ? `${application.applicationData.name} (${application.applicationIdentifier})`
+        : null,
+      startDate: application?.applicationData.startTime,
+      endDate: application?.applicationData.endTime,
       backgroundColor: 'var(--color-suomenlinna-light)',
       enableCopyArea: true,
     }),

--- a/src/domain/map/hooks/useApplicationFeatures.ts
+++ b/src/domain/map/hooks/useApplicationFeatures.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Vector } from 'ol/source';
 import GeoJSON from 'ol/format/GeoJSON';
 import { Feature } from 'ol';
@@ -13,8 +13,10 @@ export default function useApplicationFeatures(
   areas?: ApplicationArea[],
   featureProperties: { [x: string]: unknown } = {},
 ) {
+  const featuresAdded = useRef(false);
+
   useEffect(() => {
-    if (areas && areas.length > 0) {
+    if (areas && areas.length > 0 && !featuresAdded.current) {
       const applicationFeatures = areas.map((area) => {
         const feature = new GeoJSON().readFeatures(area.geometry)[0] as Feature<Geometry>;
 
@@ -31,10 +33,7 @@ export default function useApplicationFeatures(
         return feature;
       }) as Feature<Geometry>[];
       source.addFeatures(applicationFeatures);
+      featuresAdded.current = true;
     }
-
-    return function cleanup() {
-      source.clear();
-    };
   }, [source, areas, featureProperties]);
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -786,7 +786,7 @@
       "applicationAdditionalInfo": "Additional information on the application",
       "applicationInfo": "Application information",
       "cableReports": "Identifiers of previous cable reports",
-      "cableReportsHelp": "Select one from the list or enter another identifier and press ‘Enter’ to add it",
+      "cableReportsHelp": "Select one from the list or enter another identifier and press ‘Enter’ to add it[TRANSLATION_PENDING]",
       "placementContractsTitle": "Placement agreements",
       "placementContracts": "Placement agreement identifier",
       "placementContractsHelp": "Enter the placement agreement identifier and press ‘Add’",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1116,7 +1116,7 @@
       "useExistingCableReports": "Käytä olemassa olevia johtoselvityksiä",
       "newCableReport": "Uusi johtoselvitys",
       "cableReports": "Tehtyjen johtoselvitysten tunnukset",
-      "cableReportsHelp": "Valitse listasta tai kirjoita muu tunnus ja paina Enter lisätäksesi",
+      "cableReportsHelp": "Valitse kartalta tai listasta tai kirjoita muu tunnus ja paina Enter lisätäksesi",
       "placementContractsTitle": "Sijoitussopimukset",
       "placementContracts": "Sijoitussopimustunnus",
       "placementContractsHelp": "Anna sijoitussopimustunnus ja paina Lisää",
@@ -1218,7 +1218,9 @@
       "deletePlacementContract": "Poista sijoitussopimustunnus {{id}}",
       "reportOperationalCondition": "Ilmoita toiminnalliseen kuntoon",
       "reportWorkFinished": "Ilmoita valmiiksi",
-      "copyWorkArea": "Kopioi työalueeksi"
+      "copyWorkArea": "Kopioi työalueeksi",
+      "removeSelection": "Poista valinta",
+      "selectCableReport": "Valitse johtoselvitys"
     },
     "errors": {
       "cancelConflict": "Hakemusta ei voida perua, koska se on edennyt käsittelyyn",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -782,7 +782,7 @@
       "applicationAdditionalInfo": "Mer information om ansökan",
       "applicationInfo": "Ansökans uppgifter",
       "cableReports": "Koder för utförda ledningsutredningar",
-      "cableReportsHelp": "Välj i listan eller skriv in en annan kod och tryck på Enter för att lägga till den",
+      "cableReportsHelp": "Välj i listan eller skriv in en annan kod och tryck på Enter för att lägga till den[TRANSLATION_PENDING]",
       "placementContractsTitle": "Placeringsavtal",
       "placementContracts": "Kod för placeringsavtal",
       "placementContractsHelp": "Ange placeringsavtalets kod och tryck på Lägg till",


### PR DESCRIPTION
# Description

In kaivuilmoitus form basic information page, user can select which of the previously made cable report applications to use by clicking their areas on the map or pressing the button in their hover box.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2818

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Make sure you have some cable report applications that have been sent to Allu
2. Create or edit existing kaivuilmoitus
3. In the first page of the form try to select cable report applications by clicking their areas on the map or by clicking "Valitse johtoselvitys" button in the hover box
4. Check that they are added to the dropdown also

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
