### PR TITLE
HAI-3349 Hide hanke areas of generated hanke in johtoselvitys application view

### DIFF
--- a/src/domain/application/applicationView/Sidebar.tsx
+++ b/src/domain/application/applicationView/Sidebar.tsx
@@ -77,14 +77,16 @@ export default function Sidebar({ hanke, application }: Readonly<SidebarProps>) 
   function getHankeWithAlueetFilteredByDates(hankeData: HankeData): HankeData {
     return {
       ...hankeData,
-      alueet: filterHankeAlueet(hankeData.alueet),
+      // Do not show hanke alueet for generated hanke
+      alueet: !hankeData.generated ? filterHankeAlueet(hankeData.alueet) : [],
     };
   }
 
   function getHankeWithAlueetFilteredByDatesForTaydennys(hankeData: HankeData): HankeData {
     return {
       ...hankeData,
-      alueet: filterHankeAlueetForTaydennys(hankeData.alueet),
+      // Do not show hanke alueet for generated hanke
+      alueet: !hankeData.generated ? filterHankeAlueetForTaydennys(hankeData.alueet) : [],
     };
   }
 


### PR DESCRIPTION
# Description

Hanke areas for generated hanke would cause confusion especially in johtoselvitys taydennys. For that reason if hanke is generated hanke areas are not shown at all in johtoselvitys application view.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3349

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
