### PR TITLE
HAI-3296 Add Cancel button on kaivuilmoitus täydennys form

### DIFF
--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
@@ -141,7 +141,7 @@ export default function KaivuilmoitusTaydennysContainer({
       validationSchema: alueetSchema,
     },
     {
-      element: <HaittojenHallinta />,
+      element: <HaittojenHallinta hankeData={hankeData} />,
       label: t('hankeForm:haittojenHallintaForm:header'),
       state: StepState.available,
       validationSchema: haittojenhallintaSuunnitelmaSchema,

--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
@@ -33,6 +33,7 @@ import { useGlobalNotification } from '../../common/components/globalNotificatio
 import useNavigateToApplicationView from '../application/hooks/useNavigateToApplicationView';
 import { changeFormStep } from '../forms/utils';
 import ApplicationSaveNotification from '../application/components/ApplicationSaveNotification';
+import TaydennysCancel from '../application/taydennys/components/TaydennysCancel';
 
 type Props = {
   taydennys: Taydennys<KaivuilmoitusData>;
@@ -235,6 +236,13 @@ export default function KaivuilmoitusTaydennysContainer({
               onPrevious={handlePrevious}
               onNext={handleNext}
             >
+              <TaydennysCancel
+                application={originalApplication}
+                navigateToApplicationViewOnSuccess
+                buttonVariant="danger"
+                buttonIsLoading={saveAndQuitIsLoading}
+                buttonIsLoadingText={saveAndQuitLoadingText}
+              />
               <Button
                 variant="secondary"
                 onClick={handleSaveAndQuit}


### PR DESCRIPTION
# Description

Add Cancel button on kaivuilmoitus täydennys form

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3296

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create a täydennyspyyntö for kaivuilmoitus
2. Open täydennys form
3. There should be cancel button which should bring the user back to application view and remove the täydennys

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
