### PR TITLE
HAI-779 Add buttons to cancel johtoselvitys täydennys

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -87,6 +87,7 @@ import AreaInformation from '../components/summary/AreaInformation';
 import useIsInformationRequestFeatureEnabled from '../taydennys/hooks/useIsInformationRequestFeatureEnabled';
 import useSendTaydennys from './hooks/useSendTaydennys';
 import { Sidebar } from './Sidebar';
+import TaydennysCancel from '../taydennys/components/TaydennysCancel';
 
 function TyoalueetList({ tyoalueet }: { tyoalueet: ApplicationArea[] }) {
   const { t } = useTranslation();
@@ -466,7 +467,7 @@ function ApplicationView({
     <InformationViewContainer>
       <InformationViewHeader backgroundColor="var(--color-suomenlinna-light)">
         <MainHeading>{name}</MainHeading>
-        <Text tag="h2" styleAs="h3" weight="bold" spacingBottom="l">
+        <Text tag="h2" styleAs="h3" weight="bold" spacingBottom="l" data-testid="allu_tunnus">
           {applicationId}
         </Text>
 
@@ -601,16 +602,19 @@ function ApplicationView({
           )}
           {informationRequestFeatureEnabled && alluStatus === AlluStatus.WAITING_INFORMATION && (
             <CheckRightsByHanke requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>
-              <Button
-                theme="coat"
-                iconLeft={<IconPen aria-hidden="true" />}
-                onClick={onEditTaydennys}
-                isLoading={creatingTaydennys}
-              >
-                {!taydennys
-                  ? t('taydennys:buttons:createTaydennys')
-                  : t('taydennys:buttons:editTaydennys')}
-              </Button>
+              <>
+                <Button
+                  theme="coat"
+                  iconLeft={<IconPen aria-hidden="true" />}
+                  onClick={onEditTaydennys}
+                  isLoading={creatingTaydennys}
+                >
+                  {!taydennys
+                    ? t('taydennys:buttons:createTaydennys')
+                    : t('taydennys:buttons:editTaydennys')}
+                </Button>
+                <TaydennysCancel application={application} />
+              </>
             </CheckRightsByHanke>
           )}
           <CheckRightsByHanke requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>

--- a/src/domain/application/taydennys/components/TaydennysCancel.tsx
+++ b/src/domain/application/taydennys/components/TaydennysCancel.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import { Button, IconCross, IconTrash } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from 'react-query';
+import { Application } from '../../types/application';
+import useNavigateToApplicationView from '../../hooks/useNavigateToApplicationView';
+import { useGlobalNotification } from '../../../../common/components/globalNotification/GlobalNotificationContext';
+import useDebouncedMutation from '../../../../common/hooks/useDebouncedMutation';
+import ConfirmationDialog from '../../../../common/components/HDSConfirmationDialog/ConfirmationDialog';
+import { cancelTaydennys } from '../taydennysApi';
+
+type Props = {
+  application: Application;
+  navigateToApplicationViewOnSuccess?: boolean;
+  buttonVariant?: 'primary' | 'danger';
+  buttonIsLoading?: boolean;
+  buttonIsLoadingText?: string;
+};
+
+export default function TaydennysCancel({
+  application,
+  navigateToApplicationViewOnSuccess,
+  buttonVariant,
+  buttonIsLoading,
+  buttonIsLoadingText,
+}: Readonly<Props>) {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+  const { setNotification } = useGlobalNotification();
+  const navigateToApplicationView = useNavigateToApplicationView();
+
+  const [isConfirmationDialogOpen, setIsConfirmationDialogOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isButtonDisabled, setIsButtonDisabled] = useState(false);
+
+  const isCancelPossible = Boolean(application.taydennys);
+
+  const taydennysCancelMutation = useDebouncedMutation(cancelTaydennys, {
+    onError() {
+      setErrorMessage(t('common:error'));
+      setIsButtonDisabled(false);
+    },
+    onSuccess() {
+      const closeButtonLabelText = t('common:components:notification:closeButtonLabelText');
+      setNotification(true, {
+        label: t('taydennys:notifications:cancelSuccessLabel'),
+        message: t('taydennys:notifications:cancelSuccessText'),
+        type: 'success',
+        dismissible: true,
+        closeButtonLabelText,
+        autoClose: true,
+        autoCloseDuration: 7000,
+      });
+      if (navigateToApplicationViewOnSuccess) {
+        navigateToApplicationView(application.id?.toString());
+      } else {
+        queryClient.invalidateQueries(['application', application.id], { refetchInactive: true });
+        setIsConfirmationDialogOpen(false);
+        setIsButtonDisabled(false);
+      }
+    },
+  });
+
+  function doApplicationCancel() {
+    setIsButtonDisabled(true);
+    if (application.taydennys?.id) {
+      taydennysCancelMutation.mutate(application.taydennys.id);
+    }
+  }
+
+  function openConfirmationDialog() {
+    setIsConfirmationDialogOpen(true);
+  }
+
+  function closeConfirmationDialog() {
+    setErrorMessage('');
+    setIsConfirmationDialogOpen(false);
+  }
+
+  if (!isCancelPossible) {
+    return null;
+  }
+
+  return (
+    <>
+      <ConfirmationDialog
+        title={t('taydennys:labels:cancelTitle')}
+        description={t('taydennys:labels:cancelDescription')}
+        isOpen={isConfirmationDialogOpen}
+        close={closeConfirmationDialog}
+        mainAction={doApplicationCancel}
+        mainBtnLabel={t('common:confirmationDialog:confirmButton')}
+        mainBtnIcon={<IconTrash />}
+        variant="danger"
+        errorMsg={errorMessage}
+        isLoading={taydennysCancelMutation.isLoading || isButtonDisabled}
+      />
+
+      <Button
+        variant={buttonVariant}
+        theme="coat"
+        iconLeft={<IconCross />}
+        onClick={openConfirmationDialog}
+        isLoading={buttonIsLoading || isButtonDisabled}
+        loadingText={buttonIsLoadingText}
+        disabled={isButtonDisabled}
+      >
+        {t('taydennys:buttons:cancelTaydennys')}
+      </Button>
+    </>
+  );
+}

--- a/src/domain/application/taydennys/taydennysApi.ts
+++ b/src/domain/application/taydennys/taydennysApi.ts
@@ -34,3 +34,10 @@ export async function sendTaydennys<ApplicationData>(id: string) {
   const response = await api.post<Application<ApplicationData>>(`/taydennykset/${id}/laheta`);
   return response.data;
 }
+
+/**
+ * Delete taydennys
+ */
+export async function cancelTaydennys(id: string) {
+  await api.delete(`/taydennykset/${id}`);
+}

--- a/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennys.test.tsx
+++ b/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennys.test.tsx
@@ -35,6 +35,9 @@ function setup(
     http.post('/api/taydennykset/:id/laheta', async () => {
       return HttpResponse.json(application, { status: responseStatus });
     }),
+    http.delete('/api/taydennykset/:id', async () => {
+      return new HttpResponse(null, { status: responseStatus });
+    }),
   );
   return {
     ...render(
@@ -210,5 +213,26 @@ describe('Sending taydennys', () => {
         'Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö.',
       ),
     ).toHaveLength(2);
+  });
+});
+
+describe('Canceling taydennys', () => {
+  test('Should be able to cancel taydennys', async () => {
+    const application = cloneDeep(hakemukset[10]) as Application<JohtoselvitysData>;
+    application.taydennys = {
+      id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+      applicationData: application.applicationData,
+      muutokset: [],
+    };
+    const { user } = setup({
+      application,
+      taydennys: application.taydennys,
+    });
+    await user.click(screen.getByRole('button', { name: /peru täydennysluonnos/i }));
+    await user.click(await screen.findByRole('button', { name: /vahvista/i }));
+
+    expect(await screen.findByText('Täydennysluonnos peruttiin')).toBeInTheDocument();
+    expect(screen.getByText('Täydennysluonnos peruttiin onnistuneesti')).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/fi/hakemus/11');
   });
 });

--- a/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennysContainer.tsx
+++ b/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennysContainer.tsx
@@ -43,6 +43,7 @@ import ConfirmationDialog from '../../common/components/HDSConfirmationDialog/Co
 import useSendTaydennys from '../application/taydennys/hooks/useSendTaydennys';
 import { isContactIn } from '../application/utils';
 import { usePermissionsForHanke } from '../hanke/hankeUsers/hooks/useUserRightsForHanke';
+import TaydennysCancel from '../application/taydennys/components/TaydennysCancel';
 
 type Props = {
   taydennys: Taydennys<JohtoselvitysData>;
@@ -262,6 +263,13 @@ export default function JohtoselvitysTaydennysContainer({
               onPrevious={handlePrevious}
               onNext={handleNext}
             >
+              <TaydennysCancel
+                application={originalApplication}
+                navigateToApplicationViewOnSuccess
+                buttonVariant="danger"
+                buttonIsLoading={saveAndQuitIsLoading}
+                buttonIsLoadingText={saveAndQuitLoadingText}
+              />
               <Button
                 variant="secondary"
                 iconLeft={<IconSaveDiskette aria-hidden="true" />}

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -181,3 +181,11 @@ export async function sendTaydennys(id: string) {
   updatedHakemus.taydennyspyynto = null;
   return updatedHakemus;
 }
+
+export async function cancelTaydennys(id: string) {
+  const hakemus = await readTaydennys(id);
+  if (!hakemus) {
+    throw new ApiError(`No application with id ${id}`, 404);
+  }
+  hakemus.taydennys = null;
+}

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -380,4 +380,10 @@ export const handlers = [
     const hakemus = await hakemuksetDB.sendTaydennys(id as string);
     return HttpResponse.json(hakemus);
   }),
+
+  http.delete(`${apiUrl}/taydennykset/:id`, async ({ params }) => {
+    const { id } = params;
+    await hakemuksetDB.cancelTaydennys(id as string);
+    return new HttpResponse();
+  }),
 ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1277,18 +1277,23 @@
     "labels": {
       "originalInformation": "Alkuperäiset",
       "taydennykset": "Täydennykset",
-      "taydennys": "Täydennys"
+      "taydennys": "Täydennys",
+      "cancelTitle": "Peru täydennysluonnos?",
+      "cancelDescription": "Haluatko varmasti perua täydennyspyyntöön vastaamisen? Tehdyt muutokset poistetaan."
     },
     "buttons": {
       "createTaydennys": "Täydennä",
       "editTaydennys": "Muokkaa hakemusta (täydennys)",
-      "sendTaydennys": "Lähetä täydennys"
+      "sendTaydennys": "Lähetä täydennys",
+      "cancelTaydennys": "Peru täydennysluonnos"
     },
     "notifications": {
       "sendSuccessLabel": "Täydennys lähetetty",
       "sendSuccessText": "Täydennys on lähetetty käsiteltäväksi.",
       "sendErrorLabel": "Täydennyksen lähettäminen epäonnistui",
-      "sendErrorText": "$t(hakemus:notifications:reportCompletionDateErrorText)"
+      "sendErrorText": "$t(hakemus:notifications:reportCompletionDateErrorText)",
+      "cancelSuccessLabel": "Täydennysluonnos peruttiin",
+      "cancelSuccessText": "Täydennysluonnos peruttiin onnistuneesti"
     },
     "sendDialog": {
       "title": "Lähetä täydennetty hakemus käsittelyyn",


### PR DESCRIPTION
# Description

Added buttons to cancel johtoselvitys täydennys to application page and johtoselvitys täydennys form.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-779

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Have a johtoselvitys application that has täydennyspyyntö
2. When täydennys has not been started check that "Peru täydennysluonnos" button is not visible in application page
3. Start making täydennys
4. Try cancelling täydennys either in täydennys form or in application page

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
