### PR TITLE
HAI-131 Kaivuilmoitus haittojenhallintatoimet for non-detected liikennemuodot

### DIFF
--- a/src/common/components/customAccordion/CustomAccordion.tsx
+++ b/src/common/components/customAccordion/CustomAccordion.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Grid } from '@chakra-ui/react';
+import { Box, BoxProps, Flex, Grid } from '@chakra-ui/react';
 import { IconAngleDown, IconAngleUp, useAccordion } from 'hds-react';
 import React from 'react';
 
@@ -12,6 +12,7 @@ type Props = {
   headingBackgroundColor?: string;
   headingElement?: React.ReactNode;
   headingSize?: 'm' | 's';
+  headingBoxProps?: BoxProps;
   strong?: boolean;
   initiallyOpen?: boolean;
   className?: string;
@@ -28,6 +29,7 @@ export default function CustomAccordion({
   headingBackgroundColor,
   headingElement,
   headingSize = 'm',
+  headingBoxProps,
   strong = false,
   initiallyOpen = false,
   children,
@@ -52,6 +54,7 @@ export default function CustomAccordion({
         padding="var(--spacing-s)"
         backgroundColor={headingBackgroundColor}
         borderBottom={showHeadingBorderBottom ? '1px solid var(--color-black-30)' : undefined}
+        {...headingBoxProps}
         {...accordionButtonProps}
       >
         <Grid

--- a/src/domain/common/haittojenhallinta/useIsHaittojenhallintaSectionVisible.ts
+++ b/src/domain/common/haittojenhallinta/useIsHaittojenhallintaSectionVisible.ts
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { HAITTOJENHALLINTATYYPPI, Haittojenhallintasuunnitelma } from './types';
+
+/**
+ * Nuisance control plan section for a traffic type should be visible if its index > 0,
+ * or if it has some content.
+ */
+function shouldBeVisible(
+  type: HAITTOJENHALLINTATYYPPI,
+  index: number,
+  haittojenhallintasuunnitelma?: Haittojenhallintasuunnitelma,
+): boolean {
+  return (
+    index > 0 ||
+    (haittojenhallintasuunnitelma ? (haittojenhallintasuunnitelma[type]?.length ?? 0) > 0 : false)
+  );
+}
+
+export default function useIsHaittojenhallintaSectionVisible(
+  haittojenhallintatyypit: [HAITTOJENHALLINTATYYPPI, number][],
+  haittojenhallintasuunnitelma?: Haittojenhallintasuunnitelma,
+) {
+  const liikennehaittatyypit = haittojenhallintatyypit.map(([tyyppi]) => tyyppi);
+  const initialVisibility = liikennehaittatyypit.reduce(
+    (acc, type) => {
+      const found = haittojenhallintatyypit.find((value) => value[0] === type);
+      return {
+        ...acc,
+        [type]: shouldBeVisible(type, found ? found[1] : 0, haittojenhallintasuunnitelma),
+      };
+    },
+    {} as Record<HAITTOJENHALLINTATYYPPI, boolean>,
+  );
+
+  const [isVisible, setIsVisible] =
+    useState<Record<HAITTOJENHALLINTATYYPPI, boolean>>(initialVisibility);
+
+  function setVisible(type: HAITTOJENHALLINTATYYPPI) {
+    setIsVisible((state) => ({ ...state, [type]: true }));
+  }
+
+  return { isVisible, setVisible };
+}

--- a/src/domain/hanke/edit/components/Haittojenhallintasuunnitelma.tsx
+++ b/src/domain/hanke/edit/components/Haittojenhallintasuunnitelma.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Box, Flex } from '@chakra-ui/react';
 import { $enum } from 'ts-enum-util';
@@ -20,31 +20,14 @@ import styles from './Haittojenhallintasuunnitelma.module.scss';
 import ProcedureTips from '../../../common/haittaIndexes/ProcedureTips';
 import HaittaTooltipContent from '../../../common/haittaIndexes/HaittaTooltipContent';
 import { Button, IconPlusCircle } from 'hds-react';
-import {
-  HAITTOJENHALLINTATYYPPI,
-  Haittojenhallintasuunnitelma,
-} from '../../../common/haittojenhallinta/types';
+import { HAITTOJENHALLINTATYYPPI } from '../../../common/haittojenhallinta/types';
 import {
   mapNuisanceEnumIndexToNuisanceIndex,
   sortedLiikenneHaittojenhallintatyyppi,
 } from '../../../common/haittojenhallinta/utils';
 import TrafficIcon from '../../../common/haittojenhallinta/TrafficIcon';
 import HaittaIndexHeading from '../../../common/haittojenhallinta/HaittaIndexHeading';
-
-/**
- * Nuisance control plan section for a traffic type should be visible if its index > 0,
- * or if it has some content.
- */
-function shouldBeVisible(
-  type: HAITTOJENHALLINTATYYPPI,
-  index: number,
-  haittojenhallintasuunnitelma?: Haittojenhallintasuunnitelma,
-): boolean {
-  return (
-    index > 0 ||
-    (haittojenhallintasuunnitelma ? (haittojenhallintasuunnitelma[type]?.length ?? 0) > 0 : false)
-  );
-}
+import useIsHaittojenhallintaSectionVisible from '../../../common/haittojenhallinta/useIsHaittojenhallintaSectionVisible';
 
 type Props = {
   hanke: HankeData;
@@ -60,7 +43,6 @@ const HankkeenHaittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke
   const tormaystarkasteluTulos = hankealue.tormaystarkasteluTulos as HaittaIndexData;
   const haittojenhallintasuunnitelma = hankealue.haittojenhallintasuunnitelma;
   const haittojenhallintatyypit = sortedLiikenneHaittojenhallintatyyppi(tormaystarkasteluTulos);
-  const liikennehaittatyypit = haittojenhallintatyypit.map(([tyyppi]) => tyyppi);
   const addressCoordinate = useAddressCoordinate(hanke.tyomaaKatuosoite);
   const meluhaittaIndex = mapNuisanceEnumIndexToNuisanceIndex(
     $enum(HANKE_MELUHAITTA).indexOfKey(hankealue.meluHaitta!),
@@ -71,18 +53,10 @@ const HankkeenHaittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke
   const tarinaHaittaIndex = mapNuisanceEnumIndexToNuisanceIndex(
     $enum(HANKE_TARINAHAITTA).indexOfKey(hankealue.tarinaHaitta!),
   );
-  const initialVisibility = liikennehaittatyypit.reduce(
-    (acc, type) => {
-      const found = haittojenhallintatyypit.find((value) => value[0] === type);
-      return {
-        ...acc,
-        [type]: shouldBeVisible(type, found ? found[1] : 0, haittojenhallintasuunnitelma),
-      };
-    },
-    {} as Record<HAITTOJENHALLINTATYYPPI, boolean>,
+  const { isVisible, setVisible } = useIsHaittojenhallintaSectionVisible(
+    haittojenhallintatyypit,
+    haittojenhallintasuunnitelma,
   );
-  const [isVisible, setVisible] =
-    useState<Record<HAITTOJENHALLINTATYYPPI, boolean>>(initialVisibility);
 
   return (
     <div>
@@ -221,7 +195,7 @@ const HankkeenHaittojenhallintasuunnitelma: React.FC<Readonly<Props>> = ({ hanke
               <Button
                 variant="supplementary"
                 iconLeft={<IconPlusCircle aria-hidden />}
-                onClick={() => setVisible((state) => ({ ...state, [haitta]: true }))}
+                onClick={() => setVisible(haitta)}
               >
                 {t('hankeForm:haittojenHallintaForm:addControlPlan')}
               </Button>

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1756,8 +1756,13 @@ describe('Haittojenhallintasuunnitelma', () => {
     expect(screen.getByText('Linja-autojen paikallisliikenne')).toBeInTheDocument();
     expect(screen.queryByTestId('test-LINJAAUTOLIIKENNE')).toHaveTextContent('0');
     expect(
-      screen.getByTestId('applicationData.areas.0.haittojenhallintasuunnitelma.LINJAAUTOLIIKENNE'),
-    ).not.toBeRequired();
+      screen.getByText(
+        'Haitaton ei löytänyt tätä kohderyhmää alueelta. Voit tarvittaessa lisätä toimet haittojen hallintaan.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Lisää toimet haittojen hallintaan' }),
+    ).toBeInTheDocument();
     expect(
       screen.getByText('Raitioliikenteelle koituvien työalueen haittojen hallintasuunnitelma'),
     ).toBeInTheDocument();
@@ -1814,5 +1819,19 @@ describe('Haittojenhallintasuunnitelma', () => {
     );
 
     applicationUpdateSpy.mockClear();
+  });
+
+  test('Non-detected nuisance field is shown correctly on nuisance control plan page', async () => {
+    const { user } = await setupHaittojenHallintaPage();
+
+    await user.click(screen.getByRole('button', { name: /lisää toimet haittojen hallintaan/i }));
+
+    expect(screen.getByTestId('test-LINJAAUTOLIIKENNE')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('applicationData.areas.0.haittojenhallintasuunnitelma.LINJAAUTOLIIKENNE'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('applicationData.areas.0.haittojenhallintasuunnitelma.LINJAAUTOLIIKENNE'),
+    ).not.toBeRequired();
   });
 });

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { $enum } from 'ts-enum-util';
 import { Box, Flex } from '@chakra-ui/layout';
+import { Button, IconPlusCircle } from 'hds-react';
 import TextArea from '../../../common/components/textArea/TextArea';
 import { KaivuilmoitusAlue } from '../../application/types/application';
 import { HAITTOJENHALLINTATYYPPI } from '../../common/haittojenhallinta/types';
@@ -22,6 +23,7 @@ import {
 } from '../../types/hanke';
 import styles from './HaittojenhallintaSuunnitelma.module.scss';
 import HaittojenhallintaMap from './HaittojenhallintaMap';
+import useIsHaittojenhallintaSectionVisible from '../../common/haittojenhallinta/useIsHaittojenhallintaSectionVisible';
 
 type Props = {
   hankeAlue: HankeAlue;
@@ -45,6 +47,10 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
   );
   const tarinaHaittaIndex = mapNuisanceEnumIndexToNuisanceIndex(
     $enum(HANKE_TARINAHAITTA).indexOfKey(kaivuilmoitusAlue.tarinahaitta!),
+  );
+  const { isVisible, setVisible } = useIsHaittojenhallintaSectionVisible(
+    haittojenhallintatyypit,
+    kaivuilmoitusAlue.haittojenhallintasuunnitelma,
   );
 
   return (
@@ -92,6 +98,7 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
                     />
                   }
                   headingBorderBottom={false}
+                  headingBoxProps={{ paddingLeft: 0 }}
                 >
                   <HaittaSubSection
                     heading={t(
@@ -153,13 +160,28 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
                 />
               )}
             </Box>
-            <TextArea
-              name={`applicationData.areas.${index}.haittojenhallintasuunnitelma.${haitta}`}
-              label={t(`kaivuilmoitusForm:haittojenHallinta:labels:${haitta}`)}
-              testId={`applicationData.areas.${index}.haittojenhallintasuunnitelma.${haitta}`}
-              required={indeksi > 0}
-              helperText={t('kaivuilmoitusForm:haittojenHallinta:helperText')}
-            />
+            {isVisible[haitta] ? (
+              <TextArea
+                name={`applicationData.areas.${index}.haittojenhallintasuunnitelma.${haitta}`}
+                label={t(`kaivuilmoitusForm:haittojenHallinta:labels:${haitta}`)}
+                testId={`applicationData.areas.${index}.haittojenhallintasuunnitelma.${haitta}`}
+                required={indeksi > 0}
+                helperText={t('kaivuilmoitusForm:haittojenHallinta:helperText')}
+              />
+            ) : (
+              <>
+                <Box as="p" mb="var(--spacing-s)">
+                  {t('hankeForm:haittojenHallintaForm:noNuisanceDetected')}
+                </Box>
+                <Button
+                  variant="supplementary"
+                  iconLeft={<IconPlusCircle />}
+                  onClick={() => setVisible(haitta)}
+                >
+                  {t('hankeForm:haittojenHallintaForm:addControlPlan')}
+                </Button>
+              </>
+            )}
           </Box>
         );
       })}


### PR DESCRIPTION
# Description

If Haitaton has not detected nuisances for some liikennemuoto text that nuisance is not detected and a button to add haittojenhallintatoimet is shown. If user presses the button field to add haittojenhallintatoimet is shown instead.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-131

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Add work areas to kaivuilmoitus in such way that some liikennemuoto has a haittaindex 0, for example pyöräliikenne
2. Check in the haittojenhallinta page that for that liikennemuoto there is a text "Haitaton ei löytänyt tätä kohderyhmää alueelta. Voit tarvittaessa lisätä toimet haittojen hallintaan." and a button "Lisää toimet haittojen hallintaan"
3. Click the button
4. The text and the button should be replaced with text area

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
