### PR TITLE
HAI-754 Johtoselvitys täydennys attachments

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -12,6 +12,7 @@ import { fi } from 'date-fns/locale';
 import { Application, JohtoselvitysData } from '../types/application';
 import * as taydennysApi from '../taydennys/taydennysApi';
 import { USER_VIEW } from '../../mocks/signedInUser';
+import { createTaydennysAttachments } from '../../mocks/attachments';
 
 describe('Cable report application view', () => {
   test('Correct information about application should be displayed', async () => {
@@ -406,6 +407,7 @@ describe('Cable report application view', () => {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
         applicationData: application.applicationData,
         muutokset: [],
+        liitteet: [],
       };
       await setup(application);
 
@@ -445,6 +447,7 @@ describe('Cable report application view', () => {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
         applicationData: application.applicationData,
         muutokset: [],
+        liitteet: [],
       };
       const { user } = await setup(application);
       await user.click(screen.getByRole('button', { name: 'Muokkaa hakemusta (täydennys)' }));
@@ -522,6 +525,7 @@ describe('Cable report application view', () => {
           'rockExcavation',
           'workDescription',
         ],
+        liitteet: [],
       };
       await setup(application);
 
@@ -619,6 +623,7 @@ describe('Cable report application view', () => {
           ],
         },
         muutokset: ['areas[1]', 'areas[2]'],
+        liitteet: [],
       };
       const { user } = await setup(application);
       await user.click(screen.getByRole('tab', { name: /alueet/i }));
@@ -647,6 +652,7 @@ describe('Cable report application view', () => {
           propertyDeveloperWithContacts: null,
         },
         muutokset: ['customerWithContacts', 'propertyDeveloperWithContacts'],
+        liitteet: [],
       };
       const { user } = await setup(application);
       await user.click(screen.getByRole('tab', { name: /yhteystiedot/i }));
@@ -657,12 +663,32 @@ describe('Cable report application view', () => {
       expect(screen.getByText('newMail@test.com')).toBeInTheDocument();
     });
 
+    test('Shows changed information in attachments tab', async () => {
+      const taydennysId = 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c';
+      const taydennysAttachments = createTaydennysAttachments(taydennysId, 2);
+      const application = cloneDeep(hakemukset[10] as Application<JohtoselvitysData>);
+      application.taydennys = {
+        id: taydennysId,
+        applicationData: application.applicationData,
+        muutokset: [],
+        liitteet: taydennysAttachments,
+      };
+      const { user } = await setup(application);
+      await user.click(screen.getByRole('tab', { name: /liitteet/i }));
+
+      expect(screen.getByText('Täydennys:')).toBeInTheDocument();
+      taydennysAttachments.forEach((attachment) => {
+        expect(screen.getByText(attachment.fileName)).toBeInTheDocument();
+      });
+    });
+
     test('Taydennys can be sent', async () => {
       const application = cloneDeep(hakemukset[10]) as Application<JohtoselvitysData>;
       application.taydennys = {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
         applicationData: application.applicationData,
         muutokset: ['workDescription'],
+        liitteet: [],
       };
       const { user } = await setup(application);
       await user.click(screen.getByRole('button', { name: 'Lähetä täydennys' }));
@@ -677,6 +703,7 @@ describe('Cable report application view', () => {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
         applicationData: application.applicationData,
         muutokset: [],
+        liitteet: [],
       };
       await setup(application);
 
@@ -694,6 +721,7 @@ describe('Cable report application view', () => {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
         applicationData: application.applicationData,
         muutokset: ['workDescription'],
+        liitteet: [],
       };
       await setup(application);
 
@@ -706,6 +734,7 @@ describe('Cable report application view', () => {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
         applicationData: application.applicationData,
         muutokset: ['workDescription'],
+        liitteet: [],
       };
       const { user } = await setup(application);
       await user.click(screen.getByRole('button', { name: 'Peru täydennysluonnos' }));
@@ -736,6 +765,7 @@ describe('Cable report application view', () => {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
         applicationData: application.applicationData,
         muutokset: ['workDescription'],
+        liitteet: [],
       };
       await setup(application);
 

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -89,6 +89,7 @@ import useSendTaydennys from './hooks/useSendTaydennys';
 import Sidebar from './Sidebar';
 import FormPagesErrorSummary from '../../forms/components/FormPagesErrorSummary';
 import TaydennysCancel from '../taydennys/components/TaydennysCancel';
+import TaydennysAttachmentsList from '../taydennys/components/TaydennysAttachmentsList';
 
 function TyoalueetList({ tyoalueet }: { tyoalueet: ApplicationArea[] }) {
   const { t } = useTranslation();
@@ -809,17 +810,22 @@ function ApplicationView({
             </TabPanel>
             <TabPanel>
               {applicationType === 'EXCAVATION_NOTIFICATION' ? (
-                <SectionTitle>{t('form:headers:liitteetJaLisatiedot')}</SectionTitle>
-              ) : (
-                <SectionTitle>{t('hankePortfolio:tabit:liitteet')}</SectionTitle>
-              )}
-              {applicationType === 'EXCAVATION_NOTIFICATION' ? (
                 <KaivuilmoitusAttachmentSummary
                   formData={application as Application<KaivuilmoitusData>}
                   attachments={attachments}
                 />
-              ) : attachments && attachments.length > 0 ? (
-                <AttachmentSummary attachments={attachments} />
+              ) : attachments ? (
+                <AttachmentSummary
+                  attachments={attachments}
+                  children={
+                    taydennys?.liitteet &&
+                    taydennys.liitteet.length > 0 && (
+                      <SectionItemContentAdded mt="var(--spacing-xs)">
+                        <TaydennysAttachmentsList attachments={taydennys.liitteet} />
+                      </SectionItemContentAdded>
+                    )
+                  }
+                />
               ) : null}
             </TabPanel>
           </Tabs>

--- a/src/domain/application/applicationView/Sidebar.test.tsx
+++ b/src/domain/application/applicationView/Sidebar.test.tsx
@@ -41,6 +41,7 @@ describe('Sidebar', () => {
           ],
         },
         muutokset: ['areas[1]'],
+        liitteet: [],
       };
       const { user } = render(<Sidebar hanke={hanke} application={application} />);
 

--- a/src/domain/application/applicationView/hooks/useSendTaydennys.tsx
+++ b/src/domain/application/applicationView/hooks/useSendTaydennys.tsx
@@ -27,7 +27,7 @@ export default function useSendTaydennys(
     application.alluStatus === AlluStatus.WAITING_INFORMATION &&
     isTaydennysValid &&
     application.taydennys &&
-    application.taydennys.muutokset.length > 0;
+    (application.taydennys.muutokset.length > 0 || application.taydennys.liitteet.length > 0);
   const [showSendTaydennysDialog, setShowSendTaydennysDialog] = useState(false);
   const sendTaydennysMutation = useSendTaydennysMutation();
   const isContact =

--- a/src/domain/application/components/summary/AttachmentSummary.tsx
+++ b/src/domain/application/components/summary/AttachmentSummary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   FormSummarySection,
@@ -11,9 +10,10 @@ import { getAttachmentFile } from '../../attachments';
 
 type Props = {
   attachments: ApplicationAttachmentMetadata[];
+  children?: React.ReactNode;
 };
 
-function AttachmentSummary({ attachments }: Props) {
+function AttachmentSummary({ attachments, children }: Readonly<Props>) {
   const { t } = useTranslation();
 
   const download = (file: ApplicationAttachmentMetadata) =>
@@ -24,6 +24,7 @@ function AttachmentSummary({ attachments }: Props) {
       <SectionItemTitle>{t('hankePortfolio:tabit:liitteet')}</SectionItemTitle>
       <SectionItemContent>
         <FileDownloadList files={attachments} download={download} />
+        {children}
       </SectionItemContent>
     </FormSummarySection>
   );

--- a/src/domain/application/taydennys/components/TaydennysAttachmentsList.tsx
+++ b/src/domain/application/taydennys/components/TaydennysAttachmentsList.tsx
@@ -1,0 +1,15 @@
+import FileDownloadList from '../../../../common/components/fileDownloadList/FileDownloadList';
+import { getAttachmentFile } from '../taydennysAttachmentsApi';
+import { TaydennysAttachmentMetadata } from '../types';
+
+type Props = {
+  attachments: TaydennysAttachmentMetadata[];
+};
+
+export default function TaydennysAttachmentsList({ attachments }: Readonly<Props>) {
+  function download(file: TaydennysAttachmentMetadata) {
+    return getAttachmentFile(file.taydennysId, file.id);
+  }
+
+  return <FileDownloadList files={attachments} download={download} />;
+}

--- a/src/domain/application/taydennys/taydennysAttachmentsApi.ts
+++ b/src/domain/application/taydennys/taydennysAttachmentsApi.ts
@@ -1,0 +1,47 @@
+import api from '../../api/api';
+import { ApplicationAttachmentMetadata, AttachmentType } from '../types/application';
+
+// Upload attachment for täydennys
+export async function uploadAttachment({
+  taydennysId,
+  attachmentType,
+  file,
+  abortSignal,
+}: {
+  taydennysId: string;
+  attachmentType: AttachmentType;
+  file: File;
+  abortSignal?: AbortSignal;
+}) {
+  const { data } = await api.post<ApplicationAttachmentMetadata>(
+    `/taydennykset/${taydennysId}/liitteet?tyyppi=${attachmentType}`,
+    { liite: file },
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+      signal: abortSignal,
+    },
+  );
+  return data;
+}
+
+// Download attachment file
+export async function getAttachmentFile(taydennysId: string, attachmentId: string) {
+  const { data } = await api.get<Blob>(
+    `/taydennykset/${taydennysId}/liitteet/${attachmentId}/content`,
+    { responseType: 'blob' },
+  );
+  return URL.createObjectURL(data);
+}
+
+// Delete attachment
+export async function deleteAttachment({
+  taydennysId,
+  attachmentId,
+}: {
+  taydennysId: string | null;
+  attachmentId: string | undefined;
+}) {
+  await api.delete(`/taydennykset/${taydennysId}/liitteet/${attachmentId}`);
+}

--- a/src/domain/application/taydennys/taydennysAttachmentsApi.ts
+++ b/src/domain/application/taydennys/taydennysAttachmentsApi.ts
@@ -1,5 +1,6 @@
 import api from '../../api/api';
-import { ApplicationAttachmentMetadata, AttachmentType } from '../types/application';
+import { AttachmentType } from '../types/application';
+import { TaydennysAttachmentMetadata } from './types';
 
 // Upload attachment for täydennys
 export async function uploadAttachment({
@@ -13,7 +14,7 @@ export async function uploadAttachment({
   file: File;
   abortSignal?: AbortSignal;
 }) {
-  const { data } = await api.post<ApplicationAttachmentMetadata>(
+  const { data } = await api.post<TaydennysAttachmentMetadata>(
     `/taydennykset/${taydennysId}/liitteet?tyyppi=${attachmentType}`,
     { liite: file },
     {

--- a/src/domain/application/taydennys/types.ts
+++ b/src/domain/application/taydennys/types.ts
@@ -1,3 +1,6 @@
+import { AttachmentMetadata } from '../../../common/types/attachment';
+import { AttachmentType } from '../types/application';
+
 export enum TaydennyspyyntoFieldKey {
   CUSTOMER = 'CUSTOMER',
   INVOICING_CUSTOMER = 'INVOICING_CUSTOMER',
@@ -28,8 +31,14 @@ export type Taydennyspyynto = {
   kentat: TaydennyspyyntoField[];
 };
 
+export interface TaydennysAttachmentMetadata extends AttachmentMetadata {
+  taydennysId: string;
+  attachmentType: AttachmentType;
+}
+
 export type Taydennys<T> = {
   id: string;
   applicationData: T;
   muutokset: string[];
+  liitteet: TaydennysAttachmentMetadata[];
 };

--- a/src/domain/forms/components/FormSummarySection.tsx
+++ b/src/domain/forms/components/FormSummarySection.tsx
@@ -75,15 +75,22 @@ const SectionItemContentAdded: React.FC<Readonly<SectionItemContentProps>> = ({
   );
 };
 
-const FormSummarySection: React.FC<{
+interface FormSummarySectionProps extends BoxProps {
   children: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
-}> = ({ children, className, style }) => {
+}
+
+const FormSummarySection: React.FC<Readonly<FormSummarySectionProps>> = ({
+  children,
+  className,
+  style,
+  ...chakraProps
+}) => {
   return (
-    <section className={clsx(styles.container, className)} style={style}>
+    <Box as="section" className={clsx(styles.container, className)} style={style} {...chakraProps}>
       {children}
-    </section>
+    </Box>
   );
 };
 

--- a/src/domain/johtoselvitysTaydennys/Attachments.tsx
+++ b/src/domain/johtoselvitysTaydennys/Attachments.tsx
@@ -1,0 +1,93 @@
+import { useTranslation } from 'react-i18next';
+import { Box } from '@chakra-ui/react';
+import { useQueryClient } from 'react-query';
+import { useFormContext } from 'react-hook-form';
+import Text from '../../common/components/text/Text';
+import { ApplicationAttachmentMetadata } from '../application/types/application';
+import FileUpload from '../../common/components/fileUpload/FileUpload';
+import { JohtoselvitysTaydennysFormValues } from './types';
+import {
+  deleteAttachment,
+  getAttachmentFile,
+  uploadAttachment,
+} from '../application/taydennys/taydennysAttachmentsApi';
+import { getAttachmentFile as getApplicationAttachmentFile } from '../application/attachments';
+import FileDownloadList from '../../common/components/fileDownloadList/FileDownloadList';
+import {
+  FormSummarySection,
+  SectionItemContent,
+  SectionItemTitle,
+} from '../forms/components/FormSummarySection';
+
+type Props = {
+  applicationId: number;
+  originalAttachments: ApplicationAttachmentMetadata[] | undefined;
+  attachmentsLoadError: boolean;
+  onFileUpload: (isUploading: boolean) => void;
+};
+
+export default function Attachments({
+  applicationId,
+  originalAttachments,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  attachmentsLoadError,
+  onFileUpload,
+}: Readonly<Props>) {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+  const { getValues } = useFormContext<JohtoselvitysTaydennysFormValues>();
+
+  function handleFileUpload(uploading: boolean) {
+    onFileUpload(uploading);
+    if (!uploading) {
+      queryClient.invalidateQueries('attachments');
+    }
+  }
+
+  return (
+    <Box mb="var(--spacing-l)">
+      <Text tag="p" spacingBottom="l">
+        {t('johtoselvitysForm:liitteet:instructions')}
+      </Text>
+
+      <Text tag="h2" styleAs="h3" weight="bold" spacingBottom="s">
+        {t('hankePortfolio:tabit:liitteet')}
+      </Text>
+
+      <FormSummarySection marginBottom="var(--spacing-m)">
+        <SectionItemTitle>{t('taydennys:labels:originalAttachments')}</SectionItemTitle>
+        <SectionItemContent>
+          <FileDownloadList
+            files={originalAttachments ?? []}
+            download={(file) => getApplicationAttachmentFile(applicationId, file.id)}
+          />
+        </SectionItemContent>
+      </FormSummarySection>
+
+      <FileUpload
+        id="cable-report-taydennys-file-upload"
+        accept=".pdf,.jpg,.jpeg,.png,.dgn,.dwg,.docx,.txt,.gt"
+        maxSize={104857600}
+        dragAndDrop
+        multiple
+        // existingAttachments={existingAttachments}
+        // existingAttachmentsLoadError={attachmentsLoadError}
+        maxFilesNumber={20}
+        uploadFunction={({ file, abortSignal }) =>
+          uploadAttachment({
+            taydennysId: getValues('id')!,
+            attachmentType: 'MUU',
+            file,
+            abortSignal,
+          })
+        }
+        onUpload={handleFileUpload}
+        fileDownLoadFunction={(file) => getAttachmentFile(getValues('id')!, file.id)}
+        fileDeleteFunction={(file) =>
+          deleteAttachment({ taydennysId: getValues('id'), attachmentId: file?.id })
+        }
+        onFileDelete={() => queryClient.invalidateQueries('attachments')}
+      />
+    </Box>
+  );
+}

--- a/src/domain/johtoselvitysTaydennys/Attachments.tsx
+++ b/src/domain/johtoselvitysTaydennys/Attachments.tsx
@@ -3,7 +3,6 @@ import { Box } from '@chakra-ui/react';
 import { useQueryClient } from 'react-query';
 import { useFormContext } from 'react-hook-form';
 import Text from '../../common/components/text/Text';
-import { ApplicationAttachmentMetadata } from '../application/types/application';
 import FileUpload from '../../common/components/fileUpload/FileUpload';
 import { JohtoselvitysTaydennysFormValues } from './types';
 import {
@@ -18,19 +17,20 @@ import {
   SectionItemContent,
   SectionItemTitle,
 } from '../forms/components/FormSummarySection';
+import { ApplicationAttachmentMetadata } from '../application/types/application';
+import { TaydennysAttachmentMetadata } from '../application/taydennys/types';
 
 type Props = {
   applicationId: number;
-  originalAttachments: ApplicationAttachmentMetadata[] | undefined;
-  attachmentsLoadError: boolean;
+  taydennysAttachments: TaydennysAttachmentMetadata[];
+  originalAttachments?: ApplicationAttachmentMetadata[];
   onFileUpload: (isUploading: boolean) => void;
 };
 
 export default function Attachments({
   applicationId,
+  taydennysAttachments,
   originalAttachments,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  attachmentsLoadError,
   onFileUpload,
 }: Readonly<Props>) {
   const queryClient = useQueryClient();
@@ -40,7 +40,7 @@ export default function Attachments({
   function handleFileUpload(uploading: boolean) {
     onFileUpload(uploading);
     if (!uploading) {
-      queryClient.invalidateQueries('attachments');
+      queryClient.invalidateQueries(['application', applicationId]);
     }
   }
 
@@ -54,15 +54,17 @@ export default function Attachments({
         {t('hankePortfolio:tabit:liitteet')}
       </Text>
 
-      <FormSummarySection marginBottom="var(--spacing-m)">
-        <SectionItemTitle>{t('taydennys:labels:originalAttachments')}</SectionItemTitle>
-        <SectionItemContent>
-          <FileDownloadList
-            files={originalAttachments ?? []}
-            download={(file) => getApplicationAttachmentFile(applicationId, file.id)}
-          />
-        </SectionItemContent>
-      </FormSummarySection>
+      {originalAttachments && originalAttachments.length > 0 && (
+        <FormSummarySection marginBottom="var(--spacing-m)">
+          <SectionItemTitle>{t('taydennys:labels:originalAttachments')}</SectionItemTitle>
+          <SectionItemContent>
+            <FileDownloadList
+              files={originalAttachments}
+              download={(file) => getApplicationAttachmentFile(applicationId, file.id)}
+            />
+          </SectionItemContent>
+        </FormSummarySection>
+      )}
 
       <FileUpload
         id="cable-report-taydennys-file-upload"
@@ -70,8 +72,7 @@ export default function Attachments({
         maxSize={104857600}
         dragAndDrop
         multiple
-        // existingAttachments={existingAttachments}
-        // existingAttachmentsLoadError={attachmentsLoadError}
+        existingAttachments={taydennysAttachments}
         maxFilesNumber={20}
         uploadFunction={({ file, abortSignal }) =>
           uploadAttachment({
@@ -86,7 +87,7 @@ export default function Attachments({
         fileDeleteFunction={(file) =>
           deleteAttachment({ taydennysId: getValues('id'), attachmentId: file?.id })
         }
-        onFileDelete={() => queryClient.invalidateQueries('attachments')}
+        onFileDelete={() => queryClient.invalidateQueries(['application', applicationId])}
       />
     </Box>
   );

--- a/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennys.test.tsx
+++ b/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennys.test.tsx
@@ -385,6 +385,7 @@ describe('Error notification', () => {
           },
         },
         muutokset: [],
+        liitteet: [],
       },
     });
     await user.click(screen.getByRole('button', { name: /yhteenveto/i }));

--- a/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennysContainer.tsx
+++ b/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennysContainer.tsx
@@ -75,9 +75,7 @@ export default function JohtoselvitysTaydennysContainer({
   const { data: signedInUser } = usePermissionsForHanke(hankeData.hankeTunnus);
   const [attachmentsUploading, setAttachmentsUploading] = useState(false);
   const attachmentsUploadingText: string = t('common:components:fileUpload:loadingText');
-  const { data: originalAttachments, isError: attachmentsLoadError } = useAttachments(
-    originalApplication.id,
-  );
+  const { data: originalAttachments } = useAttachments(originalApplication.id);
 
   const formContext = useForm<JohtoselvitysTaydennysFormValues>({
     mode: 'onTouched',
@@ -139,8 +137,8 @@ export default function JohtoselvitysTaydennysContainer({
       element: (
         <Attachments
           applicationId={originalApplication.id!}
+          taydennysAttachments={taydennys.liitteet}
           originalAttachments={originalAttachments}
-          attachmentsLoadError={attachmentsLoadError}
           onFileUpload={handleAttachmentUpload}
         />
       ),
@@ -150,9 +148,10 @@ export default function JohtoselvitysTaydennysContainer({
     {
       element: (
         <ReviewAndSend
-          taydennys={getValues()}
+          taydennys={taydennys}
           muutokset={taydennys.muutokset}
           originalApplication={originalApplication}
+          originalAttachments={originalAttachments ?? []}
         />
       ),
       label: t('form:headers:yhteenveto'),

--- a/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennysContainer.tsx
+++ b/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennysContainer.tsx
@@ -327,7 +327,10 @@ export default function JohtoselvitysTaydennysContainer({
           }
 
           const lastStep = activeStep === formSteps.length - 1;
-          const showSendButton = lastStep && taydennys.muutokset.length > 0 && isValid;
+          const showSendButton =
+            lastStep &&
+            isValid &&
+            (taydennys.muutokset.length > 0 || taydennys.liitteet.length > 0);
           const isContact = isContactIn(signedInUser, getValues('applicationData'));
           const disableSendButton = showSendButton && !isContact;
 

--- a/src/domain/johtoselvitysTaydennys/ReviewAndSend.tsx
+++ b/src/domain/johtoselvitysTaydennys/ReviewAndSend.tsx
@@ -1,26 +1,39 @@
 import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
 import { useTranslation } from 'react-i18next';
-import { FormSummarySection, SectionTitle } from '../forms/components/FormSummarySection';
+import {
+  FormSummarySection,
+  SectionItemContent,
+  SectionItemTitle,
+  SectionTitle,
+} from '../forms/components/FormSummarySection';
 import BasicInformationSummary from '../application/components/summary/JohtoselvitysBasicInformationSummary';
 import AreaSummary from '../johtoselvitys/components/AreaSummary';
 import ContactsSummary from '../application/components/summary/ContactsSummary';
-import { Application, JohtoselvitysData } from '../application/types/application';
+import {
+  Application,
+  ApplicationAttachmentMetadata,
+  JohtoselvitysData,
+} from '../application/types/application';
 import { Box } from '@chakra-ui/react';
 import { Taydennys } from '../application/taydennys/types';
 import TaydennysBasicInformationSummary from '../application/taydennys/components/summary/JohtoselvitysBasicInformationSummary';
 import TaydennysAreaSummary from '../application/taydennys/components/summary/JohtoselvitysAreaSummary';
 import TaydennysContactsSummary from '../application/taydennys/components/summary/JohtoselvitysContactsSummary';
+import AttachmentSummary from '../application/components/summary/AttachmentSummary';
+import TaydennysAttachmentsList from '../application/taydennys/components/TaydennysAttachmentsList';
 
 type Props = {
   taydennys: Taydennys<JohtoselvitysData>;
   muutokset: string[];
   originalApplication: Application<JohtoselvitysData>;
+  originalAttachments: ApplicationAttachmentMetadata[];
 };
 
 export default function ReviewAndSend({
   taydennys,
   muutokset,
   originalApplication,
+  originalAttachments,
 }: Readonly<Props>) {
   const { t } = useTranslation();
 
@@ -47,6 +60,17 @@ export default function ReviewAndSend({
             originalData={originalApplication.applicationData}
             muutokset={muutokset}
           />
+          {taydennys.liitteet?.length > 0 && (
+            <>
+              <SectionTitle>{t('hankePortfolio:tabit:liitteet')}</SectionTitle>
+              <FormSummarySection>
+                <SectionItemTitle>{t('taydennys:labels:addedAttachments')}</SectionItemTitle>
+                <SectionItemContent>
+                  <TaydennysAttachmentsList attachments={taydennys.liitteet} />
+                </SectionItemContent>
+              </FormSummarySection>
+            </>
+          )}
         </Box>
       </TabPanel>
       <TabPanel>
@@ -78,6 +102,10 @@ export default function ReviewAndSend({
               title={t('form:yhteystiedot:titles:representativeWithContacts')}
             />
           </FormSummarySection>
+          <SectionTitle>{t('hankePortfolio:tabit:liitteet')}</SectionTitle>
+          {originalAttachments && originalAttachments.length > 0 ? (
+            <AttachmentSummary attachments={originalAttachments} />
+          ) : null}
         </Box>
       </TabPanel>
     </Tabs>

--- a/src/domain/johtoselvitysTaydennys/types.ts
+++ b/src/domain/johtoselvitysTaydennys/types.ts
@@ -1,9 +1,11 @@
 import { JohtoselvitysFormData } from '../johtoselvitys/types';
+import { TaydennysAttachmentMetadata } from '../application/taydennys/types';
 
 export interface JohtoselvitysTaydennysFormValues {
   id: string;
   applicationData: JohtoselvitysFormData;
   muutokset: string[];
+  liitteet: TaydennysAttachmentMetadata[];
   geometriesChanged?: boolean; // virtualField
   selfIntersectingPolygon?: boolean; // virtualField
 }

--- a/src/domain/johtoselvitysTaydennys/validationSchema.ts
+++ b/src/domain/johtoselvitysTaydennys/validationSchema.ts
@@ -1,4 +1,5 @@
 import yup from '../../common/utils/yup';
+import { TaydennysAttachmentMetadata } from '../application/taydennys/types';
 import { johtoselvitysApplicationDataSchema } from '../johtoselvitys/validationSchema';
 import { JohtoselvitysTaydennysFormValues } from './types';
 
@@ -6,6 +7,7 @@ export const validationSchema: yup.ObjectSchema<JohtoselvitysTaydennysFormValues
   id: yup.string().defined(),
   applicationData: johtoselvitysApplicationDataSchema,
   muutokset: yup.array(yup.string().defined()).defined(),
+  liitteet: yup.array(yup.mixed<TaydennysAttachmentMetadata>().defined()).defined(),
   selfIntersectingPolygon: yup.boolean().isFalse(),
   geometriesChanged: yup.boolean(),
 });

--- a/src/domain/mocks/attachments.ts
+++ b/src/domain/mocks/attachments.ts
@@ -1,0 +1,43 @@
+import { faker } from '@faker-js/faker/.';
+import { TaydennysAttachmentMetadata } from '../application/taydennys/types';
+import { ApplicationAttachmentMetadata, AttachmentType } from '../application/types/application';
+
+function createTaydennysAttachment(taydennysId: string): TaydennysAttachmentMetadata {
+  return {
+    id: faker.string.uuid(),
+    taydennysId,
+    fileName: faker.system.commonFileName('pdf'),
+    attachmentType: faker.helpers.arrayElement<AttachmentType>(['MUU', 'LIIKENNEJARJESTELY']),
+    contentType: 'application/pdf',
+    size: faker.number.int({ min: 1, max: 1000000 }),
+    createdByUserId: faker.string.uuid(),
+    createdAt: faker.date.recent().toISOString(),
+  };
+}
+
+export function createTaydennysAttachments(
+  taydennysId: string,
+  count: number,
+): TaydennysAttachmentMetadata[] {
+  return Array.from({ length: count }, () => createTaydennysAttachment(taydennysId));
+}
+
+function createApplicationAttachment(applicationId: number): ApplicationAttachmentMetadata {
+  return {
+    id: faker.string.uuid(),
+    applicationId,
+    fileName: faker.system.commonFileName('pdf'),
+    attachmentType: faker.helpers.arrayElement<AttachmentType>(['MUU', 'LIIKENNEJARJESTELY']),
+    contentType: 'application/pdf',
+    size: faker.number.int({ min: 1, max: 1000000 }),
+    createdByUserId: faker.string.uuid(),
+    createdAt: faker.date.recent().toISOString(),
+  };
+}
+
+export function createApplicationAttachments(
+  applicationId: number,
+  count: number,
+): ApplicationAttachmentMetadata[] {
+  return Array.from({ length: count }, () => createApplicationAttachment(applicationId));
+}

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -151,6 +151,7 @@ export async function createTaydennys(id: number) {
     id: faker.string.uuid(),
     applicationData: cloneDeep(hakemus.applicationData),
     muutokset: [],
+    liitteet: [],
   };
   hakemus.taydennys = taydennys;
   return taydennys;

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -386,4 +386,13 @@ export const handlers = [
     await hakemuksetDB.cancelTaydennys(id as string);
     return new HttpResponse();
   }),
+
+  http.post(`${apiUrl}/taydennykset/:id/liitteet`, async () => {
+    await delay(500);
+    return new HttpResponse();
+  }),
+
+  http.delete(`${apiUrl}/taydennykset/:id/liitteet/:attachmentId`, async () => {
+    return new HttpResponse();
+  }),
 ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1353,7 +1353,9 @@
       "taydennykset": "Täydennykset",
       "taydennys": "Täydennys",
       "cancelTitle": "Peru täydennysluonnos?",
-      "cancelDescription": "Haluatko varmasti perua täydennyspyyntöön vastaamisen? Tehdyt muutokset poistetaan."
+      "cancelDescription": "Haluatko varmasti perua täydennyspyyntöön vastaamisen? Tehdyt muutokset poistetaan.",
+      "originalAttachments": "Alkuperäiset liitteet",
+      "addedAttachments": "Lisätyt liitetiedostot"
     },
     "buttons": {
       "createTaydennys": "Täydennä",


### PR DESCRIPTION
# Description

Make it possible to add attachments to johtoselvitys täydennys in täydennys form.

Also show original application attachments in attachments page if they exist.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-754

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Try to add attachments to johtoselvitys täydennys
2. Check that added attachments are shown in form attachments and summary pages and in application view
3. Check that possible original attachments are shown also

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
