### PR TITLE
HAI-2760 Show changes in johtoselvitys taydennys form summary page

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -398,6 +398,7 @@ describe('Cable report application view', () => {
       application.taydennys = {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
         applicationData: application.applicationData,
+        muutokset: [],
       };
       await setup(application);
 
@@ -436,6 +437,7 @@ describe('Cable report application view', () => {
       application.taydennys = {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
         applicationData: application.applicationData,
+        muutokset: [],
       };
       const { user } = await setup(application);
       await user.click(screen.getByRole('button', { name: 'Muokkaa hakemusta (täydennys)' }));

--- a/src/domain/application/components/summary/ContactsSummary.tsx
+++ b/src/domain/application/components/summary/ContactsSummary.tsx
@@ -48,8 +48,9 @@ export const ContactSummary: React.FC<{ contact: Contact }> = ({ contact }) => {
 
 const ContactsSummary: React.FC<{
   customerWithContacts?: CustomerWithContacts | null;
+  ContentContainer?: JSX.ElementType;
   title: string;
-}> = ({ customerWithContacts, title }) => {
+}> = ({ customerWithContacts, ContentContainer = SectionItemContent, title }) => {
   const { t } = useTranslation();
 
   if (!customerWithContacts || isCustomerEmpty(customerWithContacts.customer)) {
@@ -59,7 +60,7 @@ const ContactsSummary: React.FC<{
   return (
     <>
       <SectionItemTitle>{title}</SectionItemTitle>
-      <SectionItemContent>
+      <ContentContainer>
         <CustomerSummary customer={customerWithContacts.customer} />
         {customerWithContacts.contacts.length > 0 && (
           <>
@@ -78,7 +79,7 @@ const ContactsSummary: React.FC<{
             </Grid>
           </>
         )}
-      </SectionItemContent>
+      </ContentContainer>
     </>
   );
 };

--- a/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.test.tsx
+++ b/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.test.tsx
@@ -1,0 +1,71 @@
+import { cloneDeep } from 'lodash';
+import JohtoselvitysAreaSummary from './JohtoselvitysAreaSummary';
+import { JohtoselvitysData } from '../../../types/application';
+import applications from '../../../../mocks/data/hakemukset-data';
+import { render, screen } from '../../../../../testUtils/render';
+
+const testApplication = cloneDeep(applications[10].applicationData as JohtoselvitysData);
+
+const mockData: JohtoselvitysData = {
+  ...testApplication,
+  startTime: new Date('2024-08-01'),
+  endTime: new Date('2024-08-31'),
+};
+
+describe('JohtoselvitysAreaSummary', () => {
+  test('renders nothing if no changes', () => {
+    const { container } = render(
+      <JohtoselvitysAreaSummary data={mockData} originalData={mockData} muutokset={[]} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders start time change', () => {
+    render(
+      <JohtoselvitysAreaSummary
+        data={{ ...mockData, startTime: new Date('2024-08-02') }}
+        originalData={mockData}
+        muutokset={['startTime']}
+      />,
+    );
+
+    expect(screen.getByText('2.8.2024')).toBeInTheDocument();
+  });
+
+  test('renders end time change', () => {
+    render(
+      <JohtoselvitysAreaSummary
+        data={{ ...mockData, endTime: new Date('2024-08-29') }}
+        originalData={mockData}
+        muutokset={['endTime']}
+      />,
+    );
+
+    expect(screen.getByText('29.8.2024')).toBeInTheDocument();
+  });
+
+  test('renders area changes', () => {
+    render(
+      <JohtoselvitysAreaSummary data={mockData} originalData={mockData} muutokset={['areas[0]']} />,
+    );
+
+    expect(screen.getByText('Työalue')).toBeInTheDocument();
+    expect(screen.getByText('Pinta-ala: 234 m²')).toBeInTheDocument();
+    expect(screen.queryByText(/poistettu/i)).not.toBeInTheDocument();
+  });
+
+  test('renders removed areas', () => {
+    render(
+      <JohtoselvitysAreaSummary
+        data={{ ...mockData, areas: [] }}
+        originalData={mockData}
+        muutokset={['areas[0]']}
+      />,
+    );
+
+    expect(screen.getByText(/poistettu/i)).toBeInTheDocument();
+    expect(screen.getByText('Työalue')).toBeInTheDocument();
+    expect(screen.getByText('Pinta-ala: 234 m²')).toBeInTheDocument();
+  });
+});

--- a/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.tsx
@@ -1,0 +1,144 @@
+import Geometry from 'ol/geom/Geometry';
+import { useTranslation } from 'react-i18next';
+import { Box } from '@chakra-ui/react';
+import { ApplicationArea, JohtoselvitysData } from '../../../types/application';
+import { getAreaGeometries, getAreaGeometry } from '../../../../johtoselvitys/utils';
+import { formatSurfaceArea, getTotalSurfaceArea } from '../../../../map/utils';
+import {
+  FormSummarySection,
+  SectionItemContent,
+  SectionItemContentRemoved,
+  SectionItemTitle,
+  SectionTitle,
+} from '../../../../forms/components/FormSummarySection';
+import { formatToFinnishDate } from '../../../../../common/utils/date';
+import Text from '../../../../../common/components/text/Text';
+import { getAreaDefaultName } from '../../../utils';
+
+function AreaInformation({
+  area,
+  areaName,
+}: Readonly<{ area: ApplicationArea; areaName: string }>) {
+  const { t } = useTranslation();
+  const geom = getAreaGeometry(area);
+
+  return (
+    <Box marginBottom="var(--spacing-m)">
+      <Text tag="p" spacingBottom="s">
+        <strong>{areaName}</strong>
+      </Text>
+      <p>
+        {t('form:labels:pintaAla')}: {formatSurfaceArea(geom)}
+      </p>
+    </Box>
+  );
+}
+
+type Props = {
+  data: JohtoselvitysData;
+  originalData: JohtoselvitysData;
+  muutokset: string[];
+};
+
+export default function JohtoselvitysAreaSummary({
+  data,
+  originalData,
+  muutokset,
+}: Readonly<Props>) {
+  const { t } = useTranslation();
+  const { startTime, endTime, areas } = data;
+  const startTimeChanged = muutokset.includes('startTime');
+  const endTimeChanged = muutokset.includes('endTime');
+  const areasChanged = areas.filter((_, index) => {
+    const areaChanged = muutokset.includes(`areas[${index}]`);
+    return areaChanged;
+  });
+  const areasRemoved = originalData.areas.filter(
+    (_, index) => muutokset.includes(`areas[${index}]`) && !areas[index],
+  );
+
+  if (
+    !startTimeChanged &&
+    !endTimeChanged &&
+    areasChanged.length === 0 &&
+    areasRemoved.length === 0
+  ) {
+    return null;
+  }
+
+  const geometries: Geometry[] = getAreaGeometries(areasChanged);
+  const totalSurfaceArea = getTotalSurfaceArea(geometries);
+
+  return (
+    <>
+      <SectionTitle>{t('hankeForm:hankkeenAlueForm:header')}</SectionTitle>
+      <FormSummarySection>
+        {startTimeChanged && (
+          <>
+            <SectionItemTitle>{t('hakemus:labels:startDate')}</SectionItemTitle>
+            {!startTime ? (
+              <SectionItemContentRemoved>
+                <p>{formatToFinnishDate(originalData.startTime)}</p>
+              </SectionItemContentRemoved>
+            ) : (
+              <SectionItemContent>{<p>{formatToFinnishDate(startTime)}</p>}</SectionItemContent>
+            )}
+          </>
+        )}
+        {endTimeChanged && (
+          <>
+            <SectionItemTitle>{t('hakemus:labels:endDate')}</SectionItemTitle>
+            {!endTime ? (
+              <SectionItemContentRemoved>
+                <p>{formatToFinnishDate(originalData.endTime)}</p>
+              </SectionItemContentRemoved>
+            ) : (
+              <SectionItemContent>{<p>{formatToFinnishDate(endTime)}</p>}</SectionItemContent>
+            )}
+          </>
+        )}
+        {(areasChanged.length > 0 || areasRemoved.length > 0) && (
+          <>
+            {areasChanged.length > 0 && (
+              <>
+                <SectionItemTitle>{t('form:labels:kokonaisAla')}</SectionItemTitle>
+                <SectionItemContent>
+                  <p>{totalSurfaceArea} m²</p>
+                </SectionItemContent>
+              </>
+            )}
+            <SectionItemTitle>{t('hankeForm:hankkeenAlueForm:header')}</SectionItemTitle>
+            <SectionItemContent>
+              {areasChanged.map((area, index) => {
+                return (
+                  <AreaInformation
+                    area={area}
+                    areaName={getAreaDefaultName(t, index, originalData.areas.length)}
+                    key={index}
+                  />
+                );
+              })}
+              {areasRemoved.length > 0 && (
+                <SectionItemContentRemoved>
+                  {areasRemoved.map((area, index) => {
+                    return (
+                      <AreaInformation
+                        area={area}
+                        areaName={getAreaDefaultName(
+                          t,
+                          originalData.areas.indexOf(area),
+                          originalData.areas.length,
+                        )}
+                        key={index}
+                      />
+                    );
+                  })}
+                </SectionItemContentRemoved>
+              )}
+            </SectionItemContent>
+          </>
+        )}
+      </FormSummarySection>
+    </>
+  );
+}

--- a/src/domain/application/taydennys/components/summary/JohtoselvitysBasicInfomationSummary.test.tsx
+++ b/src/domain/application/taydennys/components/summary/JohtoselvitysBasicInfomationSummary.test.tsx
@@ -1,0 +1,96 @@
+import { cloneDeep } from 'lodash';
+import { render, screen } from '../../../../../testUtils/render';
+import BasicInformationSummary from './JohtoselvitysBasicInformationSummary';
+import { JohtoselvitysData } from '../../../types/application';
+import applications from '../../../../mocks/data/hakemukset-data';
+
+const testApplication = cloneDeep(applications[10].applicationData as JohtoselvitysData);
+
+const mockData: JohtoselvitysData = {
+  ...testApplication,
+  name: 'Test Name',
+  workDescription: 'Test Description',
+  rockExcavation: true,
+  postalAddress: {
+    streetAddress: {
+      streetName: 'Test Street',
+    },
+  },
+};
+
+describe('BasicInformationSummary', () => {
+  test('renders nothing if no changes are detected', () => {
+    const { container } = render(
+      <BasicInformationSummary data={mockData} originalData={mockData} muutokset={[]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders name change correctly', () => {
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, name: 'New Name' }}
+        originalData={mockData}
+        muutokset={['name']}
+      />,
+    );
+    expect(screen.getByText('New Name')).toBeInTheDocument();
+  });
+
+  test('renders postal address change correctly', () => {
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, postalAddress: { streetAddress: { streetName: 'New Street' } } }}
+        originalData={mockData}
+        muutokset={['postalAddress']}
+      />,
+    );
+    expect(screen.getByText('New Street')).toBeInTheDocument();
+  });
+
+  test('renders work description change correctly', () => {
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, workDescription: 'New Description' }}
+        originalData={mockData}
+        muutokset={['workDescription']}
+      />,
+    );
+    expect(screen.getByText('New Description')).toBeInTheDocument();
+  });
+
+  test('renders rock excavation change correctly', () => {
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, rockExcavation: false }}
+        originalData={mockData}
+        muutokset={['rockExcavation']}
+      />,
+    );
+    expect(screen.getByText('Louhitaanko työn yhteydessä')).toBeInTheDocument();
+    expect(screen.getByText('Ei')).toBeInTheDocument();
+  });
+
+  test('renders work is about changes correctly', () => {
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, constructionWork: true }}
+        originalData={mockData}
+        muutokset={['constructionWork']}
+      />,
+    );
+    expect(screen.getByText('Uuden rakenteen tai johdon rakentamisesta')).toBeInTheDocument();
+  });
+
+  test('renders removed work is about changes correctly', () => {
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, constructionWork: false }}
+        originalData={{ ...mockData, constructionWork: true }}
+        muutokset={['constructionWork']}
+      />,
+    );
+    expect(screen.getByText(/poistettu/i)).toBeInTheDocument();
+    expect(screen.getByText('Uuden rakenteen tai johdon rakentamisesta')).toBeInTheDocument();
+  });
+});

