### PR TITLE
HAI-2762 Add send button to johtoselvitys täydennys form

### DIFF
--- a/src/common/components/HDSConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/common/components/HDSConfirmationDialog/ConfirmationDialog.tsx
@@ -11,7 +11,7 @@ type Props = {
   isOpen: boolean;
   close?: () => void;
   mainAction: () => void;
-  mainBtnLabel: string;
+  mainBtnLabel?: string;
   mainBtnIcon?: React.ReactElement;
   variant: DialogVariant;
   errorMsg?: string;
@@ -51,7 +51,7 @@ const ConfirmationDialog: React.FC<React.PropsWithChildren<Props>> = ({
       iconLeft={mainBtnIcon}
       isLoading={isLoading}
     >
-      {mainBtnLabel}
+      {mainBtnLabel ?? t('common:confirmationDialog:confirmButton')}
     </Button>
   );
 

--- a/src/domain/application/taydennys/hooks/useSendTaydennys.ts
+++ b/src/domain/application/taydennys/hooks/useSendTaydennys.ts
@@ -1,0 +1,23 @@
+import { useQueryClient } from 'react-query';
+import { JohtoselvitysData, KaivuilmoitusData } from '../../types/application';
+import useTaydennysSendNotification from './useTaydennysSendNotification';
+import useDebouncedMutation from '../../../../common/hooks/useDebouncedMutation';
+import { sendTaydennys } from '../taydennysApi';
+
+export default function useSendTaydennys() {
+  const queryClient = useQueryClient();
+  const { showSendSuccess, showSendError } = useTaydennysSendNotification();
+
+  return useDebouncedMutation(
+    (id: string) => sendTaydennys<JohtoselvitysData | KaivuilmoitusData>(id),
+    {
+      onError() {
+        showSendError();
+      },
+      async onSuccess(data) {
+        showSendSuccess();
+        await queryClient.invalidateQueries(['application', data.id], { refetchInactive: true });
+      },
+    },
+  );
+}

--- a/src/domain/application/taydennys/hooks/useTaydennysSendNotification.tsx
+++ b/src/domain/application/taydennys/hooks/useTaydennysSendNotification.tsx
@@ -1,0 +1,47 @@
+import { Trans, useTranslation } from 'react-i18next';
+import { Link } from 'hds-react';
+import { useGlobalNotification } from '../../../../common/components/globalNotification/GlobalNotificationContext';
+
+/**
+ * Returns functions for showing success and error notifications for sending taydennys
+ */
+export default function useTaydennysSendNotification() {
+  const { t } = useTranslation();
+  const { setNotification } = useGlobalNotification();
+
+  function showSendSuccess() {
+    setNotification(true, {
+      position: 'top-right',
+      dismissible: true,
+      autoClose: true,
+      autoCloseDuration: 8000,
+      label: t('taydennys:notifications:sendSuccessLabel'),
+      message: t('taydennys:notifications:sendSuccessText'),
+      type: 'success',
+      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+    });
+  }
+
+  function showSendError() {
+    const sendErrorMessage = (
+      <Trans i18nKey="taydennys:notifications:sendErrorText">
+        <p>
+          Lähettämisessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman
+          tekniseen tukeen sähköpostiosoitteessa
+          <Link href="mailto:haitatontuki@hel.fi">haitatontuki@hel.fi</Link>.
+        </p>
+      </Trans>
+    );
+
+    setNotification(true, {
+      position: 'top-right',
+      dismissible: true,
+      label: t('taydennys:notifications:sendErrorLabel'),
+      message: sendErrorMessage,
+      type: 'error',
+      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+    });
+  }
+
+  return { showSendSuccess, showSendError };
+}

--- a/src/domain/application/taydennys/taydennysApi.ts
+++ b/src/domain/application/taydennys/taydennysApi.ts
@@ -1,4 +1,5 @@
 import api from '../../api/api';
+import { Application } from '../types/application';
 import { Taydennys } from './types';
 
 /**
@@ -22,5 +23,14 @@ export async function updateTaydennys<ApplicationData, UpdateData>({
   data: UpdateData;
 }) {
   const response = await api.put<Taydennys<ApplicationData>>(`/taydennykset/${id}`, data);
+  return response.data;
+}
+
+/**
+ * Send taydennys to Allu
+ * @param id taydennys id
+ */
+export async function sendTaydennys<ApplicationData>(id: string) {
+  const response = await api.post<Application<ApplicationData>>(`/taydennykset/${id}/laheta`);
   return response.data;
 }

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -22,7 +22,7 @@ export async function read(id: number) {
 }
 
 async function readTaydennys(id: string) {
-  return hakemukset.find((hakemus) => hakemus.taydennys?.id === id)?.taydennys;
+  return hakemukset.find((hakemus) => hakemus.taydennys?.id === id);
 }
 
 export async function readAll() {
@@ -160,10 +160,24 @@ export async function updateTaydennys(
   id: string,
   updates: JohtoselvitysUpdateData | KaivuilmoitusUpdateData,
 ) {
-  const taydennys = await readTaydennys(id);
+  const hakemus = await readTaydennys(id);
+  const taydennys = hakemus?.taydennys;
   if (!taydennys) {
     throw new ApiError(`No application with id ${id}`, 404);
   }
   taydennys.applicationData = Object.assign(taydennys.applicationData, updates);
   return taydennys;
+}
+
+export async function sendTaydennys(id: string) {
+  const hakemus = await readTaydennys(id);
+  if (!hakemus) {
+    throw new ApiError(`No application with id ${id}`, 404);
+  }
+  const updatedHakemus = cloneDeep(hakemus);
+  updatedHakemus.alluStatus = 'INFORMATION_RECEIVED';
+  updatedHakemus.applicationData = hakemus.taydennys!.applicationData;
+  updatedHakemus.taydennys = null;
+  updatedHakemus.taydennyspyynto = null;
+  return updatedHakemus;
 }

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -374,4 +374,10 @@ export const handlers = [
       }
     },
   ),
+
+  http.post(`${apiUrl}/taydennykset/:id/laheta`, async ({ params }) => {
+    const { id } = params;
+    const hakemus = await hakemuksetDB.sendTaydennys(id as string);
+    return HttpResponse.json(hakemus);
+  }),
 ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1281,7 +1281,18 @@
     },
     "buttons": {
       "createTaydennys": "Täydennä",
-      "editTaydennys": "Muokkaa hakemusta (täydennys)"
+      "editTaydennys": "Muokkaa hakemusta (täydennys)",
+      "sendTaydennys": "Lähetä täydennys"
+    },
+    "notifications": {
+      "sendSuccessLabel": "Täydennys lähetetty",
+      "sendSuccessText": "Täydennys on lähetetty käsiteltäväksi.",
+      "sendErrorLabel": "Täydennyksen lähettäminen epäonnistui",
+      "sendErrorText": "$t(hakemus:notifications:reportCompletionDateErrorText)"
+    },
+    "sendDialog": {
+      "title": "Lähetä täydennetty hakemus käsittelyyn",
+      "description": "Lähettämällä tiedot käsittelyssä oleva hakemuksesi päivitetään täydennetyillä tiedoilla."
     }
   },
   "hankeSidebar": {


### PR DESCRIPTION
# Description

Täydennys can be sent to Allu if it has changes and it is valid. There is a confirmation dialog before sending.

### Jira Issue:

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Make a täydennys to johtoselvitys and make some changes to some fields
2. Check that täydennys can be sent to Allu from summary page

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
