### PR TITLE
HAI-192 Show nuisance management on kaivuilmoitus summary form page

### DIFF
--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -331,7 +331,7 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
       validationSchema: liitteetSchema,
     },
     {
-      element: <ReviewAndSend attachments={existingAttachments} />,
+      element: <ReviewAndSend hankealueet={hankeData.alueet} attachments={existingAttachments} />,
       label: t('form:headers:yhteenveto'),
       state: StepState.available,
     },

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -512,6 +512,58 @@ test('Should be able to fill form pages and show filled information in summary p
   expect(screen.getByText('Kaistahaittojen pituus: 10-99 m')).toBeInTheDocument();
   expect(screen.getByText('Lisätietoja alueesta: -')).toBeInTheDocument();
 
+  // Nuisance management
+  expect(screen.getByText('Työalueen yleisten haittojen hallintasuunnitelma')).toBeInTheDocument();
+  expect(
+    screen.getByText('Raitioliikenteelle koituvien työalueen haittojen hallintasuunnitelma'),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText('Pyöräliikenteelle koituvien työalueen haittojen hallintasuunnitelma'),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText('Autoliikenteelle koituvien työalueen haittojen hallintasuunnitelma'),
+  ).toBeInTheDocument();
+  expect(screen.getByText('Muiden työalueen haittojen hallintasuunnitelma')).toBeInTheDocument();
+  expect(screen.getByTestId('test-RAITIOLIIKENNE')).toHaveTextContent('1');
+  expect(screen.getByTestId('test-PYORALIIKENNE')).toHaveTextContent('3');
+  expect(screen.getByTestId('test-AUTOLIIKENNE')).toHaveTextContent('1.4');
+  expect(screen.getByTestId('test-LINJAAUTOLIIKENNE')).toHaveTextContent('0');
+  expect(screen.getByText('Yleisten haittojen hallintasuunnitelma')).not.toBeVisible();
+  expect(
+    screen.getByText('Raitioliikenteelle koituvien haittojen hallintasuunnitelma'),
+  ).not.toBeVisible();
+  expect(
+    screen.getByText('Pyöräliikenteelle koituvien haittojen hallintasuunnitelma'),
+  ).not.toBeVisible();
+  expect(
+    screen.getByText('Autoliikenteelle koituvien haittojen hallintasuunnitelma'),
+  ).not.toBeVisible();
+  expect(
+    screen.getByText('Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma'),
+  ).not.toBeVisible();
+  expect(screen.getByText('Muiden haittojen hallintasuunnitelma')).not.toBeVisible();
+  // open "hankealueen haittojen hallinta" accordions
+  await user.click(screen.getAllByText('Hankealueen haittojen hallinta')[0]);
+  expect(screen.getByText('Yleisten haittojen hallintasuunnitelma')).toBeVisible();
+  await user.click(screen.getAllByText('Hankealueen haittojen hallinta')[1]);
+  expect(
+    screen.getByText('Pyöräliikenteelle koituvien haittojen hallintasuunnitelma'),
+  ).toBeVisible();
+  await user.click(screen.getAllByText('Hankealueen haittojen hallinta')[2]);
+  expect(
+    screen.getByText('Autoliikenteelle koituvien haittojen hallintasuunnitelma'),
+  ).toBeVisible();
+  await user.click(screen.getAllByText('Hankealueen haittojen hallinta')[3]);
+  expect(
+    screen.getByText('Raitioliikenteelle koituvien haittojen hallintasuunnitelma'),
+  ).toBeVisible();
+  await user.click(screen.getAllByText('Hankealueen haittojen hallinta')[4]);
+  expect(
+    screen.getByText('Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma'),
+  ).toBeVisible();
+  await user.click(screen.getAllByText('Hankealueen haittojen hallinta')[5]);
+  expect(screen.getByText('Muiden haittojen hallintasuunnitelma')).toBeVisible();
+
   // Contacts information
   expect(screen.getByText(customer.name)).toBeInTheDocument();
   expect(screen.getByText(customer.registryKey)).toBeInTheDocument();

--- a/src/domain/kaivuilmoitus/ReviewAndSend.tsx
+++ b/src/domain/kaivuilmoitus/ReviewAndSend.tsx
@@ -10,15 +10,55 @@ import InvoicingCustomerSummary from '../application/components/summary/Invoicin
 import AttachmentSummary from '../application/components/summary/KaivuilmoitusAttachmentSummary';
 import { ApplicationAttachmentMetadata } from '../application/types/application';
 import AreaSummary from './components/AreaSummary';
+import { HankeAlue } from '../types/hanke';
+import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
+import { HaittojenhallintasuunnitelmaInfo } from './components/HaittojenhallintasuunnitelmaInfo';
+
+const HaittojenhallintaSummary: React.FC<{
+  hankealueet: HankeAlue[];
+  formData: KaivuilmoitusFormValues;
+}> = ({ hankealueet, formData }) => {
+  const { t } = useTranslation();
+  const kaivuilmoitusAlueet = formData.applicationData.areas;
+
+  return (
+    <Tabs>
+      <TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+        {kaivuilmoitusAlueet.map((alue) => {
+          return (
+            <Tab key={alue.hankealueId}>
+              {t('hakemus:labels:workAreaPlural') + ' (' + alue.name + ')'}
+            </Tab>
+          );
+        })}
+      </TabList>
+      {kaivuilmoitusAlueet.map((alue) => {
+        const hankealue = hankealueet?.find((ha) => ha.id === alue.hankealueId);
+        return (
+          <TabPanel key={alue.hankealueId}>
+            <HaittojenhallintasuunnitelmaInfo
+              key={alue.hankealueId}
+              kaivuilmoitusAlue={alue}
+              hankealue={hankealue}
+            />
+          </TabPanel>
+        );
+      })}
+    </Tabs>
+  );
+};
 
 type Props = {
+  hankealueet: HankeAlue[];
   attachments: ApplicationAttachmentMetadata[] | undefined;
 };
 
-export const ReviewAndSend: React.FC<React.PropsWithChildren<Props>> = ({ attachments }) => {
+export const ReviewAndSend: React.FC<React.PropsWithChildren<Props>> = ({
+  hankealueet,
+  attachments,
+}) => {
   const { getValues } = useFormContext<KaivuilmoitusFormValues>();
   const { t } = useTranslation();
-
   const {
     customerWithContacts,
     contractorWithContacts,
@@ -38,6 +78,9 @@ export const ReviewAndSend: React.FC<React.PropsWithChildren<Props>> = ({ attach
 
       <SectionTitle>{t('hankeForm:hankkeenAlueForm:header')}</SectionTitle>
       <AreaSummary formData={getValues()} />
+
+      <SectionTitle>{t('hankePortfolio:tabit:haittojenHallinta')}</SectionTitle>
+      <HaittojenhallintaSummary hankealueet={hankealueet} formData={getValues()} />
 
       <SectionTitle>{t('form:yhteystiedot:header')}</SectionTitle>
       <FormSummarySection>

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.tsx
@@ -9,12 +9,12 @@ import {
 } from '../../forms/components/FormSummarySection';
 import { Box, Grid, GridItem } from '@chakra-ui/react';
 import HankkeenHaittojenhallintasuunnitelma from './HankkeenHaittojenhallintasuunnitelma';
+import Text from '../../../common/components/text/Text';
 import { HAITTOJENHALLINTATYYPPI } from '../../common/haittojenhallinta/types';
 import { KaivuilmoitusAlue } from '../../application/types/application';
 import { HankeAlue } from '../../types/hanke';
 import HaittaIndex from '../../common/haittaIndexes/HaittaIndex';
 import HaittaTooltipContent from '../../common/haittaIndexes/HaittaTooltipContent';
-import Text from '../../../common/components/text/Text';
 
 type LiikennehaitanHallintasuunnitelmaProps = {
   tyyppi: HAITTOJENHALLINTATYYPPI;

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.tsx
@@ -9,12 +9,12 @@ import {
 } from '../../forms/components/FormSummarySection';
 import { Box, Grid, GridItem } from '@chakra-ui/react';
 import HankkeenHaittojenhallintasuunnitelma from './HankkeenHaittojenhallintasuunnitelma';
-import Text from '../../../common/components/text/Text';
 import { HAITTOJENHALLINTATYYPPI } from '../../common/haittojenhallinta/types';
 import { KaivuilmoitusAlue } from '../../application/types/application';
 import { HankeAlue } from '../../types/hanke';
 import HaittaIndex from '../../common/haittaIndexes/HaittaIndex';
 import HaittaTooltipContent from '../../common/haittaIndexes/HaittaTooltipContent';
+import Text from '../../../common/components/text/Text';
 
 type LiikennehaitanHallintasuunnitelmaProps = {
   tyyppi: HAITTOJENHALLINTATYYPPI;


### PR DESCRIPTION
# Description

Show kaivuilmoitus traffic nuisance management information on summary form page.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-192

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Have some nuisance management plans filled in kaivuilmoitus
2. Check the summary form page and the nuisance management plan information there.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