--- a/src/domain/application/taydennys/components/summary/JohtoselvitysBasicInformationSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/JohtoselvitysBasicInformationSummary.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  FormSummarySection,
+  SectionItemContent,
+  SectionItemContentRemoved,
+  SectionItemTitle,
+  SectionTitle,
+} from '../../../../forms/components/FormSummarySection';
+import { JohtoselvitysData } from '../../../types/application';
+
+type Props = {
+  data: JohtoselvitysData;
+  originalData: JohtoselvitysData;
+  muutokset: string[];
+  children?: React.ReactNode;
+};
+
+export default function BasicInformationSummary({
+  data,
+  originalData,
+  muutokset,
+  children,
+}: Readonly<Props>) {
+  const { t } = useTranslation();
+  const { name, workDescription, rockExcavation, postalAddress } = data;
+
+  const nameChanged = muutokset.includes('name');
+  const postalAddressChanged = muutokset.includes('postalAddress');
+  const workIsAboutChanged: string[] = muutokset.filter((muutos) =>
+    ['constructionWork', 'maintenanceWork', 'emergencyWork', 'propertyConnectivity'].includes(
+      muutos,
+    ),
+  );
+  const workIsAboutRemoved: string[] = workIsAboutChanged.filter(
+    (muutos) => !data[muutos as keyof JohtoselvitysData],
+  );
+  const workIsAboutChangedButNotRemoved = workIsAboutChanged.filter(
+    (muutos) => !workIsAboutRemoved.includes(muutos),
+  );
+  const rockExcavationChanged = muutokset.includes('rockExcavation');
+  const workDescriptionChanged = muutokset.includes('workDescription');
+
+  if (
+    !nameChanged &&
+    !postalAddressChanged &&
+    !workIsAboutChanged.length &&
+    !rockExcavationChanged &&
+    !workDescriptionChanged
+  ) {
+    return null;
+  }
+
+  return (
+    <>
+      <SectionTitle>{t('hankeForm:perustiedotForm:header')}</SectionTitle>
+      <FormSummarySection>
+        {nameChanged && (
+          <>
+            <SectionItemTitle>{t('hakemus:labels:nimi')}</SectionItemTitle>
+            {!name ? (
+              <SectionItemContentRemoved>
+                <p>{originalData.name}</p>
+              </SectionItemContentRemoved>
+            ) : (
+              <SectionItemContent>
+                <p>{name}</p>
+              </SectionItemContent>
+            )}
+          </>
+        )}
+        {postalAddressChanged && (
+          <>
+            <SectionItemTitle>{t('form:labels:addressInformation')}</SectionItemTitle>
+            {!postalAddress?.streetAddress.streetName ? (
+              <SectionItemContentRemoved>
+                <p>{originalData.postalAddress?.streetAddress.streetName}</p>
+              </SectionItemContentRemoved>
+            ) : (
+              <SectionItemContent>
+                <p>{postalAddress?.streetAddress.streetName}</p>
+              </SectionItemContent>
+            )}
+          </>
+        )}
+        {workIsAboutChanged.length > 0 && (
+          <>
+            <SectionItemTitle>{t('hakemus:labels:tyossaKyse')}</SectionItemTitle>
+            <SectionItemContent>
+              {workIsAboutChangedButNotRemoved.length > 0 && (
+                <>
+                  {workIsAboutChangedButNotRemoved.map((changed) => (
+                    <p key={changed}>{t(`hakemus:labels:${changed}`)}</p>
+                  ))}
+                </>
+              )}
+              {workIsAboutRemoved.length > 0 && (
+                <SectionItemContentRemoved>
+                  {workIsAboutRemoved.map((removed) => (
+                    <p key={removed}>{t(`hakemus:labels:${removed}`)}</p>
+                  ))}
+                </SectionItemContentRemoved>
+              )}
+            </SectionItemContent>
+          </>
+        )}
+        {rockExcavationChanged && (
+          <>
+            <SectionItemTitle>
+              <p>{t('hakemus:labels:rockExcavationShort')}</p>
+            </SectionItemTitle>
+            <SectionItemContent>
+              <p>{rockExcavation ? t('common:yes') : t('common:no')}</p>
+            </SectionItemContent>
+          </>
+        )}
+        {workDescriptionChanged && (
+          <>
+            <SectionItemTitle>{t('hakemus:labels:kuvaus')}</SectionItemTitle>
+            {!workDescription ? (
+              <SectionItemContentRemoved>
+                <p style={{ whiteSpace: 'pre-wrap' }}>{originalData.workDescription}</p>
+              </SectionItemContentRemoved>
+            ) : (
+              <SectionItemContent>
+                <p style={{ whiteSpace: 'pre-wrap' }}>{workDescription}</p>
+              </SectionItemContent>
+            )}
+          </>
+        )}
+        {children}
+      </FormSummarySection>
+    </>
+  );
+}

