### PR TITLE
HAI-934 Make sure that user sending johtoselvitys taydennys is added as a contact person

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -425,7 +425,7 @@ function ApplicationView({
 
   const informationRequestFeatureEnabled = useIsInformationRequestFeatureEnabled(applicationType);
 
-  const { sendTaydennysButton, sendTaydennysDialog } = useSendTaydennys(application);
+  const { sendTaydennysButton, sendTaydennysDialog } = useSendTaydennys(application, signedInUser);
 
   async function onSendApplication(pdr: PaperDecisionReceiver | undefined | null) {
     applicationSendMutation.mutate({


### PR DESCRIPTION
# Description

If user is not added as contact person, send button is disabled and a notification is shown.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-934

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Have a täydennyspyyntö for johtoselvitys and start making täydennys
2. Make sure that you are not as a contact person in the form
3. Check in summary page and in application page that send täydennys button is disabled and that there is a notification "Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö"

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
