### PR TITLE
HAI-678 Add maps for each liikennemuoto to kaivuilmoitus haittojenhallinta

### DIFF
--- a/src/common/components/map/Map.tsx
+++ b/src/common/components/map/Map.tsx
@@ -78,7 +78,7 @@ const Map: React.FC<React.PropsWithChildren<Props>> = ({
 
   return (
     <MapContext.Provider value={{ map, layers }}>
-      <div ref={mapRef} className={mapClassName} id="ol-map">
+      <div ref={mapRef} className={mapClassName} id="ol-map" style={{ height: '100%' }}>
         {map && children}
       </div>
     </MapContext.Provider>

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -251,6 +251,10 @@ function KaivuilmoitusAreasInfo({ areas }: { areas: KaivuilmoitusAlue[] | null }
             heading={`${t('kaivuilmoitusForm:alueet:liikennehaittaindeksienYhteenveto')} (0-5)`}
             haittaIndexData={calculateLiikennehaittaindeksienYhteenveto(alue)}
             initiallyOpen
+            autoHaitanKestoHeading={t(
+              'kaivuilmoitusForm:haittojenHallinta:carTrafficNuisanceType:haitanKesto',
+            )}
+            autoHaitanKestoTooltipTranslationKey="hankeIndexes:tooltips:autoTyonKesto"
           />
         </Box>
         <Box as="h2" className="heading-xxs" marginBottom="var(--spacing-m)">

--- a/src/domain/application/applicationView/__snapshots__/ApplicationView.test.tsx.snap
+++ b/src/domain/application/applicationView/__snapshots__/ApplicationView.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`Excavation notification application view Shows correct information in s
       <div
         class="mapContainer__inner"
         id="ol-map"
+        style="height: 100%;"
       />
     </div>
   </div>

--- a/src/domain/common/haittojenhallinta/utils.test.ts
+++ b/src/domain/common/haittojenhallinta/utils.test.ts
@@ -1,4 +1,4 @@
-import { sortedLiikenneHaittojenhallintatyyppi } from './utils';
+import { getHaittaIndexForTyyppi, sortedLiikenneHaittojenhallintatyyppi } from './utils';
 import { HAITTA_INDEX_TYPE, HaittaIndexData } from '../../common/haittaIndexes/types';
 import { HAITTOJENHALLINTATYYPPI } from '../../common/haittojenhallinta/types';
 
@@ -42,4 +42,35 @@ test('Should sort nuisance types in default order if tormaysTarkastelunTulos is 
     [HAITTOJENHALLINTATYYPPI.RAITIOLIIKENNE, 0.0],
     [HAITTOJENHALLINTATYYPPI.LINJAAUTOLIIKENNE, 0.0],
   ]);
+});
+
+describe('getHaittaIndexForTyyppi', () => {
+  const tormaysTarkastelunTulos: HaittaIndexData = {
+    autoliikenne: {
+      indeksi: 2.0,
+      haitanKesto: 1,
+      katuluokka: 1,
+      liikennemaara: 1,
+      kaistahaitta: 1,
+      kaistapituushaitta: 1,
+    },
+    pyoraliikenneindeksi: 5.0,
+    linjaautoliikenneindeksi: 1.0,
+    raitioliikenneindeksi: 0.0,
+    liikennehaittaindeksi: {
+      indeksi: 3.0,
+      tyyppi: HAITTA_INDEX_TYPE.PYORALIIKENNEINDEKSI,
+    },
+  };
+
+  test.each([
+    [HAITTOJENHALLINTATYYPPI.PYORALIIKENNE, 5.0],
+    [HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE, 2.0],
+    [HAITTOJENHALLINTATYYPPI.LINJAAUTOLIIKENNE, 1.0],
+    [HAITTOJENHALLINTATYYPPI.RAITIOLIIKENNE, 0.0],
+  ])('Should return correct haitta index for %s', (haittojenhallintaTyyppi, expected) => {
+    const haittaIndex = getHaittaIndexForTyyppi(tormaysTarkastelunTulos, haittojenhallintaTyyppi);
+
+    expect(haittaIndex).toEqual(expected);
+  });
 });

--- a/src/domain/common/haittojenhallinta/utils.ts
+++ b/src/domain/common/haittojenhallinta/utils.ts
@@ -1,6 +1,10 @@
 import { HAITTA_INDEX_TYPE, HaittaIndexData } from '../haittaIndexes/types';
 import { HAITTOJENHALLINTATYYPPI } from './types';
 
+function getHaittaIndexValue(v: number | { indeksi: number }): number {
+  return typeof v === 'number' ? v : v.indeksi;
+}
+
 /**
  * Sorts HAITTOJENHALLINTATYYPPI based on given tormaystarkasteluTulos.
  * For example, if tormaystarkasteluTulos has {autoliikenneindeksi: 1.0, pyoraliiikenneindeksi: 1.3, linjaautoliikenneindeksi: 0.0, raitioliikenneindeksi: 0.0},
@@ -23,14 +27,10 @@ export function sortedLiikenneHaittojenhallintatyyppi(
     return key.toLowerCase() as keyof HaittaIndexData;
   }
 
-  function value(v: number | { indeksi: number }): number {
-    return typeof v === 'number' ? v : v.indeksi;
-  }
-
   const sortedIndices = Object.values(HAITTA_INDEX_TYPE)
     .map((key) => ({
       type: key.toUpperCase().replace('INDEKSI', '') as HAITTOJENHALLINTATYYPPI,
-      value: value(tormaystarkasteluTulos[keyOfIndexType(key)]),
+      value: getHaittaIndexValue(tormaystarkasteluTulos[keyOfIndexType(key)]),
     }))
     .sort((a, b): number => {
       const diff = b.value - a.value;
@@ -47,4 +47,27 @@ export function mapNuisanceEnumIndexToNuisanceIndex(index: number): number {
   if (index === 2) return 3;
   if (index === 3) return 5;
   return index;
+}
+
+/**
+ * Get haitta index value for given haittojenhallinta tyyppi from tormaystarkasteluTulos
+ */
+export function getHaittaIndexForTyyppi(
+  tormaystarkasteluTulos: HaittaIndexData | null | undefined,
+  haittojenhallintaTyyppi: HAITTOJENHALLINTATYYPPI,
+) {
+  if (!tormaystarkasteluTulos) {
+    return 0;
+  }
+
+  function getKeyOfHaittaIndexTyyppi(tyyppi: HAITTOJENHALLINTATYYPPI): keyof HaittaIndexData {
+    if (tyyppi === HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE) {
+      return 'autoliikenne';
+    }
+    return `${tyyppi.toLowerCase()}indeksi` as keyof HaittaIndexData;
+  }
+
+  return getHaittaIndexValue(
+    tormaystarkasteluTulos[getKeyOfHaittaIndexTyyppi(haittojenhallintaTyyppi)],
+  );
 }

--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -423,6 +423,7 @@ export default function Areas({ hankeData, hankkeenHakemukset }: Readonly<Props>
           {/* Johtoselvitys areas */}
           {selectedJohtoselvitykset.map((hakemus) => (
             <HakemusLayer
+              key={hakemus.id}
               hakemusId={hakemus.id!}
               layerStyle={styleFunction}
               featureProperties={{ statusKey: LIIKENNEHAITTA_STATUS.LAVENDER_BLUE }}

--- a/src/domain/kaivuilmoitus/HaittojenHallinta.tsx
+++ b/src/domain/kaivuilmoitus/HaittojenHallinta.tsx
@@ -4,8 +4,13 @@ import Text from '../../common/components/text/Text';
 import useFieldArrayWithStateUpdate from '../../common/hooks/useFieldArrayWithStateUpdate';
 import { KaivuilmoitusFormValues } from './types';
 import HaittojenhallintaSuunnitelma from './components/HaittojenhallintaSuunnitelma';
+import { HankeData } from '../types/hanke';
 
-export default function HaittojenHallinta() {
+type Props = {
+  hankeData: HankeData;
+};
+
+export default function HaittojenHallinta({ hankeData }: Readonly<Props>) {
   const { t } = useTranslation();
   const { fields: hakemusAlueet } = useFieldArrayWithStateUpdate<
     KaivuilmoitusFormValues,
@@ -40,9 +45,14 @@ export default function HaittojenHallinta() {
           })}
         </TabList>
         {hakemusAlueet.map((alue, index) => {
+          const hankeAlue = hankeData.alueet.find((ha) => ha.id === alue.hankealueId);
           return (
             <TabPanel key={alue.id}>
-              <HaittojenhallintaSuunnitelma kaivuilmoitusAlue={alue} index={index} />
+              <HaittojenhallintaSuunnitelma
+                hankeAlue={hankeAlue!}
+                kaivuilmoitusAlue={alue}
+                index={index}
+              />
             </TabPanel>
           );
         })}

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { FieldPath, FormProvider, useForm } from 'react-hook-form';
 import { merge } from 'lodash';
 import {
@@ -306,7 +306,7 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
       validationSchema: alueetSchema,
     },
     {
-      element: <HaittojenHallinta />,
+      element: <HaittojenHallinta hankeData={hankeData} />,
       label: t('hankeForm:haittojenHallintaForm:header'),
       state: StepState.available,
       validationSchema: haittojenhallintaSuunnitelmaSchema,

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1665,7 +1665,7 @@ describe('Registry key', () => {
 
 describe('Haittojenhallintasuunnitelma', () => {
   async function setupHaittojenHallintaPage(
-    hankeData: HankeData = hankkeet[2] as HankeData,
+    hankeData: HankeData = hankkeet[1] as HankeData,
     application: Application<KaivuilmoitusData> = cloneDeep(
       applications[4] as Application<KaivuilmoitusData>,
     ),

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaMap.module.scss
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaMap.module.scss
@@ -1,0 +1,3 @@
+.overviewMap {
+  bottom: 5px;
+}

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaMap.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaMap.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react';
+import VectorSource from 'ol/source/Vector';
+import { Box, BoxProps } from '@chakra-ui/layout';
+import { Feature } from 'ol';
+import { Geometry } from 'ol/geom';
+import Map from '../../../common/components/map/Map';
+import Kantakartta from '../../map/components/Layers/Kantakartta';
+import AddressSearchContainer from '../../map/components/AddressSearch/AddressSearchContainer';
+import OverviewMapControl from '../../../common/components/map/controls/OverviewMapControl';
+import styles from './HaittojenhallintaMap.module.scss';
+import useHankealueFeature from '../../map/hooks/useHankealueFeature';
+import { HankeAlue } from '../../types/hanke';
+import VectorLayer from '../../../common/components/map/layers/VectorLayer';
+import { styleFunction } from '../../map/utils/geometryStyle';
+import FitSource from '../../map/components/interations/FitSource';
+import { KaivuilmoitusAlue } from '../../application/types/application';
+import { HAITTOJENHALLINTATYYPPI } from '../../common/haittojenhallinta/types';
+import { getHaittaIndexForTyyppi } from '../../common/haittojenhallinta/utils';
+
+interface HaittojenhallintaMapProps extends BoxProps {
+  hankeAlue: HankeAlue;
+  kaivuilmoitusAlue: KaivuilmoitusAlue;
+  haittojenHallintaTyyppi: HAITTOJENHALLINTATYYPPI;
+}
+
+export default function HaittojenhallintaMap({
+  hankeAlue,
+  kaivuilmoitusAlue,
+  haittojenHallintaTyyppi,
+  ...chakraProps
+}: Readonly<HaittojenhallintaMapProps>) {
+  const hankeSource = useRef(new VectorSource());
+  const hankeAlueHaittaIndex = getHaittaIndexForTyyppi(
+    hankeAlue.tormaystarkasteluTulos,
+    haittojenHallintaTyyppi,
+  );
+  useHankealueFeature(hankeSource.current, hankeAlue, hankeAlueHaittaIndex);
+
+  const kaivuilmoitusSource = useRef(new VectorSource());
+  useEffect(() => {
+    kaivuilmoitusSource.current.clear();
+    const applicationFeatures = kaivuilmoitusAlue.tyoalueet.map((tyoalue) => {
+      const tyoalueHaittaIndex = getHaittaIndexForTyyppi(
+        tyoalue.tormaystarkasteluTulos,
+        haittojenHallintaTyyppi,
+      );
+
+      const feature = tyoalue.openlayersFeature?.clone();
+      feature?.setProperties(
+        {
+          liikennehaittaindeksi: tyoalueHaittaIndex,
+        },
+        true,
+      );
+      return feature;
+    }) as Feature<Geometry>[];
+    kaivuilmoitusSource.current.addFeatures(applicationFeatures);
+  }, [kaivuilmoitusSource, kaivuilmoitusAlue.tyoalueet, haittojenHallintaTyyppi]);
+
+  return (
+    <Box height="500px" position="relative" {...chakraProps}>
+      <Map zoom={9}>
+        <Kantakartta />
+        <AddressSearchContainer position={{ top: '1rem', left: '1rem' }} />
+        <OverviewMapControl className={styles.overviewMap} />
+        <FitSource source={hankeSource.current} />
+        <VectorLayer
+          source={hankeSource.current}
+          className="hankeGeometryLayer"
+          style={styleFunction}
+        />
+        <VectorLayer
+          source={kaivuilmoitusSource.current}
+          className="kaivuilmoitusGeometryLayer"
+          style={styleFunction}
+        />
+      </Map>
+    </Box>
+  );
+}

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
@@ -14,15 +14,23 @@ import CustomAccordion from '../../../common/components/customAccordion/CustomAc
 import { HaittaSubSection } from '../../common/haittaIndexes/HaittaSubSection';
 import HaittaIndexHeading from '../../common/haittojenhallinta/HaittaIndexHeading';
 import HaittaTooltipContent from '../../common/haittaIndexes/HaittaTooltipContent';
-import { HANKE_MELUHAITTA, HANKE_POLYHAITTA, HANKE_TARINAHAITTA } from '../../types/hanke';
+import {
+  HANKE_MELUHAITTA,
+  HANKE_POLYHAITTA,
+  HANKE_TARINAHAITTA,
+  HankeAlue,
+} from '../../types/hanke';
 import styles from './HaittojenhallintaSuunnitelma.module.scss';
+import HaittojenhallintaMap from './HaittojenhallintaMap';
 
 type Props = {
+  hankeAlue: HankeAlue;
   kaivuilmoitusAlue: KaivuilmoitusAlue;
   index: number;
 };
 
 export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
+  hankeAlue,
   kaivuilmoitusAlue,
   index,
 }: Readonly<Props>) {
@@ -66,6 +74,12 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
               </Box>
             </Flex>
             <Box mb="var(--spacing-m)">
+              <HaittojenhallintaMap
+                hankeAlue={hankeAlue}
+                kaivuilmoitusAlue={kaivuilmoitusAlue}
+                haittojenHallintaTyyppi={haitta}
+                mb="var(--spacing-m)"
+              />
               {haitta === HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE ? (
                 <CustomAccordion
                   heading={


### PR DESCRIPTION
# Description

Maps show hanke and work areas coloured by corresponding liikennemuoto haittaindex.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-678

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check that haittojenhallinta maps show areas coloured correctly.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