--- a/src/domain/application/taydennys/components/summary/JohtoselvitysContactsSummary.test.tsx
+++ b/src/domain/application/taydennys/components/summary/JohtoselvitysContactsSummary.test.tsx
@@ -1,0 +1,240 @@
+import { cloneDeep } from 'lodash';
+import JohtoselvitysContactsSummary from './JohtoselvitysContactsSummary';
+import { JohtoselvitysData } from '../../../types/application';
+import applications from '../../../../mocks/data/hakemukset-data';
+import { render, screen } from '../../../../../testUtils/render';
+
+const testApplication = cloneDeep(applications[10].applicationData as JohtoselvitysData);
+
+const mockData: JohtoselvitysData = {
+  ...testApplication,
+  propertyDeveloperWithContacts: {
+    customer: {
+      type: 'COMPANY',
+      name: 'Yritys 3 Oy',
+      country: 'FI',
+      email: 'yritys3@test.com',
+      phone: '040123456',
+      registryKey: null,
+      registryKeyHidden: false,
+      ovt: null,
+      invoicingOperator: null,
+      sapCustomerNumber: null,
+    },
+    contacts: [
+      {
+        hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afb1',
+        email: 'tauno@test.com',
+        firstName: 'Tauno',
+        lastName: 'Testinen',
+        orderer: false,
+        phone: '0401234567',
+      },
+    ],
+  },
+  representativeWithContacts: {
+    customer: {
+      type: 'COMPANY',
+      name: 'Yritys 4 Oy',
+      country: 'FI',
+      email: 'yritys4@test.com',
+      phone: '040123456',
+      registryKey: null,
+      registryKeyHidden: false,
+      ovt: null,
+      invoicingOperator: null,
+      sapCustomerNumber: null,
+    },
+    contacts: [
+      {
+        hankekayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afb1',
+        email: 'tauno@test.com',
+        firstName: 'Tauno',
+        lastName: 'Testinen',
+        orderer: false,
+        phone: '0401234567',
+      },
+    ],
+  },
+};
+
+describe('JohtoselvitysContactsSummary', () => {
+  test('renders nothing if no changes are detected', () => {
+    const { container } = render(
+      <JohtoselvitysContactsSummary data={mockData} originalData={mockData} muutokset={[]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders customer with contacts change correctly', () => {
+    render(
+      <JohtoselvitysContactsSummary
+        data={{
+          ...mockData,
+          customerWithContacts: {
+            customer: { ...mockData.customerWithContacts!.customer, phone: '040555123' },
+            contacts: mockData.customerWithContacts!.contacts,
+          },
+        }}
+        originalData={mockData}
+        muutokset={['customerWithContacts']}
+      />,
+    );
+
+    expect(screen.getByText('Työstä vastaava')).toBeInTheDocument();
+    expect(screen.getByText('040555123')).toBeInTheDocument();
+    expect(screen.getByText(mockData.customerWithContacts!.customer.name)).toBeInTheDocument();
+    expect(screen.getByText(mockData.customerWithContacts!.customer.email)).toBeInTheDocument();
+    mockData.customerWithContacts!.contacts.forEach((contact) => {
+      expect(screen.getByText(`${contact.firstName} ${contact.lastName}`)).toBeInTheDocument();
+      expect(screen.getByText(contact.email)).toBeInTheDocument();
+      expect(screen.getByText(contact.phone)).toBeInTheDocument();
+    });
+  });
+
+  test('renders contractor with contacts change correctly', () => {
+    render(
+      <JohtoselvitysContactsSummary
+        data={{
+          ...mockData,
+          contractorWithContacts: {
+            customer: { ...mockData.contractorWithContacts!.customer, name: 'New Contractor' },
+            contacts: mockData.contractorWithContacts!.contacts,
+          },
+        }}
+        originalData={mockData}
+        muutokset={['contractorWithContacts']}
+      />,
+    );
+
+    expect(screen.getByText('Työn suorittaja')).toBeInTheDocument();
+    expect(screen.getByText('New Contractor')).toBeInTheDocument();
+    expect(screen.getByText(mockData.contractorWithContacts!.customer.email)).toBeInTheDocument();
+    expect(screen.getByText(mockData.contractorWithContacts!.customer.phone)).toBeInTheDocument();
+    mockData.contractorWithContacts!.contacts.forEach((contact) => {
+      expect(screen.getByText(`${contact.firstName} ${contact.lastName}`)).toBeInTheDocument();
+      expect(screen.getByText(contact.email)).toBeInTheDocument();
+      expect(screen.getByText(contact.phone)).toBeInTheDocument();
+    });
+  });
+
+  test('renders property developer with contacts change correctly', () => {
+    render(
+      <JohtoselvitysContactsSummary
+        data={{
+          ...mockData,
+          propertyDeveloperWithContacts: {
+            customer: {
+              ...mockData.propertyDeveloperWithContacts!.customer,
+              email: 'developer@test.com',
+            },
+            contacts: mockData.propertyDeveloperWithContacts!.contacts,
+          },
+        }}
+        originalData={mockData}
+        muutokset={['propertyDeveloperWithContacts']}
+      />,
+    );
+
+    expect(screen.getByText('Rakennuttaja')).toBeInTheDocument();
+    expect(screen.getByText('developer@test.com')).toBeInTheDocument();
+    expect(
+      screen.getByText(mockData.propertyDeveloperWithContacts!.customer.name),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(mockData.propertyDeveloperWithContacts!.customer.phone),
+    ).toBeInTheDocument();
+    mockData.propertyDeveloperWithContacts!.contacts.forEach((contact) => {
+      expect(screen.getByText(`${contact.firstName} ${contact.lastName}`)).toBeInTheDocument();
+      expect(screen.getByText(contact.email)).toBeInTheDocument();
+      expect(screen.getByText(contact.phone)).toBeInTheDocument();
+    });
+  });
+
+  test('renders representative with contacts change correctly', () => {
+    render(
+      <JohtoselvitysContactsSummary
+        data={{
+          ...mockData,
+          representativeWithContacts: {
+            customer: {
+              ...mockData.representativeWithContacts!.customer,
+              name: 'New representative',
+            },
+            contacts: mockData.representativeWithContacts!.contacts,
+          },
+        }}
+        originalData={mockData}
+        muutokset={['representativeWithContacts']}
+      />,
+    );
+
+    expect(screen.getByText('Asianhoitaja')).toBeInTheDocument();
+    expect(screen.getByText('New representative')).toBeInTheDocument();
+    expect(
+      screen.getByText(mockData.representativeWithContacts!.customer.email),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(mockData.representativeWithContacts!.customer.phone),
+    ).toBeInTheDocument();
+    mockData.representativeWithContacts!.contacts.forEach((contact) => {
+      expect(screen.getByText(`${contact.firstName} ${contact.lastName}`)).toBeInTheDocument();
+      expect(screen.getByText(contact.email)).toBeInTheDocument();
+      expect(screen.getByText(contact.phone)).toBeInTheDocument();
+    });
+  });
+
+  test('renders removed property developer with contacts correctly', () => {
+    render(
+      <JohtoselvitysContactsSummary
+        data={{ ...mockData, propertyDeveloperWithContacts: null }}
+        originalData={mockData}
+        muutokset={['propertyDeveloperWithContacts']}
+      />,
+    );
+
+    expect(screen.getByText('Rakennuttaja')).toBeInTheDocument();
+    expect(screen.getByText(/poistettu/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(mockData.propertyDeveloperWithContacts!.customer.name),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(mockData.propertyDeveloperWithContacts!.customer.email),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(mockData.propertyDeveloperWithContacts!.customer.phone),
+    ).toBeInTheDocument();
+    mockData.propertyDeveloperWithContacts!.contacts.forEach((contact) => {
+      expect(screen.getByText(`${contact.firstName} ${contact.lastName}`)).toBeInTheDocument();
+      expect(screen.getByText(contact.email)).toBeInTheDocument();
+      expect(screen.getByText(contact.phone)).toBeInTheDocument();
+    });
+  });
+
+  test('renders removed representative with contacts correctly', () => {
+    render(
+      <JohtoselvitysContactsSummary
+        data={{ ...mockData, representativeWithContacts: null }}
+        originalData={mockData}
+        muutokset={['representativeWithContacts']}
+      />,
+    );
+
+    expect(screen.getByText('Asianhoitaja')).toBeInTheDocument();
+    expect(screen.getByText(/poistettu/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(mockData.representativeWithContacts!.customer.name),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(mockData.representativeWithContacts!.customer.email),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(mockData.representativeWithContacts!.customer.phone),
+    ).toBeInTheDocument();
+    mockData.representativeWithContacts!.contacts.forEach((contact) => {
+      expect(screen.getByText(`${contact.firstName} ${contact.lastName}`)).toBeInTheDocument();
+      expect(screen.getByText(contact.email)).toBeInTheDocument();
+      expect(screen.getByText(contact.phone)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/domain/application/taydennys/components/summary/JohtoselvitysContactsSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/JohtoselvitysContactsSummary.tsx
@@ -1,0 +1,81 @@
+import { useTranslation } from 'react-i18next';
+import { JohtoselvitysData } from '../../../types/application';
+import {
+  FormSummarySection,
+  SectionItemContentRemoved,
+  SectionTitle,
+} from '../../../../forms/components/FormSummarySection';
+import ContactsSummary from '../../../components/summary/ContactsSummary';
+
+type Props = {
+  data: JohtoselvitysData;
+  originalData: JohtoselvitysData;
+  muutokset: string[];
+};
+
+export default function JohtoselvitysContactsSummary({
+  data,
+  originalData,
+  muutokset,
+}: Readonly<Props>) {
+  const { t } = useTranslation();
+  const {
+    customerWithContacts,
+    contractorWithContacts,
+    propertyDeveloperWithContacts,
+    representativeWithContacts,
+  } = data;
+  const customerWithContactsChanged = muutokset.includes('customerWithContacts');
+  const contractorWithContactsChanged = muutokset.includes('contractorWithContacts');
+  const propertyDeveloperWithContactsChanged = muutokset.includes('propertyDeveloperWithContacts');
+  const representativeWithContactsChanged = muutokset.includes('representativeWithContacts');
+
+  if (
+    !customerWithContactsChanged &&
+    !contractorWithContactsChanged &&
+    !propertyDeveloperWithContactsChanged &&
+    !representativeWithContactsChanged
+  ) {
+    return null;
+  }
+
+  return (
+    <>
+      <SectionTitle>{t('form:yhteystiedot:header')}</SectionTitle>
+      <FormSummarySection>
+        {customerWithContactsChanged && (
+          <ContactsSummary
+            customerWithContacts={customerWithContacts}
+            title={t('form:yhteystiedot:titles:customerWithContacts')}
+          />
+        )}
+        {contractorWithContactsChanged && (
+          <ContactsSummary
+            customerWithContacts={contractorWithContacts}
+            title={t('form:yhteystiedot:titles:contractorWithContacts')}
+          />
+        )}
+        {propertyDeveloperWithContactsChanged && (
+          <ContactsSummary
+            customerWithContacts={
+              propertyDeveloperWithContacts ?? originalData.propertyDeveloperWithContacts
+            }
+            title={t('form:yhteystiedot:titles:rakennuttajat')}
+            ContentContainer={
+              !propertyDeveloperWithContacts ? SectionItemContentRemoved : undefined
+            }
+          />
+        )}
+        {representativeWithContactsChanged && (
+          <ContactsSummary
+            customerWithContacts={
+              representativeWithContacts ?? originalData.representativeWithContacts
+            }
+            title={t('form:yhteystiedot:titles:representativeWithContacts')}
+            ContentContainer={!representativeWithContacts ? SectionItemContentRemoved : undefined}
+          />
+        )}
+      </FormSummarySection>
+    </>
+  );
+}

--- a/src/domain/application/taydennys/types.ts
+++ b/src/domain/application/taydennys/types.ts
@@ -31,4 +31,5 @@ export type Taydennyspyynto = {
 export type Taydennys<T> = {
   id: string;
   applicationData: T;
+  muutokset: string[];
 };

--- a/src/domain/forms/components/FormSummarySection.tsx
+++ b/src/domain/forms/components/FormSummarySection.tsx
@@ -1,8 +1,9 @@
-import { Box } from '@chakra-ui/react';
+import { Box, BoxProps } from '@chakra-ui/react';
 import clsx from 'clsx';
 import React from 'react';
 import Text from '../../../common/components/text/Text';
 import styles from './FormSummarySection.module.scss';
+import { useTranslation } from 'react-i18next';
 
 const SectionTitle: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
@@ -24,8 +25,38 @@ const SectionItemTitle: React.FC<{ children: React.ReactNode }> = ({ children })
   );
 };
 
-const SectionItemContent: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
-  return <Box color="var(--color-black-70)">{children}</Box>;
+interface SectionItemContentProps extends BoxProps {
+  children?: React.ReactNode;
+}
+const SectionItemContent: React.FC<Readonly<SectionItemContentProps>> = ({
+  children,
+  ...chakraProps
+}) => {
+  return (
+    <Box color="var(--color-black-70)" {...chakraProps}>
+      {children}
+    </Box>
+  );
+};
+
+const SectionItemContentRemoved: React.FC<Readonly<SectionItemContentProps>> = ({
+  children,
+  ...chakraProps
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <SectionItemContent
+      border="1px solid var(--color-error)"
+      padding="var(--spacing-2-xs)"
+      {...chakraProps}
+    >
+      <Box as="p" color="var(--color-error)" marginBottom="var(--spacing-s)">
+        {t('common:removed')}:
+      </Box>
+      {children}
+    </SectionItemContent>
+  );
 };
 
 const FormSummarySection: React.FC<{
@@ -40,4 +71,10 @@ const FormSummarySection: React.FC<{
   );
 };
 
-export { FormSummarySection, SectionTitle, SectionItemTitle, SectionItemContent };
+export {
+  FormSummarySection,
+  SectionTitle,
+  SectionItemTitle,
+  SectionItemContent,
+  SectionItemContentRemoved,
+};

--- a/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennys.test.tsx
+++ b/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennys.test.tsx
@@ -22,6 +22,7 @@ function setup(
     taydennys = {
       id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
       applicationData: application.applicationData,
+      muutokset: [],
     },
     hankeData = hankkeet[1] as HankeData,
     responseStatus = 200,

--- a/src/domain/johtoselvitysTaydennys/ReviewAndSend.tsx
+++ b/src/domain/johtoselvitysTaydennys/ReviewAndSend.tsx
@@ -6,27 +6,49 @@ import AreaSummary from '../johtoselvitys/components/AreaSummary';
 import ContactsSummary from '../application/components/summary/ContactsSummary';
 import { Application, JohtoselvitysData } from '../application/types/application';
 import { Box } from '@chakra-ui/react';
+import { Taydennys } from '../application/taydennys/types';
+import TaydennysBasicInformationSummary from '../application/taydennys/components/summary/JohtoselvitysBasicInformationSummary';
+import TaydennysAreaSummary from '../application/taydennys/components/summary/JohtoselvitysAreaSummary';
+import TaydennysContactsSummary from '../application/taydennys/components/summary/JohtoselvitysContactsSummary';
 
 type Props = {
+  taydennys: Taydennys<JohtoselvitysData>;
+  muutokset: string[];
   originalApplication: Application<JohtoselvitysData>;
 };
 
-export default function ReviewAndSend({ originalApplication }: Readonly<Props>) {
+export default function ReviewAndSend({
+  taydennys,
+  muutokset,
+  originalApplication,
+}: Readonly<Props>) {
   const { t } = useTranslation();
-  const {
-    applicationData: {
-      customerWithContacts,
-      contractorWithContacts,
-      propertyDeveloperWithContacts,
-      representativeWithContacts,
-    },
-  } = originalApplication;
 
   return (
     <Tabs>
       <TabList>
+        <Tab>{t('taydennys:labels:taydennykset')}</Tab>
         <Tab>{t('taydennys:labels:originalInformation')}</Tab>
       </TabList>
+      <TabPanel>
+        <Box mt="var(--spacing-s)">
+          <TaydennysBasicInformationSummary
+            data={taydennys.applicationData}
+            originalData={originalApplication.applicationData}
+            muutokset={muutokset}
+          />
+          <TaydennysAreaSummary
+            data={taydennys.applicationData}
+            originalData={originalApplication.applicationData}
+            muutokset={muutokset}
+          />
+          <TaydennysContactsSummary
+            data={taydennys.applicationData}
+            originalData={originalApplication.applicationData}
+            muutokset={muutokset}
+          />
+        </Box>
+      </TabPanel>
       <TabPanel>
         <Box mt="var(--spacing-s)">
           <SectionTitle>{t('hankeForm:perustiedotForm:header')}</SectionTitle>
@@ -38,19 +60,21 @@ export default function ReviewAndSend({ originalApplication }: Readonly<Props>) 
           <SectionTitle>{t('form:yhteystiedot:header')}</SectionTitle>
           <FormSummarySection>
             <ContactsSummary
-              customerWithContacts={customerWithContacts}
+              customerWithContacts={originalApplication.applicationData.customerWithContacts}
               title={t('form:yhteystiedot:titles:customerWithContacts')}
             />
             <ContactsSummary
-              customerWithContacts={contractorWithContacts}
+              customerWithContacts={originalApplication.applicationData.contractorWithContacts}
               title={t('form:yhteystiedot:titles:contractorWithContacts')}
             />
             <ContactsSummary
-              customerWithContacts={propertyDeveloperWithContacts}
+              customerWithContacts={
+                originalApplication.applicationData.propertyDeveloperWithContacts
+              }
               title={t('form:yhteystiedot:titles:rakennuttajat')}
             />
             <ContactsSummary
-              customerWithContacts={representativeWithContacts}
+              customerWithContacts={originalApplication.applicationData.representativeWithContacts}
               title={t('form:yhteystiedot:titles:representativeWithContacts')}
             />
           </FormSummarySection>

--- a/src/domain/johtoselvitysTaydennys/types.ts
+++ b/src/domain/johtoselvitysTaydennys/types.ts
@@ -3,6 +3,7 @@ import { JohtoselvitysFormData } from '../johtoselvitys/types';
 export interface JohtoselvitysTaydennysFormValues {
   id: string;
   applicationData: JohtoselvitysFormData;
+  muutokset: string[];
   geometriesChanged?: boolean; // virtualField
   selfIntersectingPolygon?: boolean; // virtualField
 }

--- a/src/domain/johtoselvitysTaydennys/validationSchema.ts
+++ b/src/domain/johtoselvitysTaydennys/validationSchema.ts
@@ -5,6 +5,7 @@ import { JohtoselvitysTaydennysFormValues } from './types';
 export const validationSchema: yup.ObjectSchema<JohtoselvitysTaydennysFormValues> = yup.object({
   id: yup.string().defined(),
   applicationData: johtoselvitysApplicationDataSchema,
+  muutokset: yup.array(yup.string().defined()).defined(),
   selfIntersectingPolygon: yup.boolean().isFalse(),
   geometriesChanged: yup.boolean(),
 });

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -150,6 +150,7 @@ export async function createTaydennys(id: number) {
   const taydennys: Taydennys<JohtoselvitysData | KaivuilmoitusData> = {
     id: faker.string.uuid(),
     applicationData: cloneDeep(hakemus.applicationData),
+    muutokset: [],
   };
   hakemus.taydennys = taydennys;
   return taydennys;

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -16,6 +16,7 @@
     "increment": "Lisää",
     "yes": "Kyllä",
     "no": "Ei",
+    "removed": "Poistettu",
     "confirmationDialog": {
       "interruptDialog": {
         "titleText": "Olet poistumassa lomakkeelta",
@@ -1274,7 +1275,8 @@
   },
   "taydennys": {
     "labels": {
-      "originalInformation": "Alkuperäiset"
+      "originalInformation": "Alkuperäiset",
+      "taydennykset": "Täydennykset"
     },
     "buttons": {
       "createTaydennys": "Täydennä",


### PR DESCRIPTION
# Description

Show fields that have changes in summary page. There are tabs for changed fields and original data.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2760

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check that when making changes in johtoselvitys täydennys form, they are shown in summary page in "Täydennys" tab.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
