### PR TITLE
HAI-499 Show tabs for täydennykset and original information in application page side bar

### DIFF
--- a/src/domain/application/applicationView/Sidebar.test.tsx
+++ b/src/domain/application/applicationView/Sidebar.test.tsx
@@ -1,0 +1,66 @@
+import { cloneDeep } from 'lodash';
+import { render, screen } from '../../../testUtils/render';
+import hankkeet from '../../mocks/data/hankkeet-data';
+import hakemukset from '../../mocks/data/hakemukset-data';
+import { Application, JohtoselvitysData } from '../types/application';
+import { Sidebar } from './Sidebar';
+import { HankeData } from '../../types/hanke';
+
+describe('Sidebar', () => {
+  describe('Taydennys', () => {
+    test('Should show correct taydennys content', async () => {
+      const hanke = cloneDeep(hankkeet[1]) as HankeData;
+      const application = cloneDeep(hakemukset[10]) as Application<JohtoselvitysData>;
+      application.taydennys = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+        applicationData: {
+          ...application.applicationData,
+          areas: [
+            ...application.applicationData.areas,
+            {
+              name: '',
+              geometry: {
+                type: 'Polygon',
+                crs: {
+                  type: 'name',
+                  properties: {
+                    name: 'urn:ogc:def:crs:EPSG::3879',
+                  },
+                },
+                coordinates: [
+                  [
+                    [25498581.440262634, 6679345.526261961],
+                    [25498582.233686976, 6679350.99321805],
+                    [25498576.766730886, 6679351.786642391],
+                    [25498575.973306544, 6679346.319686302],
+                    [25498581.440262634, 6679345.526261961],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+        muutokset: ['areas[1]'],
+      };
+      const { user } = render(<Sidebar hanke={hanke} application={application} />);
+
+      expect(screen.getByText('Täydennykset')).toBeInTheDocument();
+      expect(screen.getByText('Työalue 1 (234 m²)')).toBeInTheDocument();
+      expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
+
+      await user.click(screen.getByText('Alkuperäiset'));
+
+      expect(screen.getByText('Työalue (234 m²)')).toBeInTheDocument();
+      expect(screen.queryByText('Työalue 2 (30 m²)')).not.toBeInTheDocument();
+    });
+
+    test('If there is no taydennys, should not show taydennys tabs', async () => {
+      const hanke = cloneDeep(hankkeet[1]) as HankeData;
+      const application = cloneDeep(hakemukset[10]) as Application<JohtoselvitysData>;
+      render(<Sidebar hanke={hanke} application={application} />);
+
+      expect(screen.queryByText('Täydennykset')).not.toBeInTheDocument();
+      expect(screen.queryByText('Alkuperäiset')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/domain/application/applicationView/Sidebar.tsx
+++ b/src/domain/application/applicationView/Sidebar.tsx
@@ -1,0 +1,168 @@
+import { useTranslation } from 'react-i18next';
+import { Box } from '@chakra-ui/layout';
+import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
+import { Application, ApplicationArea, KaivuilmoitusAlue } from '../types/application';
+import { getAreaDefaultName } from '../utils';
+import { getAreaGeometry } from '../../johtoselvitys/utils';
+import Text from '../../../common/components/text/Text';
+import { formatSurfaceArea } from '../../map/utils';
+import ApplicationDates from '../components/ApplicationDates';
+import OwnHankeMapHeader from '../../map/components/OwnHankeMap/OwnHankeMapHeader';
+import OwnHankeMap from '../../map/components/OwnHankeMap/OwnHankeMap';
+import useFilterHankeAlueetByApplicationDates from '../hooks/useFilterHankeAlueetByApplicationDates';
+import { HankeData } from '../../types/hanke';
+import CustomAccordion from '../../../common/components/customAccordion/CustomAccordion';
+
+type SidebarTyoalueetProps = {
+  tyoalueet: ApplicationArea[];
+  startTime: Date | null;
+  endTime: Date | null;
+};
+
+function SidebarTyoalueet({ tyoalueet, startTime, endTime }: Readonly<SidebarTyoalueetProps>) {
+  const { t } = useTranslation();
+
+  return tyoalueet.map((tyoalue, index) => {
+    const areaName = getAreaDefaultName(t, index, tyoalueet.length);
+    const geometry = getAreaGeometry(tyoalue);
+    return (
+      <Box
+        key={areaName}
+        padding="var(--spacing-s)"
+        paddingRight="var(--spacing-m)"
+        _notLast={{ borderBottom: '1px solid var(--color-black-30)' }}
+      >
+        <Text tag="p" styleAs="body-m" weight="bold" spacingBottom="2-xs">
+          {areaName} ({formatSurfaceArea(geometry)})
+        </Text>
+        <ApplicationDates startTime={startTime} endTime={endTime} />
+      </Box>
+    );
+  });
+}
+
+type SidebarProps = {
+  hanke: HankeData;
+  application: Application;
+};
+
+export function Sidebar({ hanke, application }: Readonly<SidebarProps>) {
+  const { t } = useTranslation();
+  const { applicationType, applicationData, taydennys } = application;
+  const tyoalueet =
+    applicationType === 'CABLE_REPORT'
+      ? (applicationData.areas as ApplicationArea[])
+      : (applicationData.areas as KaivuilmoitusAlue[]).flatMap((area) => area.tyoalueet);
+  const taydennysTyoalueet =
+    applicationType === 'CABLE_REPORT'
+      ? (application.taydennys?.applicationData.areas as ApplicationArea[] | undefined)
+      : (application.taydennys?.applicationData.areas as KaivuilmoitusAlue[] | undefined)?.flatMap(
+          (area) => area.tyoalueet,
+        );
+  const kaivuilmoitusAlueet =
+    applicationType === 'EXCAVATION_NOTIFICATION'
+      ? (applicationData.areas as KaivuilmoitusAlue[])
+      : null;
+
+  const filterHankeAlueet = useFilterHankeAlueetByApplicationDates({
+    applicationStartDate: applicationData.startTime,
+    applicationEndDate: applicationData.endTime,
+  });
+
+  const filterHankeAlueetForTaydennys = useFilterHankeAlueetByApplicationDates({
+    applicationStartDate: taydennys?.applicationData.startTime ?? null,
+    applicationEndDate: taydennys?.applicationData.endTime ?? null,
+  });
+
+  function getHankeWithAlueetFilteredByDates(hankeData: HankeData): HankeData {
+    return {
+      ...hankeData,
+      alueet: filterHankeAlueet(hankeData.alueet),
+    };
+  }
+
+  function getHankeWithAlueetFilteredByDatesForTaydennys(hankeData: HankeData): HankeData {
+    return {
+      ...hankeData,
+      alueet: filterHankeAlueetForTaydennys(hankeData.alueet),
+    };
+  }
+
+  const hakemusContent = (
+    <>
+      <Box mb="var(--spacing-s)">
+        <OwnHankeMapHeader hankeTunnus={hanke.hankeTunnus} showLink={false} />
+        <OwnHankeMap hanke={getHankeWithAlueetFilteredByDates(hanke)} tyoalueet={tyoalueet} />
+      </Box>
+      {applicationType === 'CABLE_REPORT' && (
+        <SidebarTyoalueet
+          tyoalueet={tyoalueet}
+          startTime={applicationData.startTime}
+          endTime={applicationData.endTime}
+        />
+      )}
+      {applicationType === 'EXCAVATION_NOTIFICATION' &&
+        kaivuilmoitusAlueet?.map((kaivuilmoitusAlue) => {
+          const hankeAlue = hanke.alueet.find((alue) => alue.id === kaivuilmoitusAlue.hankealueId);
+          return (
+            <CustomAccordion
+              key={kaivuilmoitusAlue.hankealueId}
+              accordionBorderBottom
+              headingSize="s"
+              heading={kaivuilmoitusAlue.name}
+              subHeading={
+                <Box marginTop="var(--spacing-2-xs)">
+                  <ApplicationDates
+                    startTime={hankeAlue?.haittaAlkuPvm ?? null}
+                    endTime={hankeAlue?.haittaLoppuPvm ?? null}
+                  />
+                </Box>
+              }
+            >
+              <Box marginLeft="var(--spacing-s)">
+                <SidebarTyoalueet
+                  tyoalueet={kaivuilmoitusAlue.tyoalueet}
+                  startTime={applicationData.startTime}
+                  endTime={applicationData.endTime}
+                />
+              </Box>
+            </CustomAccordion>
+          );
+        })}
+    </>
+  );
+
+  if (taydennys) {
+    return (
+      <Tabs>
+        <TabList>
+          <Tab>{t('taydennys:labels:taydennykset')}</Tab>
+          <Tab>{t('taydennys:labels:originalInformation')}</Tab>
+        </TabList>
+        <TabPanel>
+          <Box mt="var(--spacing-s)">
+            <Box mb="var(--spacing-s)">
+              <OwnHankeMapHeader hankeTunnus={hanke.hankeTunnus} showLink={false} />
+              <OwnHankeMap
+                hanke={getHankeWithAlueetFilteredByDatesForTaydennys(hanke)}
+                tyoalueet={taydennysTyoalueet}
+              />
+            </Box>
+            {applicationType === 'CABLE_REPORT' && (
+              <SidebarTyoalueet
+                tyoalueet={taydennysTyoalueet ?? []}
+                startTime={taydennys.applicationData.startTime}
+                endTime={taydennys.applicationData.endTime}
+              />
+            )}
+          </Box>
+        </TabPanel>
+        <TabPanel>
+          <Box mt="var(--spacing-s)">{hakemusContent}</Box>
+        </TabPanel>
+      </Tabs>
+    );
+  }
+
+  return hakemusContent;
+}

--- a/src/domain/map/components/OwnHankeMap/OwnHankeMap.tsx
+++ b/src/domain/map/components/OwnHankeMap/OwnHankeMap.tsx
@@ -9,31 +9,17 @@ import { styleFunction } from '../../utils/geometryStyle';
 import FitSource from '../interations/FitSource';
 import useHankeFeatures from '../../hooks/useHankeFeatures';
 import styles from './OwnHankeMap.module.scss';
-import {
-  Application,
-  ApplicationArea,
-  KaivuilmoitusAlue,
-} from '../../../application/types/application';
+import { ApplicationArea } from '../../../application/types/application';
 import useApplicationFeatures from '../../hooks/useApplicationFeatures';
 
 type Props = {
   hanke: HankeData;
-  application?: Application;
+  tyoalueet?: ApplicationArea[];
 };
 
-const OwnHankeMap: React.FC<Props> = ({ hanke, application }) => {
+const OwnHankeMap: React.FC<Props> = ({ hanke, tyoalueet }) => {
   const hankeSource = useRef(new VectorSource());
   useHankeFeatures(hankeSource.current, [hanke]);
-
-  let tyoalueet: ApplicationArea[] = [];
-  if (application) {
-    tyoalueet =
-      application.applicationType === 'CABLE_REPORT'
-        ? (application.applicationData.areas as ApplicationArea[])
-        : (application.applicationData.areas as KaivuilmoitusAlue[]).flatMap(
-            (area) => area.tyoalueet,
-          );
-  }
 
   const applicationSource = useRef(new VectorSource());
   useApplicationFeatures(applicationSource.current, tyoalueet);
@@ -55,9 +41,7 @@ const OwnHankeMap: React.FC<Props> = ({ hanke, application }) => {
           className="applicationGeometryLayer"
           style={(feature: FeatureLike) => styleFunction(feature, undefined, true)}
         />
-        <FitSource
-          source={application && tyoalueet.length ? applicationSource.current : hankeSource.current}
-        />
+        <FitSource source={tyoalueet?.length ? applicationSource.current : hankeSource.current} />
       </Map>
     </div>
   );


### PR DESCRIPTION
# Description

If there is taydennys for application show updated and original information in tabs in side bar.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-499

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check that johtoselvitys täydennys has "Täydennykset" and "Alkuperäiset" tabs in application page side bar displaying correct map information.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
