### PR TITLE
HAI-3325 Add send button for kaivuilmoitus taydennys

### DIFF
--- a/src/domain/application/applicationView/hooks/useSendTaydennys.tsx
+++ b/src/domain/application/applicationView/hooks/useSendTaydennys.tsx
@@ -3,6 +3,7 @@ import { Button, IconEnvelope, IconQuestionCircle, Notification } from 'hds-reac
 import { useTranslation } from 'react-i18next';
 import { AlluStatus, Application } from '../../types/application';
 import { validationSchema as johtoselvitysValidationSchema } from '../../../johtoselvitysTaydennys/validationSchema';
+import { validationSchema as kaivuilmoitusValidationSchema } from '../../../kaivuilmoitusTaydennys/validationSchema';
 import ConfirmationDialog from '../../../../common/components/HDSConfirmationDialog/ConfirmationDialog';
 import useIsInformationRequestFeatureEnabled from '../../taydennys/hooks/useIsInformationRequestFeatureEnabled';
 import useSendTaydennysMutation from '../../taydennys/hooks/useSendTaydennys';
@@ -11,7 +12,7 @@ import { SignedInUser } from '../../../hanke/hankeUsers/hankeUser';
 
 const validationSchemas = {
   CABLE_REPORT: johtoselvitysValidationSchema,
-  EXCAVATION_NOTIFICATION: null,
+  EXCAVATION_NOTIFICATION: kaivuilmoitusValidationSchema,
 };
 
 export default function useSendTaydennys(

--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennys.test.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennys.test.tsx
@@ -19,6 +19,7 @@ import api from '../api/api';
 import * as taydennysAttachmentsApi from '../application/taydennys/taydennysAttachmentsApi';
 import * as applicationAttachmentsApi from '../application/attachments';
 import { HAITTA_INDEX_TYPE, HaittaIndexData } from '../common/haittaIndexes/types';
+import { SignedInUser } from '../hanke/hankeUsers/hankeUser';
 
 const applicationAttachments = createApplicationAttachments(13, [
   { attachmentType: 'LIIKENNEJARJESTELY' },
@@ -183,6 +184,111 @@ describe('Taydennyspyynto notification', () => {
 
     expect(screen.getByRole('heading', { name: 'Täydennyspyyntö' })).toBeInTheDocument();
     expect(screen.getByText('Muokkaa hakemusta korjataksesi seuraavat asiat:')).toBeInTheDocument();
+  });
+});
+
+describe('Sending taydennys', () => {
+  test('Should be able to send the form', async () => {
+    const { user } = setup({
+      taydennys: {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>)
+          .applicationData,
+        muutokset: ['name'],
+        liitteet: [],
+      },
+    });
+    await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
+    await user.click(screen.getByRole('button', { name: /lähetä täydennys/i }));
+    await user.click(await screen.findByRole('button', { name: /vahvista/i }));
+
+    expect(await screen.findByText(/täydennys lähetetty/i)).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/fi/hakemus/13');
+  });
+
+  test('Should show error message if sending fails', async () => {
+    const { user } = setup({
+      taydennys: {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>)
+          .applicationData,
+        muutokset: ['name'],
+        liitteet: [],
+      },
+      responseStatus: 500,
+    });
+    await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
+    await user.click(screen.getByRole('button', { name: /lähetä täydennys/i }));
+    await user.click(await screen.findByRole('button', { name: /vahvista/i }));
+
+    expect(screen.getByText(/täydennyksen lähettäminen epäonnistui/i)).toBeInTheDocument();
+  });
+
+  test('Should not show send button if there are no changes', async () => {
+    const { user } = setup({
+      taydennys: {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>)
+          .applicationData,
+        muutokset: [],
+        liitteet: [],
+      },
+    });
+    await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
+
+    expect(screen.queryByRole('button', { name: /lähetä täydennys/i })).not.toBeInTheDocument();
+  });
+
+  test('Should not show send button if form is not valid', async () => {
+    const { user } = setup({
+      taydennys: {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>)
+          .applicationData,
+        muutokset: ['workDescription'],
+        liitteet: [],
+      },
+    });
+
+    // Change work description to invalid value
+    fireEvent.change(screen.getByLabelText(/työn kuvaus/i), {
+      target: { value: '' },
+    });
+    await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
+
+    expect(screen.queryByRole('button', { name: /lähetä täydennys/i })).not.toBeInTheDocument();
+  });
+
+  test('Should show and disable send button and show notification when user is not a contact person', async () => {
+    server.use(
+      http.get('/api/hankkeet/:hankeTunnus/whoami', async () => {
+        return HttpResponse.json<SignedInUser>({
+          hankeKayttajaId: 'not-a-contact-person-id',
+          kayttooikeustaso: 'KATSELUOIKEUS',
+          kayttooikeudet: ['VIEW'],
+        });
+      }),
+    );
+
+    const { user } = setup({
+      taydennys: {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>)
+          .applicationData,
+        muutokset: ['name'],
+        liitteet: [],
+      },
+    });
+
+    await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
+
+    expect(screen.queryByRole('button', { name: /lähetä täydennys/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /lähetä täydennys/i })).toBeDisabled();
+    expect(
+      screen.queryAllByText(
+        'Hakemuksen voi lähettää ainoastaan hakemuksen yhteyshenkilönä oleva henkilö.',
+      ),
+    ).toHaveLength(2);
   });
 });
 

--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
@@ -2,7 +2,14 @@ import { useState } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FieldPath, FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { Button, IconSaveDiskette, StepState } from 'hds-react';
+import {
+  Button,
+  IconEnvelope,
+  IconQuestionCircle,
+  IconSaveDiskette,
+  Notification,
+  StepState,
+} from 'hds-react';
 import { useQueryClient } from 'react-query';
 import { Box } from '@chakra-ui/layout';
 import { KaivuilmoitusTaydennysFormValues } from './types';
