### PR TITLE
HAI-485 Fix showing johtoselvitys täydennys areas

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -621,7 +621,6 @@ describe('Cable report application view', () => {
       await user.click(screen.getByRole('tab', { name: /alueet/i }));
 
       expect(screen.getAllByText('Täydennys:').length).toBe(2);
-      expect(screen.getAllByText('Poistettu:').length).toBe(1);
       expect(screen.getByText('264 m²')).toBeInTheDocument();
     });
 

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -130,13 +130,11 @@ function TotalSurfaceArea({
   return (
     <>
       {totalSurfaceArea > 0 && <p>{totalSurfaceArea} m²</p>}
-      {changedTotalSurfaceArea &&
-        changedTotalSurfaceArea > 0 &&
-        changedTotalSurfaceArea !== totalSurfaceArea && (
-          <SectionItemContentAdded marginTop="var(--spacing-s)">
-            <p>{changedTotalSurfaceArea} m²</p>
-          </SectionItemContentAdded>
-        )}
+      {changedTotalSurfaceArea !== undefined && changedTotalSurfaceArea !== totalSurfaceArea && (
+        <SectionItemContentAdded marginTop="var(--spacing-s)">
+          <p>{changedTotalSurfaceArea} m²</p>
+        </SectionItemContentAdded>
+      )}
     </>
   );
 }
@@ -193,7 +191,7 @@ function JohtoselvitysAreasInfo({
             })}
           </SectionItemContentAdded>
         )}
-        {areasRemoved && areasRemoved.length > 0 && (
+        {areasRemoved && areasRemoved.length === tyoalueet.length && (
           <SectionItemContentRemoved marginTop="var(--spacing-s)">
             {areasRemoved.map((area, index) => {
               return (

--- a/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.tsx
@@ -26,15 +26,14 @@ export default function JohtoselvitysAreaSummary({
   muutokset,
 }: Readonly<Props>) {
   const { t } = useTranslation();
-  const { startTime, endTime, areas } = data;
+  const { startTime, endTime, areas: taydennysAreas } = data;
   const startTimeChanged = muutokset.includes('startTime');
   const endTimeChanged = muutokset.includes('endTime');
-  const areasChanged = areas.filter((_, index) => {
-    const areaChanged = muutokset.includes(`areas[${index}]`);
-    return areaChanged;
+  const areasChanged = taydennysAreas.filter((_, index) => {
+    return muutokset.includes(`areas[${index}]`);
   });
   const areasRemoved = originalData.areas.filter(
-    (_, index) => muutokset.includes(`areas[${index}]`) && !areas[index],
+    (_, index) => muutokset.includes(`areas[${index}]`) && !taydennysAreas[index],
   );
 
   if (
@@ -89,7 +88,7 @@ export default function JohtoselvitysAreaSummary({
             )}
             <SectionItemTitle>{t('hankeForm:hankkeenAlueForm:header')}</SectionItemTitle>
             <SectionItemContent>
-              {areas.map((area, index) => {
+              {taydennysAreas.map((area, index) => {
                 if (!muutokset.includes(`areas[${index}]`)) {
                   return null;
                 }
@@ -101,7 +100,7 @@ export default function JohtoselvitysAreaSummary({
                   />
                 );
               })}
-              {areasRemoved.length > 0 && (
+              {areasRemoved.length === originalData.areas.length && (
                 <SectionItemContentRemoved>
                   {areasRemoved.map((area, index) => {
                     return (


### PR DESCRIPTION
# Description

It was decided that removed areas are not shown in johtoselvitys täydennys form summary or application view unless all areas are removed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-485

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Check that when changing areas in johtoselvitys täydennys they are shown correctly in summary and that when removing all areas they are shown as "Poistettu".

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
