### PR TITLE
HAI-3295 Add attachments page to kaivuilmoitus taydennys form

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -665,7 +665,10 @@ describe('Cable report application view', () => {
 
     test('Shows changed information in attachments tab', async () => {
       const taydennysId = 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c';
-      const taydennysAttachments = createTaydennysAttachments(taydennysId, 2);
+      const taydennysAttachments = createTaydennysAttachments(taydennysId, [
+        { attachmentType: 'MUU' },
+        { attachmentType: 'MUU' },
+      ]);
       const application = cloneDeep(hakemukset[10] as Application<JohtoselvitysData>);
       application.taydennys = {
         id: taydennysId,

--- a/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennys.test.tsx
+++ b/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennys.test.tsx
@@ -26,8 +26,14 @@ import * as taydennysAttachmentsApi from '../application/taydennys/taydennysAtta
 import * as applicationAttachmentsApi from '../application/attachments';
 import { createApplicationAttachments, createTaydennysAttachments } from '../mocks/attachments';
 
-const applicationAttachments = createApplicationAttachments(11, 2);
-const taydennysAttachments = createTaydennysAttachments('c0a1fe7b-326c-4b25-a7bc-d1797762c01c', 2);
+const applicationAttachments = createApplicationAttachments(11, [
+  { attachmentType: 'MUU' },
+  { attachmentType: 'MUU' },
+]);
+const taydennysAttachments = createTaydennysAttachments('c0a1fe7b-326c-4b25-a7bc-d1797762c01c', [
+  { attachmentType: 'MUU' },
+  { attachmentType: 'MUU' },
+]);
 
 function setup(
   options: {

--- a/src/domain/kaivuilmoitusTaydennys/Attachments.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/Attachments.tsx
@@ -1,0 +1,225 @@
+import { Trans, useTranslation } from 'react-i18next';
+import { Link, Notification } from 'hds-react';
+import { Box, Flex } from '@chakra-ui/react';
+import { useQueryClient } from 'react-query';
+import { useFormContext } from 'react-hook-form';
+import FileUpload from '../../common/components/fileUpload/FileUpload';
+import {
+  deleteAttachment,
+  getAttachmentFile,
+  uploadAttachment,
+} from '../application/taydennys/taydennysAttachmentsApi';
+import { getAttachmentFile as getApplicationAttachmentFile } from '../application/attachments';
+import FileDownloadList from '../../common/components/fileDownloadList/FileDownloadList';
+import {
+  FormSummarySection,
+  SectionItemContent,
+  SectionItemTitle,
+} from '../forms/components/FormSummarySection';
+import { ApplicationAttachmentMetadata } from '../application/types/application';
+import { TaydennysAttachmentMetadata } from '../application/taydennys/types';
+import { KaivuilmoitusTaydennysFormValues } from './types';
+import TextArea from '../../common/components/textArea/TextArea';
+import { AttachmentMetadata } from '../../common/types/attachment';
+
+type Props = {
+  applicationId: number;
+  taydennysAttachments: TaydennysAttachmentMetadata[];
+  originalAttachments?: ApplicationAttachmentMetadata[];
+  onFileUpload: (isUploading: boolean) => void;
+};
+
+export default function Attachments({
+  applicationId,
+  taydennysAttachments,
+  originalAttachments,
+  onFileUpload,
+}: Readonly<Props>) {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+  const { getValues } = useFormContext<KaivuilmoitusTaydennysFormValues>();
+  const originalTrafficArrangementPlans = originalAttachments?.filter(
+    (attachment) => attachment.attachmentType === 'LIIKENNEJARJESTELY',
+  );
+  const originalMandates = originalAttachments?.filter(
+    (attachment) => attachment.attachmentType === 'VALTAKIRJA',
+  );
+  const originalOtherAttachments = originalAttachments?.filter(
+    (attachment) => attachment.attachmentType === 'MUU',
+  );
+
+  function downloadOriginalAttachment(file: ApplicationAttachmentMetadata) {
+    return getApplicationAttachmentFile(applicationId, file.id);
+  }
+
+  function handleFileUpload(uploading: boolean) {
+    onFileUpload(uploading);
+    if (!uploading) {
+      queryClient.invalidateQueries(['application', applicationId]);
+    }
+  }
+
+  function downloadTaydennysAttachment(file: AttachmentMetadata) {
+    return getAttachmentFile(getValues('id')!, file.id);
+  }
+
+  function deleteFile(file: AttachmentMetadata) {
+    return deleteAttachment({ taydennysId: getValues('id'), attachmentId: file?.id });
+  }
+
+  function handleFileDelete() {
+    queryClient.invalidateQueries(['application', applicationId]);
+  }
+
+  return (
+    <Box mb="var(--spacing-l)">
+      <Flex direction="column" gap="var(--spacing-m)" mb="var(--spacing-m)">
+        <Trans
+          i18nKey="kaivuilmoitusForm:liitteetJaLisatiedot:instructions"
+          components={{
+            a: (
+              <Link
+                href="https://www.hel.fi/static/hkr/luvat/tyyppikuvat/Tyyppikuvat.pdf"
+                openInNewTab
+              >
+                Helsingin kaupungin tyyppikuvat
+              </Link>
+            ),
+          }}
+        />
+      </Flex>
+
+      {originalAttachments && originalAttachments.length > 0 && (
+        <FormSummarySection>
+          <SectionItemTitle>
+            {t('kaivuilmoitusForm:liitteetJaLisatiedot:originalTrafficArrangementPlan')}
+          </SectionItemTitle>
+          <SectionItemContent>
+            {originalTrafficArrangementPlans && originalTrafficArrangementPlans.length > 0 && (
+              <FileDownloadList
+                files={originalTrafficArrangementPlans}
+                download={downloadOriginalAttachment}
+              />
+            )}
+          </SectionItemContent>
+          <SectionItemTitle>
+            {t('kaivuilmoitusForm:liitteetJaLisatiedot:originalMandate')}
+          </SectionItemTitle>
+          <SectionItemContent>
+            {originalMandates && originalMandates.length > 0 && (
+              <FileDownloadList files={originalMandates} />
+            )}
+          </SectionItemContent>
+          <SectionItemTitle>
+            {t('kaivuilmoitusForm:liitteetJaLisatiedot:originalOtherAttachments')}
+          </SectionItemTitle>
+          <SectionItemContent>
+            {originalOtherAttachments && originalOtherAttachments.length > 0 && (
+              <FileDownloadList
+                files={originalOtherAttachments}
+                download={downloadOriginalAttachment}
+              />
+            )}
+          </SectionItemContent>
+        </FormSummarySection>
+      )}
+
+      <Box as="h2" className="heading-m" marginBottom="var(--spacing-s)">
+        {t('kaivuilmoitusForm:liitteetJaLisatiedot:trafficArrangementPlan')}
+      </Box>
+      <FileUpload
+        id="excavation-notification-file-upload-traffic-arrangement-plan"
+        accept=".pdf"
+        maxSize={104857600}
+        dragAndDrop
+        multiple
+        existingAttachments={taydennysAttachments?.filter(
+          (metadata) => metadata.attachmentType === 'LIIKENNEJARJESTELY',
+        )}
+        maxFilesNumber={20}
+        uploadFunction={({ file, abortSignal }) =>
+          uploadAttachment({
+            taydennysId: getValues('id')!,
+            attachmentType: 'LIIKENNEJARJESTELY',
+            file,
+            abortSignal,
+          })
+        }
+        onUpload={handleFileUpload}
+        fileDownLoadFunction={downloadTaydennysAttachment}
+        fileDeleteFunction={deleteFile}
+        onFileDelete={handleFileDelete}
+      />
+
+      <Box as="h2" className="heading-m" marginBottom="var(--spacing-s)">
+        {t('kaivuilmoitusForm:liitteetJaLisatiedot:mandate')}
+      </Box>
+      <Notification
+        size="small"
+        type="info"
+        label={t('kaivuilmoitusForm:liitteetJaLisatiedot:mandateCheck')}
+        style={{ marginTop: 'var(--spacing-s)', marginBottom: 'var(--spacing-s)' }}
+      >
+        {t('kaivuilmoitusForm:liitteetJaLisatiedot:mandateInfo')}
+      </Notification>
+      <FileUpload
+        id="excavation-notification-file-upload-mandate"
+        accept=".pdf"
+        maxSize={104857600}
+        dragAndDrop
+        multiple
+        existingAttachments={taydennysAttachments?.filter(
+          (metadata) => metadata.attachmentType === 'VALTAKIRJA',
+        )}
+        maxFilesNumber={20}
+        uploadFunction={({ file, abortSignal }) =>
+          uploadAttachment({
+            taydennysId: getValues('id')!,
+            attachmentType: 'VALTAKIRJA',
+            file,
+            abortSignal,
+          })
+        }
+        onUpload={handleFileUpload}
+        fileDeleteFunction={deleteFile}
+        onFileDelete={handleFileDelete}
+      />
+
+      <Box as="h2" className="heading-m" marginBottom="var(--spacing-s)">
+        {t('kaivuilmoitusForm:liitteetJaLisatiedot:otherAttachments')}
+      </Box>
+      <FileUpload
+        id="excavation-notification-file-upload-other-attachments"
+        accept=".pdf,.jpg,.jpeg,.png,.dgn,.dwg,.docx,.txt,.gt"
+        maxSize={104857600}
+        dragAndDrop
+        multiple
+        existingAttachments={taydennysAttachments?.filter(
+          (metadata) => metadata.attachmentType === 'MUU',
+        )}
+        maxFilesNumber={20}
+        uploadFunction={({ file, abortSignal }) =>
+          uploadAttachment({
+            taydennysId: getValues('id')!,
+            attachmentType: 'MUU',
+            file,
+            abortSignal,
+          })
+        }
+        onUpload={handleFileUpload}
+        fileDownLoadFunction={downloadTaydennysAttachment}
+        fileDeleteFunction={deleteFile}
+        onFileDelete={handleFileDelete}
+      />
+
+      <Box as="h2" className="heading-m" marginBottom="var(--spacing-s)">
+        {t('kaivuilmoitusForm:liitteetJaLisatiedot:additionalInformation')}
+      </Box>
+      <TextArea
+        name="applicationData.additionalInfo"
+        label={t('hakemus:labels:additionalInformation')}
+        maxLength={2000}
+      />
+    </Box>
+  );
+}

--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennys.test.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennys.test.tsx
@@ -1,13 +1,33 @@
 import { cloneDeep } from 'lodash';
-import { Application, KaivuilmoitusData } from '../application/types/application';
+import { UserEvent } from '@testing-library/user-event';
+import {
+  Application,
+  ApplicationAttachmentMetadata,
+  AttachmentType,
+  KaivuilmoitusData,
+} from '../application/types/application';
 import { HankeData } from '../types/hanke';
 import hankkeet from '../mocks/data/hankkeet-data';
 import hakemukset from '../mocks/data/hakemukset-data';
 import { server } from '../mocks/test-server';
 import { HttpResponse, http } from 'msw';
-import { Taydennys } from '../application/taydennys/types';
-import { fireEvent, render, screen } from '../../testUtils/render';
+import { Taydennys, TaydennysAttachmentMetadata } from '../application/taydennys/types';
+import { act, fireEvent, render, screen, waitFor, within } from '../../testUtils/render';
 import KaivuilmoitusTaydennysContainer from './KaivuilmoitusTaydennysContainer';
+import { createApplicationAttachments, createTaydennysAttachments } from '../mocks/attachments';
+import api from '../api/api';
+import * as taydennysAttachmentsApi from '../application/taydennys/taydennysAttachmentsApi';
+import * as applicationAttachmentsApi from '../application/attachments';
+
+const applicationAttachments = createApplicationAttachments(13, [
+  { attachmentType: 'LIIKENNEJARJESTELY' },
+  { attachmentType: 'MUU' },
+]);
+const taydennysAttachments = createTaydennysAttachments('c0a1fe7b-326c-4b25-a7bc-d1797762c01d', [
+  { attachmentType: 'LIIKENNEJARJESTELY' },
+  { attachmentType: 'VALTAKIRJA' },
+  { attachmentType: 'MUU' },
+]);
 
 function setup(
   options: {
@@ -53,6 +73,47 @@ function setup(
     ),
     application,
   };
+}
+
+async function fillAttachments(
+  user: UserEvent,
+  options: {
+    trafficArrangementPlanFiles?: File[];
+    mandateFiles?: File[];
+    otherFiles?: File[];
+    additionalInfo?: string;
+  } = {},
+) {
+  const {
+    trafficArrangementPlanFiles = [
+      new File(['Liikennejärjestelyt'], 'liikennejärjestelyt.pdf', { type: 'application/pdf' }),
+    ],
+    mandateFiles = [],
+    otherFiles = [],
+    additionalInfo = 'Lisätietoja',
+  } = options;
+
+  const fileUploads = await screen.findAllByLabelText('Raahaa tiedostot tänne');
+  if (trafficArrangementPlanFiles) {
+    const fileUpload = fileUploads[0];
+    await user.upload(fileUpload, trafficArrangementPlanFiles);
+  }
+
+  if (mandateFiles) {
+    const fileUpload = fileUploads[1];
+    await user.upload(fileUpload, mandateFiles);
+  }
+
+  if (otherFiles) {
+    const fileUpload = fileUploads[2];
+    await user.upload(fileUpload, otherFiles);
+  }
+
+  if (additionalInfo) {
+    fireEvent.change(screen.getByLabelText(/lisätietoja hakemuksesta/i), {
+      target: { value: additionalInfo },
+    });
+  }
 }
 
 describe('Saving the form', () => {
@@ -121,5 +182,124 @@ describe('Canceling taydennys', () => {
     expect(await screen.findByText('Täydennysluonnos peruttiin')).toBeInTheDocument();
     expect(screen.getByText('Täydennysluonnos peruttiin onnistuneesti')).toBeInTheDocument();
     expect(window.location.pathname).toBe('/fi/hakemus/13');
+  });
+});
+
+describe('Taydennys attachments', () => {
+  async function uploadAttachmentMock({
+    taydennysId,
+    attachmentType,
+    file,
+    abortSignal,
+  }: {
+    taydennysId: string;
+    attachmentType: AttachmentType;
+    file: File;
+    abortSignal?: AbortSignal;
+  }) {
+    const { data } = await api.post<TaydennysAttachmentMetadata>(
+      `/taydennykset/${taydennysId}/liitteet?tyyppi=${attachmentType}`,
+      { liite: file },
+      {
+        signal: abortSignal,
+      },
+    );
+    return data;
+  }
+
+  function initFileGetResponse(response: ApplicationAttachmentMetadata[]) {
+    server.use(
+      http.get('/api/hakemukset/:id/liitteet', async () => {
+        return HttpResponse.json(response);
+      }),
+    );
+  }
+
+  test('Should be able to upload attachments', async () => {
+    const uploadSpy = jest
+      .spyOn(taydennysAttachmentsApi, 'uploadAttachment')
+      .mockImplementation(uploadAttachmentMock);
+    initFileGetResponse([]);
+    const { user } = setup();
+    await user.click(screen.getByRole('button', { name: /liitteet/i }));
+    await fillAttachments(user, {
+      trafficArrangementPlanFiles: [
+        new File(['liikennejärjestelyt'], 'liikennejärjestelyt.pdf', { type: 'application/pdf' }),
+      ],
+      mandateFiles: [new File(['valtakirja'], 'valtakirja.pdf', { type: 'application/pdf' })],
+      otherFiles: [new File(['muu'], 'muu.png', { type: 'image/png' })],
+    });
+    await act(async () => {
+      waitFor(() => expect(screen.queryAllByText('Tallennetaan tiedostoja')).toHaveLength(0));
+    });
+    await waitFor(
+      () => {
+        expect(screen.queryAllByText('1/1 tiedosto(a) tallennettu')).toHaveLength(3);
+      },
+      { timeout: 5000 },
+    );
+    expect(uploadSpy).toHaveBeenCalledTimes(3);
+  });
+
+  test('Should be able to delete attachments', async () => {
+    initFileGetResponse([]);
+    const testApplication = cloneDeep(hakemukset[12]) as Application<KaivuilmoitusData>;
+    testApplication.taydennys = {
+      id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+      applicationData: testApplication.applicationData,
+      muutokset: [],
+      liitteet: taydennysAttachments,
+    };
+    const { user } = setup({
+      application: testApplication,
+      taydennys: testApplication.taydennys,
+    });
+    await user.click(screen.getByRole('button', { name: /liitteet/i }));
+
+    taydennysAttachments.forEach((attachment) => {
+      expect(screen.getByText(attachment.fileName)).toBeInTheDocument();
+    });
+
+    const fileUploadLists = screen.getAllByTestId('file-upload-list');
+    let index = 0;
+    for (const fileUploadList of fileUploadLists) {
+      const metadata = taydennysAttachments[index++];
+      const { getAllByRole } = within(fileUploadList);
+      const fileListItems = getAllByRole('listitem');
+      const fileItem = fileListItems.find((i) => i.innerHTML.includes(metadata.fileName));
+      const { getByRole } = within(fileItem!);
+      await user.click(getByRole('button', { name: 'Poista' }));
+      const { getByRole: getByRoleInDialog, getByText: getByTextInDialog } = within(
+        await screen.findByRole('dialog'),
+      );
+
+      expect(
+        getByTextInDialog(`Haluatko varmasti poistaa liitetiedoston ${metadata.fileName}`),
+      ).toBeInTheDocument();
+      await user.click(getByRoleInDialog('button', { name: 'Poista' }));
+      expect(screen.getByText(`Liitetiedosto ${metadata.fileName} poistettu`)).toBeInTheDocument();
+    }
+  });
+
+  test('Should show original application attachments in attachments page', async () => {
+    const fetchContentMock = jest
+      .spyOn(applicationAttachmentsApi, 'getAttachmentFile')
+      .mockImplementation(jest.fn());
+    initFileGetResponse(applicationAttachments);
+    const { user } = setup();
+    await user.click(screen.getByRole('button', { name: /liitteet/i }));
+
+    expect(
+      screen.getByText('Alkuperäiset tilapäisiä liikennejärjestelyitä koskevat suunnitelmat'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Alkuperäinen valtakirja')).toBeInTheDocument();
+    expect(screen.getByText('Alkuperäiset muut liitteet')).toBeInTheDocument();
+    applicationAttachments.forEach((attachment) => {
+      expect(screen.getByText(attachment.fileName)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText(applicationAttachments[0].fileName));
+
+    expect(fetchContentMock).toHaveBeenCalledWith(13, applicationAttachments[0].id);
   });
 });

--- a/src/domain/kaivuilmoitusTaydennys/types.ts
+++ b/src/domain/kaivuilmoitusTaydennys/types.ts
@@ -1,3 +1,4 @@
+import { TaydennysAttachmentMetadata } from '../application/taydennys/types';
 import { KaivuilmoitusFormValues } from '../kaivuilmoitus/types';
 
 export interface KaivuilmoitusTaydennysFormValues
@@ -15,4 +16,5 @@ export interface KaivuilmoitusTaydennysFormValues
   > {
   id: string;
   muutokset: string[];
+  liitteet: TaydennysAttachmentMetadata[];
 }

--- a/src/domain/kaivuilmoitusTaydennys/validationSchema.ts
+++ b/src/domain/kaivuilmoitusTaydennys/validationSchema.ts
@@ -1,11 +1,13 @@
 import yup from '../../common/utils/yup';
 import { applicationDataSchema } from '../kaivuilmoitus/validationSchema';
 import { KaivuilmoitusTaydennysFormValues } from './types';
+import { TaydennysAttachmentMetadata } from '../application/taydennys/types';
 
 export const validationSchema: yup.ObjectSchema<KaivuilmoitusTaydennysFormValues> = yup.object({
   id: yup.string().defined(),
   applicationData: applicationDataSchema,
   muutokset: yup.array(yup.string().defined()).defined(),
+  liitteet: yup.array(yup.mixed<TaydennysAttachmentMetadata>().defined()).defined(),
   selfIntersectingPolygon: yup.boolean().isFalse(),
   geometriesChanged: yup.boolean(),
 });

--- a/src/domain/mocks/attachments.ts
+++ b/src/domain/mocks/attachments.ts
@@ -2,42 +2,42 @@ import { faker } from '@faker-js/faker/.';
 import { TaydennysAttachmentMetadata } from '../application/taydennys/types';
 import { ApplicationAttachmentMetadata, AttachmentType } from '../application/types/application';
 
-function createTaydennysAttachment(taydennysId: string): TaydennysAttachmentMetadata {
-  return {
-    id: faker.string.uuid(),
-    taydennysId,
-    fileName: faker.system.commonFileName('pdf'),
-    attachmentType: faker.helpers.arrayElement<AttachmentType>(['MUU', 'LIIKENNEJARJESTELY']),
-    contentType: 'application/pdf',
-    size: faker.number.int({ min: 1, max: 1000000 }),
-    createdByUserId: faker.string.uuid(),
-    createdAt: faker.date.recent().toISOString(),
+function createAttachment(
+  id: number | string,
+  attachment: Partial<ApplicationAttachmentMetadata | TaydennysAttachmentMetadata>,
+): ApplicationAttachmentMetadata | TaydennysAttachmentMetadata {
+  const metadata = {
+    id: attachment.id ?? faker.string.uuid(),
+    fileName: attachment.fileName ?? faker.system.commonFileName('pdf'),
+    attachmentType:
+      attachment.attachmentType ??
+      faker.helpers.arrayElement<AttachmentType>(['MUU', 'LIIKENNEJARJESTELY', 'VALTAKIRJA']),
+    contentType: attachment.contentType ?? 'application/pdf',
+    size: attachment.size ?? faker.number.int({ min: 1, max: 1000000 }),
+    createdByUserId: attachment.createdByUserId ?? faker.string.uuid(),
+    createdAt: attachment.createdAt ?? faker.date.recent().toISOString(),
   };
+
+  if (typeof id === 'number') {
+    return { ...metadata, applicationId: id } as ApplicationAttachmentMetadata;
+  }
+  return { ...metadata, taydennysId: id } as TaydennysAttachmentMetadata;
 }
 
 export function createTaydennysAttachments(
   taydennysId: string,
-  count: number,
+  attachments: Partial<TaydennysAttachmentMetadata>[],
 ): TaydennysAttachmentMetadata[] {
-  return Array.from({ length: count }, () => createTaydennysAttachment(taydennysId));
-}
-
-function createApplicationAttachment(applicationId: number): ApplicationAttachmentMetadata {
-  return {
-    id: faker.string.uuid(),
-    applicationId,
-    fileName: faker.system.commonFileName('pdf'),
-    attachmentType: faker.helpers.arrayElement<AttachmentType>(['MUU', 'LIIKENNEJARJESTELY']),
-    contentType: 'application/pdf',
-    size: faker.number.int({ min: 1, max: 1000000 }),
-    createdByUserId: faker.string.uuid(),
-    createdAt: faker.date.recent().toISOString(),
-  };
+  return attachments.map((attachment) =>
+    createAttachment(taydennysId, attachment),
+  ) as TaydennysAttachmentMetadata[];
 }
 
 export function createApplicationAttachments(
   applicationId: number,
-  count: number,
+  attachments: Partial<ApplicationAttachmentMetadata>[],
 ): ApplicationAttachmentMetadata[] {
-  return Array.from({ length: count }, () => createApplicationAttachment(applicationId));
+  return attachments.map((attachment) =>
+    createAttachment(applicationId, attachment),
+  ) as ApplicationAttachmentMetadata[];
 }

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1073,7 +1073,10 @@
       "mandateCheck": "Tarkista valtakirja",
       "mandateInfo": "Tietosuojasyistä hakemukselle lisättyä valtakirjaa ei enää tallennuksen jälkeen pääse katselemaan. Tarkistathan ennen lisäämistä, että kyseinen valtakirja on oikea.",
       "otherAttachments": "Muut liitteet",
-      "additionalInformation": "Lisätiedot"
+      "additionalInformation": "Lisätiedot",
+      "originalTrafficArrangementPlan": "Alkuperäiset tilapäisiä liikennejärjestelyitä koskevat suunnitelmat",
+      "originalMandate": "Alkuperäinen valtakirja",
+      "originalOtherAttachments": "Alkuperäiset muut liitteet"
     },
     "yhteenveto": {
       "instructions": "Tarkista antamasi tiedot ja lähetä ilmoitus käsittelyyn."


### PR DESCRIPTION
# Description

Attachments page shows original attachments added to kaivuilmoitus. It's also possible to add new attachments and remove those.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3295

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Try to add attachments to kaivuilmoitus täydennys
2. Check that possible original attachments are shown also

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
