### PR TITLE
HAI-3369 Use UBI9 base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,44 @@
-FROM public.ecr.aws/docker/library/node:20-alpine as staticbuilder
+FROM registry.access.redhat.com/ubi9/nodejs-20:latest AS staticbuilder
+
+USER root
+RUN npm install --ignore-scripts -g yarn
+
 COPY . /builder/
 WORKDIR /builder
+RUN chown -R default:root /builder
+
+USER default
+
 RUN yarn && yarn cache clean --force
 RUN REACT_APP_DISABLE_SENTRY=0 yarn build
 
-FROM public.ecr.aws/docker/library/nginx:1.22.1
-# Install mods for nginx that include the Headers More mod, that allows the
-# removal of the Server -header
-RUN apt-get update && apt-get --no-install-recommends install -y nginx-extras && apt-get clean
+FROM registry.access.redhat.com/ubi9/nginx-124:latest
 EXPOSE 8000
 COPY --from=staticbuilder ./builder/build /usr/share/nginx/html
 WORKDIR /usr/share/nginx/html
-
-# Create the environment file so that the user that will run the backend has
-# permission to overwrite the config based on environment variables.
-RUN touch env-config.js
-RUN chmod a+rw env-config.js
 
 # Copy default environment config and setup script
 # Copy package.json so env.sh can read it
 COPY --from=staticbuilder ./builder/scripts/env.sh /opt/env.sh
 COPY --from=staticbuilder ./builder/.env /opt/.env
 COPY --from=staticbuilder ./builder/package.json /opt/package.json
-RUN chmod +x /opt/env.sh
 
 # Copy script that injects environment variables to nginx.conf
 COPY ./scripts/nginx-env.sh /opt/nginx-env.sh
 # The script copies /opt/nginx.conf to /etc/nginx/nginx.conf
 # while replacing the environment variables
 COPY --from=staticbuilder ./builder/nginx/nginx.conf /opt/nginx.conf
-RUN chmod +x /opt/nginx-env.sh
 
-RUN chmod a+w /etc/nginx/nginx.conf
+USER root
+# Create the environment file so that the user that will run the backend has
+# permission to overwrite the config based on environment variables.
+RUN touch env-config.js && \
+    chmod a+rw env-config.js && \
+# Set permissions for running scripts and updating the config
+    chmod +x /opt/env.sh && \
+    chmod +x /opt/nginx-env.sh && \
+    chmod a+w /etc/nginx/nginx.conf
+USER default
 
 ENV REACT_APP_DISABLE_SENTRY=0
 

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,8 +1,17 @@
-FROM public.ecr.aws/docker/library/node:20-alpine as staticbuilder
+FROM registry.access.redhat.com/ubi9/nodejs-20:latest AS staticbuilder
+
+USER root
+RUN npm install -g yarn
+
 # Copy files needed for downloading dependencies
 COPY ./package.json /builder/package.json
 COPY ./yarn.lock /builder/yarn.lock
 WORKDIR /builder
+
+RUN chown -R default:root /builder
+
+USER default
+
 # The sources are not copied yet, so this step is cached between different builds
 # with modified sources, as long as the files above have not changed.
 RUN yarn && yarn cache clean --force
@@ -16,10 +25,7 @@ COPY ./tsconfig.eslint.json /builder/tsconfig.eslint.json
 COPY ./.eslintrc.js /builder/.eslintrc.js
 RUN REACT_APP_DISABLE_SENTRY=1 yarn build
 
-FROM public.ecr.aws/docker/library/nginx:1.22.1
-# Install mods for nginx that include the Headers More mod, that allows the
-# removal of the Server -header
-RUN apt-get update && apt-get --no-install-recommends install -y nginx-extras && apt-get clean
+FROM registry.access.redhat.com/ubi9/nginx-124:latest
 EXPOSE 8000
 COPY --from=staticbuilder ./builder/build /usr/share/nginx/html
 WORKDIR /usr/share/nginx/html
@@ -29,7 +35,6 @@ WORKDIR /usr/share/nginx/html
 COPY ./scripts/env.sh /opt/env.sh
 COPY .env /opt/.env
 COPY package.json /opt/package.json
-RUN chmod +x /opt/env.sh
 
 #COPY ./nginx/variables.conf /etc/nginx/templates/10-variables.conf.template
 
@@ -38,7 +43,10 @@ COPY ./scripts/nginx-env.sh /opt/nginx-env.sh
 # The script copies /opt/nginx.conf to /etc/nginx/nginx.conf
 # while replacing the environment variables
 COPY ./nginx/nginx.conf /opt/nginx.conf
+USER root
+RUN chmod +x /opt/env.sh
 RUN chmod +x /opt/nginx-env.sh
+USER default
 
 ENV REACT_APP_DISABLE_SENTRY=1
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,4 @@
-load_module modules/ngx_http_headers_more_filter_module.so;
+#load_module modules/ngx_http_headers_more_filter_module.so;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;
@@ -22,8 +22,7 @@ http {
     fastcgi_temp_path       /tmp/fastcgi_temp;
     uwsgi_temp_path         /tmp/uwsgi_temp;
     scgi_temp_path          /tmp/scgi_temp;
-    server_tokens           off; # hides version on 404 or 500 pages
-    more_clear_headers      Server; # removes Server header from response headers
+    server_tokens           off; # hides version nginx from Server-header
 
     server {
         listen          8000;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,3 @@
-#load_module modules/ngx_http_headers_more_filter_module.so;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;


### PR DESCRIPTION
# Description

Use the Red Hat Universal Base Image 9 based images for building the
image for haitaton-ui.

NOTE: The headers more module can not be installed on RHEL without a
commercial nginx subscription, so we can't remove the server header from
responses. The version of the nginx will still be hidden.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3369

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Other