@@ -42,6 +49,10 @@ import FormFieldsErrorSummary from '../forms/components/FormFieldsErrorSummary';
 import { mapValidationErrorToErrorListItem } from '../kaivuilmoitus/mapValidationErrorToErrorListItem';
 import { useFormErrorsByPage } from '../kaivuilmoitus/hooks/useFormErrorsByPage';
 import ReviewAndSend from './ReviewAndSend';
+import { isContactIn } from '../application/utils';
+import useSendTaydennys from '../application/taydennys/hooks/useSendTaydennys';
+import { usePermissionsForHanke } from '../hanke/hankeUsers/hooks/useUserRightsForHanke';
+import ConfirmationDialog from '../../common/components/HDSConfirmationDialog/ConfirmationDialog';
 
 type Props = {
   taydennys: Taydennys<KaivuilmoitusData>;
@@ -65,6 +76,9 @@ export default function KaivuilmoitusTaydennysContainer({
         hakemus.applicationType === 'CABLE_REPORT' && Boolean(hakemus.applicationIdentifier),
     )
     .map((hakemus) => hakemus.applicationIdentifier!);
+  const sendTaydennysMutation = useSendTaydennys();
+  const [showSendDialog, setShowSendDialog] = useState(false);
+  const { data: signedInUser } = usePermissionsForHanke(hankeData.hankeTunnus);
   const { data: originalAttachments } = useAttachments(originalApplication.id);
   const [attachmentsUploading, setAttachmentsUploading] = useState(false);
   const attachmentsUploadingText: string = t('common:components:fileUpload:loadingText');
@@ -81,7 +95,8 @@ export default function KaivuilmoitusTaydennysContainer({
     setValue,
     watch,
     trigger,
-    formState: { isDirty },
+    formState: { isDirty, isValid },
+    handleSubmit,
   } = formContext;
   const watchFormValues = watch();
 
@@ -247,6 +262,23 @@ export default function KaivuilmoitusTaydennysContainer({
     saveTaydennys(handleSuccess);
   }
 
+  function openSendDialog() {
+    setShowSendDialog(true);
+  }
+
+  function closeSendDialog() {
+    setShowSendDialog(false);
+  }
+
+  function sendTaydennys() {
+    sendTaydennysMutation.mutate(taydennys.id, {
+      onSuccess(data) {
+        navigateToApplicationView(data.id?.toString());
+      },
+    });
+    closeSendDialog();
+  }
+
   function validateStepChange(changeStep: () => void, stepIndex: number) {
     return changeFormStep(changeStep, pageFieldsToValidate[stepIndex] || [], trigger);
   }
@@ -271,6 +303,7 @@ export default function KaivuilmoitusTaydennysContainer({
         isLoadingText={attachmentsUploadingText}
         onStepChange={handleStepChange}
         stepChangeValidator={validateStepChange}
+        onSubmit={handleSubmit(openSendDialog)}
       >
         {function renderFormActions(activeStep, handlePrevious, handleNext) {
           async function handleSaveAndQuit() {
@@ -282,6 +315,14 @@ export default function KaivuilmoitusTaydennysContainer({
               saveAndQuit();
             }
           }
+
+          const lastStep = activeStepIndex === formSteps.length - 1;
+          const showSendButton =
+            lastStep &&
+            isValid &&
+            (taydennys.muutokset.length > 0 || taydennys.liitteet.length > 0);
+          const isContact = isContactIn(signedInUser, getValues('applicationData'));
+          const disableSendButton = showSendButton && !isContact;
 
           const saveAndQuitIsLoading = taydennysUpdateMutation.isLoading || attachmentsUploading;
           const saveAndQuitLoadingText = attachmentsUploading
@@ -315,6 +356,27 @@ export default function KaivuilmoitusTaydennysContainer({
               >
                 {t('hankeForm:saveDraftButton')}
               </Button>
+              {showSendButton && (
+                <Button
+                  type="submit"
+                  iconLeft={<IconEnvelope aria-hidden="true" />}
+                  loadingText={t('common:buttons:sendingText')}
+                  isLoading={sendTaydennysMutation.isLoading}
+                  disabled={disableSendButton}
+                >
+                  {t('taydennys:buttons:sendTaydennys')}
+                </Button>
+              )}
+              {disableSendButton && (
+                <Notification
+                  size="small"
+                  style={{ marginTop: 'var(--spacing-xs)' }}
+                  type="info"
+                  label={t('hakemus:notifications:sendApplicationDisabled')}
+                >
+                  {t('hakemus:notifications:sendApplicationDisabled')}
+                </Notification>
+              )}
             </FormActions>
           );
         }}
@@ -326,6 +388,17 @@ export default function KaivuilmoitusTaydennysContainer({
           onClose={() => setShowSaveNotification(false)}
         />
       )}
+
+      <ConfirmationDialog
+        title={t('taydennys:sendDialog:title')}
+        description={t('taydennys:sendDialog:description')}
+        showCloseButton
+        isOpen={showSendDialog}
+        close={closeSendDialog}
+        mainAction={sendTaydennys}
+        variant="primary"
+        headerIcon={<IconQuestionCircle />}
+      />
     </FormProvider>
   );
 }


### PR DESCRIPTION
# Description

Show "Lähetä täydennys" button in kaivuilmoitus form summary page and in application view.
Also, added tests for sending + copied other täydennys tests from johtoselvitys täydennys.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3325

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create a täydennys for kaivuilmoitus
2. Make some changes in täydennys
3. Check that "Lähetä täydennys" button is shown in summary page and in application view

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
