### PR TITLE
HAI-2763 Add send täydennys button to application page

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -88,8 +88,9 @@ import useFilterHankeAlueetByApplicationDates from '../hooks/useFilterHankeAluee
 import ApplicationSendDialog from '../components/ApplicationSendDialog';
 import TaydennyspyyntoNotification from '../taydennys/TaydennyspyyntoNotification';
 import { useQueryClient } from 'react-query';
-import { useFeatureFlags } from '../../../common/components/featureFlags/FeatureFlagsContext';
 import AreaInformation from '../components/summary/AreaInformation';
+import useIsInformationRequestFeatureEnabled from '../taydennys/hooks/useIsInformationRequestFeatureEnabled';
+import useSendTaydennys from './hooks/useSendTaydennys';
 
 function SidebarTyoalueet({
   tyoalueet,
@@ -383,7 +384,6 @@ function ApplicationView({
   creatingTaydennys,
 }: Readonly<Props>) {
   const { t } = useTranslation();
-  const features = useFeatureFlags();
   const queryClient = useQueryClient();
   const [isSendButtonDisabled, setIsSendButtonDisabled] = useState(false);
   const [showSendDialog, setShowSendDialog] = useState(false);
@@ -458,9 +458,9 @@ function ApplicationView({
     applicationEndDate: endTime,
   });
 
-  // TODO: at the moment information request (täydennyspyyntö) feature can be enabled for CABLE_REPORT applications only
-  const informationRequestFeatureEnabled =
-    applicationType === 'CABLE_REPORT' && features.informationRequest;
+  const informationRequestFeatureEnabled = useIsInformationRequestFeatureEnabled(applicationType);
+
+  const { sendTaydennysButton, sendTaydennysDialog } = useSendTaydennys(application);
 
   async function onSendApplication(pdr: PaperDecisionReceiver | undefined | null) {
     applicationSendMutation.mutate({
@@ -655,6 +655,9 @@ function ApplicationView({
               </Button>
             </CheckRightsByHanke>
           )}
+          <CheckRightsByHanke requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>
+            {sendTaydennysButton}
+          </CheckRightsByHanke>
         </InformationViewHeaderButtons>
       </InformationViewHeader>
 
@@ -916,6 +919,7 @@ function ApplicationView({
         onClose={closeSendDialog}
         onSend={onSendApplication}
       />
+      {sendTaydennysDialog}
     </InformationViewContainer>
   );
 }

--- a/src/domain/application/applicationView/hooks/useSendTaydennys.tsx
+++ b/src/domain/application/applicationView/hooks/useSendTaydennys.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { Button, IconEnvelope, IconQuestionCircle } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { AlluStatus, Application } from '../../types/application';
+import { validationSchema as johtoselvitysValidationSchema } from '../../../johtoselvitysTaydennys/validationSchema';
+import ConfirmationDialog from '../../../../common/components/HDSConfirmationDialog/ConfirmationDialog';
+import useIsInformationRequestFeatureEnabled from '../../taydennys/hooks/useIsInformationRequestFeatureEnabled';
+import useSendTaydennysMutation from '../../taydennys/hooks/useSendTaydennys';
+
+const validationSchemas = {
+  CABLE_REPORT: johtoselvitysValidationSchema,
+  EXCAVATION_NOTIFICATION: null,
+};
+
+export default function useSendTaydennys(application: Application) {
+  const { t } = useTranslation();
+  const informationRequestFeatureEnabled = useIsInformationRequestFeatureEnabled(
+    application.applicationType,
+  );
+  const taydennysValidationSchema = validationSchemas[application.applicationType];
+  const isTaydennysValid = taydennysValidationSchema?.isValidSync(application.taydennys);
+  const showSendTaydennysButton =
+    informationRequestFeatureEnabled &&
+    application.alluStatus === AlluStatus.WAITING_INFORMATION &&
+    isTaydennysValid &&
+    application.taydennys &&
+    application.taydennys.muutokset.length > 0;
+  const [showSendTaydennysDialog, setShowSendTaydennysDialog] = useState(false);
+  const sendTaydennysMutation = useSendTaydennysMutation();
+
+  function openSendTaydennysDialog() {
+    setShowSendTaydennysDialog(true);
+  }
+
+  function closeSendTaydennysDialog() {
+    setShowSendTaydennysDialog(false);
+  }
+
+  function sendTaydennysHakemus() {
+    if (application.taydennys?.id) {
+      sendTaydennysMutation.mutate(application.taydennys.id);
+      closeSendTaydennysDialog();
+    }
+  }
+
+  const sendTaydennysButton = showSendTaydennysButton ? (
+    <Button
+      theme="coat"
+      iconLeft={<IconEnvelope />}
+      onClick={openSendTaydennysDialog}
+      loadingText={t('common:buttons:sendingText')}
+      isLoading={sendTaydennysMutation.isLoading}
+    >
+      {t('taydennys:buttons:sendTaydennys')}
+    </Button>
+  ) : null;
+
+  const sendTaydennysDialog = (
+    <ConfirmationDialog
+      title={t('taydennys:sendDialog:title')}
+      description={t('taydennys:sendDialog:description')}
+      showCloseButton
+      isOpen={showSendTaydennysDialog}
+      close={closeSendTaydennysDialog}
+      mainAction={sendTaydennysHakemus}
+      variant="primary"
+      headerIcon={<IconQuestionCircle />}
+    />
+  );
+
+  return { sendTaydennysButton, sendTaydennysDialog };
+}

--- a/src/domain/application/taydennys/hooks/useIsInformationRequestFeatureEnabled.ts
+++ b/src/domain/application/taydennys/hooks/useIsInformationRequestFeatureEnabled.ts
@@ -1,0 +1,8 @@
+import { useFeatureFlags } from '../../../../common/components/featureFlags/FeatureFlagsContext';
+import { ApplicationType } from '../../types/application';
+
+export default function useIsInformationRequestFeatureEnabled(applicationType: ApplicationType) {
+  const features = useFeatureFlags();
+  // TODO: at the moment information request (täydennyspyyntö) feature can be enabled for CABLE_REPORT applications only
+  return applicationType === 'CABLE_REPORT' && features.informationRequest;
+}

--- a/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennysContainer.tsx
+++ b/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennysContainer.tsx
@@ -52,7 +52,7 @@ export default function JohtoselvitysTaydennysContainer({
   const navigateToApplicationView = useNavigateToApplicationView();
   const { taydennysUpdateMutation, showSaveNotification, setShowSaveNotification } =
     useUpdateTaydennys<JohtoselvitysData, JohtoselvitysUpdateData>();
-  const taydennysSendMutation = useSendTaydennys();
+  const sendTaydennysMutation = useSendTaydennys();
   const [showSendDialog, setShowSendDialog] = useState(false);
 
   const formContext = useForm<JohtoselvitysTaydennysFormValues>({
@@ -199,7 +199,7 @@ export default function JohtoselvitysTaydennysContainer({
   }
 
   function sendTaydennys() {
-    taydennysSendMutation.mutate(taydennys.id, {
+    sendTaydennysMutation.mutate(taydennys.id, {
       onSuccess(data) {
         navigateToApplicationView(data.id?.toString());
       },
@@ -264,7 +264,7 @@ export default function JohtoselvitysTaydennysContainer({
                   type="submit"
                   iconLeft={<IconEnvelope aria-hidden="true" />}
                   loadingText={t('common:buttons:sendingText')}
-                  isLoading={taydennysSendMutation.isLoading}
+                  isLoading={sendTaydennysMutation.isLoading}
                 >
                   {t('taydennys:buttons:sendTaydennys')}
                 </Button>


### PR DESCRIPTION
# Description

Send täydennys button is visible if täydennys data is valid, user has EDIT_APPLICATIONS permission, hakemus Allu status is WAITING_INFORMATION and täydennys has changes.

### Jira Issue:

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Have a johtoselvitys täydennys with some changes and try to send it in application page.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
