### PR TITLE
HAI-3322 Add summary page to kaivuilmoitus taydennys form

### DIFF
--- a/src/domain/application/taydennys/components/TaydennysAttachmentsList.tsx
+++ b/src/domain/application/taydennys/components/TaydennysAttachmentsList.tsx
@@ -4,12 +4,16 @@ import { TaydennysAttachmentMetadata } from '../types';
 
 type Props = {
   attachments: TaydennysAttachmentMetadata[];
+  allowDownload?: boolean;
 };
 
-export default function TaydennysAttachmentsList({ attachments }: Readonly<Props>) {
+export default function TaydennysAttachmentsList({
+  attachments,
+  allowDownload = true,
+}: Readonly<Props>) {
   function download(file: TaydennysAttachmentMetadata) {
     return getAttachmentFile(file.taydennysId, file.id);
   }
 
-  return <FileDownloadList files={attachments} download={download} />;
+  return <FileDownloadList files={attachments} download={allowDownload ? download : undefined} />;
 }

--- a/src/domain/application/taydennys/components/summary/ContactsSummary.test.tsx
+++ b/src/domain/application/taydennys/components/summary/ContactsSummary.test.tsx
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
-import JohtoselvitysContactsSummary from './JohtoselvitysContactsSummary';
-import { JohtoselvitysData } from '../../../types/application';
+import ContactsSummary from './ContactsSummary';
+import { JohtoselvitysData, KaivuilmoitusData } from '../../../types/application';
 import applications from '../../../../mocks/data/hakemukset-data';
 import { render, screen } from '../../../../../testUtils/render';
 
@@ -58,17 +58,21 @@ const mockData: JohtoselvitysData = {
   },
 };
 
-describe('JohtoselvitysContactsSummary', () => {
+const kaivuilmoitusTestApplication = cloneDeep(
+  applications[12].applicationData as KaivuilmoitusData,
+);
+
+describe('ContactsSummary', () => {
   test('renders nothing if no changes are detected', () => {
     const { container } = render(
-      <JohtoselvitysContactsSummary data={mockData} originalData={mockData} muutokset={[]} />,
+      <ContactsSummary data={mockData} originalData={mockData} muutokset={[]} />,
     );
     expect(container).toBeEmptyDOMElement();
   });
 
   test('renders customer with contacts change correctly', () => {
     render(
-      <JohtoselvitysContactsSummary
+      <ContactsSummary
         data={{
           ...mockData,
           customerWithContacts: {
@@ -94,7 +98,7 @@ describe('JohtoselvitysContactsSummary', () => {
 
   test('renders contractor with contacts change correctly', () => {
     render(
-      <JohtoselvitysContactsSummary
+      <ContactsSummary
         data={{
           ...mockData,
           contractorWithContacts: {
@@ -120,7 +124,7 @@ describe('JohtoselvitysContactsSummary', () => {
 
   test('renders property developer with contacts change correctly', () => {
     render(
-      <JohtoselvitysContactsSummary
+      <ContactsSummary
         data={{
           ...mockData,
           propertyDeveloperWithContacts: {
@@ -153,7 +157,7 @@ describe('JohtoselvitysContactsSummary', () => {
 
   test('renders representative with contacts change correctly', () => {
     render(
-      <JohtoselvitysContactsSummary
+      <ContactsSummary
         data={{
           ...mockData,
           representativeWithContacts: {
@@ -186,7 +190,7 @@ describe('JohtoselvitysContactsSummary', () => {
 
   test('renders removed property developer with contacts correctly', () => {
     render(
-      <JohtoselvitysContactsSummary
+      <ContactsSummary
         data={{ ...mockData, propertyDeveloperWithContacts: null }}
         originalData={mockData}
         muutokset={['propertyDeveloperWithContacts']}
@@ -213,7 +217,7 @@ describe('JohtoselvitysContactsSummary', () => {
 
   test('renders removed representative with contacts correctly', () => {
     render(
-      <JohtoselvitysContactsSummary
+      <ContactsSummary
         data={{ ...mockData, representativeWithContacts: null }}
         originalData={mockData}
         muutokset={['representativeWithContacts']}
@@ -236,5 +240,27 @@ describe('JohtoselvitysContactsSummary', () => {
       expect(screen.getByText(contact.email)).toBeInTheDocument();
       expect(screen.getByText(contact.phone)).toBeInTheDocument();
     });
+  });
+
+  test('renders invoicing customer change correctly', () => {
+    render(
+      <ContactsSummary
+        data={{
+          ...kaivuilmoitusTestApplication,
+          invoicingCustomer: {
+            ...kaivuilmoitusTestApplication.invoicingCustomer!,
+            name: 'New invoicing customer',
+          },
+        }}
+        originalData={kaivuilmoitusTestApplication}
+        muutokset={['invoicingCustomer']}
+      />,
+    );
+
+    expect(screen.getByText('Laskutustiedot')).toBeInTheDocument();
+    expect(screen.getByText('New invoicing customer')).toBeInTheDocument();
+    expect(
+      screen.getByText(kaivuilmoitusTestApplication.invoicingCustomer!.registryKey!),
+    ).toBeInTheDocument();
   });
 });

--- a/src/domain/application/taydennys/components/summary/ContactsSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/ContactsSummary.tsx
@@ -1,19 +1,20 @@
 import { useTranslation } from 'react-i18next';
-import { JohtoselvitysData } from '../../../types/application';
+import { JohtoselvitysData, KaivuilmoitusData } from '../../../types/application';
 import {
   FormSummarySection,
   SectionItemContentRemoved,
   SectionTitle,
 } from '../../../../forms/components/FormSummarySection';
 import ContactsSummary from '../../../components/summary/ContactsSummary';
+import InvoicingCustomerSummary from '../../../components/summary/InvoicingCustomerSummary';
 
 type Props = {
-  data: JohtoselvitysData;
-  originalData: JohtoselvitysData;
+  data: JohtoselvitysData | KaivuilmoitusData;
+  originalData: JohtoselvitysData | KaivuilmoitusData;
   muutokset: string[];
 };
 
-export default function JohtoselvitysContactsSummary({
+export default function TaydennysContactsSummary({
   data,
   originalData,
   muutokset,
@@ -25,16 +26,20 @@ export default function JohtoselvitysContactsSummary({
     propertyDeveloperWithContacts,
     representativeWithContacts,
   } = data;
+  const invoicingCustomer = (data as KaivuilmoitusData).invoicingCustomer;
+
   const customerWithContactsChanged = muutokset.includes('customerWithContacts');
   const contractorWithContactsChanged = muutokset.includes('contractorWithContacts');
   const propertyDeveloperWithContactsChanged = muutokset.includes('propertyDeveloperWithContacts');
   const representativeWithContactsChanged = muutokset.includes('representativeWithContacts');
+  const invoicingCustomerChanged = muutokset.includes('invoicingCustomer');
 
   if (
     !customerWithContactsChanged &&
     !contractorWithContactsChanged &&
     !propertyDeveloperWithContactsChanged &&
-    !representativeWithContactsChanged
+    !representativeWithContactsChanged &&
+    !invoicingCustomerChanged
   ) {
     return null;
   }
@@ -74,6 +79,9 @@ export default function JohtoselvitysContactsSummary({
             title={t('form:yhteystiedot:titles:representativeWithContacts')}
             ContentContainer={!representativeWithContacts ? SectionItemContentRemoved : undefined}
           />
+        )}
+        {invoicingCustomerChanged && (
+          <InvoicingCustomerSummary invoicingCustomer={invoicingCustomer} />
         )}
       </FormSummarySection>
     </>

--- a/src/domain/application/taydennys/components/summary/KaivuilmoitusAreaSummary.test.tsx
+++ b/src/domain/application/taydennys/components/summary/KaivuilmoitusAreaSummary.test.tsx
@@ -1,0 +1,126 @@
+import { cloneDeep } from 'lodash';
+import KaivuilmoitusAreaSummary from './KaivuilmoitusAreaSummary';
+import { KaivuilmoitusData } from '../../../types/application';
+import applications from '../../../../mocks/data/hakemukset-data';
+import { render, screen } from '../../../../../testUtils/render';
+
+const testApplication = cloneDeep(applications[12].applicationData as KaivuilmoitusData);
+
+const mockData: KaivuilmoitusData = {
+  ...testApplication,
+  startTime: new Date('2024-08-01'),
+  endTime: new Date('2024-08-31'),
+};
+
+describe('Kaivuilmoitus taydennys AreaSummary', () => {
+  test('renders nothing if no changes', () => {
+    const { container } = render(
+      <KaivuilmoitusAreaSummary data={mockData} originalData={mockData} muutokset={[]} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders start time change', () => {
+    render(
+      <KaivuilmoitusAreaSummary
+        data={{ ...mockData, startTime: new Date('2024-08-02') }}
+        originalData={mockData}
+        muutokset={['startTime']}
+      />,
+    );
+
+    expect(screen.getByText('2.8.2024')).toBeInTheDocument();
+  });
+
+  test('renders end time change', () => {
+    render(
+      <KaivuilmoitusAreaSummary
+        data={{ ...mockData, endTime: new Date('2024-08-29') }}
+        originalData={mockData}
+        muutokset={['endTime']}
+      />,
+    );
+
+    expect(screen.getByText('29.8.2024')).toBeInTheDocument();
+  });
+
+  test('renders area changes', () => {
+    render(
+      <KaivuilmoitusAreaSummary
+        data={{
+          ...mockData,
+          areas: [
+            {
+              ...mockData.areas[0],
+              katuosoite: 'Aidasmäentie 6',
+              tyonTarkoitukset: ['VIEMARI', 'KAUKOLAMPO'],
+              meluhaitta: 'JATKUVA_MELUHAITTA',
+              polyhaitta: 'SATUNNAINEN_POLYHAITTA',
+              tarinahaitta: 'EI_TARINAHAITTAA',
+              kaistahaitta: 'USEITA_AJOSUUNTIA_POISTUU_KAYTOSTA',
+              kaistahaittojenPituus: 'PITUUS_ALLE_10_METRIA',
+              lisatiedot: 'Lorem ipsum',
+            },
+          ],
+        }}
+        originalData={mockData}
+        muutokset={[
+          'areas[0]',
+          'areas[0].tyoalueet[0]',
+          'areas[0].tyoalueet[0].geometry',
+          'areas[0].katuosoite',
+          'areas[0].tyonTarkoitukset',
+          'areas[0].meluhaitta',
+          'areas[0].polyhaitta',
+          'areas[0].tarinahaitta',
+          'areas[0].kaistahaitta',
+          'areas[0].kaistahaittojenPituus',
+          'areas[0].lisatiedot',
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.tagName === 'P' && element?.textContent === 'Työalueet (Hankealue 2)',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Työalue 1 (158 m²)')).toBeInTheDocument();
+    expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
+    expect(screen.getByText('Pinta-ala: 188 m²')).toBeInTheDocument();
+    expect(screen.getByText('Katuosoite: Aidasmäentie 6')).toBeInTheDocument();
+    expect(screen.getByText('Työn tarkoitus: Viemäri, Kaukolämpö')).toBeInTheDocument();
+    expect(screen.getByText('Meluhaitta: Jatkuva meluhaitta')).toBeInTheDocument();
+    expect(screen.getByText('Pölyhaitta: Satunnainen pölyhaitta')).toBeInTheDocument();
+    expect(screen.getByText('Tärinähaitta: Ei tärinähaittaa')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Autoliikenteen kaistahaitta: Useita autoliikenteen ajosuuntia poistuu käytöstä',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Kaistahaittojen pituus: Alle 10 m')).toBeInTheDocument();
+    expect(screen.getByText('Lisätietoja alueesta: Lorem ipsum')).toBeInTheDocument();
+  });
+
+  test('renders removed areas', () => {
+    render(
+      <KaivuilmoitusAreaSummary
+        data={{ ...mockData, areas: [] }}
+        originalData={mockData}
+        muutokset={['areas[0]']}
+      />,
+    );
+
+    expect(screen.getByText(/poistettu/i)).toBeInTheDocument();
+    expect(screen.getByText('Työalue 1 (158 m²)')).toBeInTheDocument();
+    expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
+    expect(screen.getByText('Pinta-ala: 188 m²')).toBeInTheDocument();
+    expect(screen.getByText('Katuosoite: Aidasmäentie 5')).toBeInTheDocument();
+    expect(screen.getByText('Työn tarkoitus: Vesi')).toBeInTheDocument();
+    expect(screen.getByText('Meluhaitta: Toistuva meluhaitta')).toBeInTheDocument();
+    expect(screen.getByText('Pölyhaitta: Jatkuva pölyhaitta')).toBeInTheDocument();
+    expect(screen.getByText('Tärinähaitta: Satunnainen tärinähaitta')).toBeInTheDocument();
+  });
+});

--- a/src/domain/application/taydennys/components/summary/KaivuilmoitusAreaSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/KaivuilmoitusAreaSummary.tsx
@@ -1,0 +1,218 @@
+import { useTranslation } from 'react-i18next';
+import { Geometry } from 'ol/geom';
+import { Box } from '@chakra-ui/layout';
+import { differenceBy } from 'lodash';
+import { KaivuilmoitusAlue, KaivuilmoitusData } from '../../../types/application';
+import { PartialExcept } from '../../../../../common/types/utils';
+import {
+  FormSummarySection,
+  SectionItemContent,
+  SectionItemContentRemoved,
+  SectionItemTitle,
+  SectionTitle,
+} from '../../../../forms/components/FormSummarySection';
+import { formatToFinnishDate } from '../../../../../common/utils/date';
+import { getAreaGeometry } from '../../../../johtoselvitys/utils';
+import { formatSurfaceArea, getTotalSurfaceArea } from '../../../../map/utils';
+import { getAreaDefaultName } from '../../../utils';
+
+function AreaDetail({ area }: Readonly<{ area: PartialExcept<KaivuilmoitusAlue, 'tyoalueet'> }>) {
+  const { t } = useTranslation();
+
+  const totalSurfaceArea = getTotalSurfaceArea(area.tyoalueet.map((alue) => getAreaGeometry(alue)));
+
+  return (
+    <Box marginBottom="var(--spacing-m)">
+      <Box as="p" marginBottom="var(--spacing-xs)">
+        <strong>
+          {t('hakemus:labels:workAreaPlural')} ({area.name})
+        </strong>
+      </Box>
+      {area.tyoalueet.length > 0 && (
+        <Box as="ul" marginBottom="var(--spacing-m)">
+          {area.tyoalueet.map((tyoalue, index) => {
+            const geom = getAreaGeometry(tyoalue);
+            return (
+              <Box as="li" key={index} listStyleType="none">
+                {getAreaDefaultName(t, index, area.tyoalueet.length)} ({formatSurfaceArea(geom)})
+              </Box>
+            );
+          })}
+        </Box>
+      )}
+      <Box marginBottom="var(--spacing-m)">
+        {totalSurfaceArea > 0 ? (
+          <p>
+            {t('form:labels:pintaAla')}: {totalSurfaceArea} m²
+          </p>
+        ) : null}
+        {area.katuosoite && (
+          <p>
+            {t('form:yhteystiedot:labels:osoite')}: {area.katuosoite}
+          </p>
+        )}
+        {area.tyonTarkoitukset && area.tyonTarkoitukset.length > 0 ? (
+          <p>
+            {t('hakemus:labels:tyonTarkoitus')}:{' '}
+            {area.tyonTarkoitukset.map((tyyppi) => t(`hanke:tyomaaTyyppi:${tyyppi}`)).join(', ')}
+          </p>
+        ) : null}
+      </Box>
+      <Box marginBottom="var(--spacing-m)">
+        {area.meluhaitta && (
+          <p>
+            {t('hankeForm:labels:meluHaitta')}: {t(`hanke:meluHaitta:${area.meluhaitta}`)}
+          </p>
+        )}
+        {area.polyhaitta && (
+          <p>
+            {t('hankeForm:labels:polyHaitta')}: {t(`hanke:polyHaitta:${area.polyhaitta}`)}
+          </p>
+        )}
+        {area.tarinahaitta && (
+          <p>
+            {t('hankeForm:labels:tarinaHaitta')}: {t(`hanke:tarinaHaitta:${area.tarinahaitta}`)}
+          </p>
+        )}
+        {area.kaistahaitta && (
+          <p>
+            {t('hankeForm:labels:kaistaHaitta')}: {t(`hanke:kaistaHaitta:${area.kaistahaitta}`)}
+          </p>
+        )}
+        {area.kaistahaittojenPituus && (
+          <p>
+            {t('hankeForm:labels:kaistaPituusHaitta')}:{' '}
+            {t(`hanke:kaistaPituusHaitta:${area.kaistahaittojenPituus}`)}
+          </p>
+        )}
+      </Box>
+      {area.lisatiedot && (
+        <p>
+          {t('hakemus:labels:areaAdditionalInfo')}: {area.lisatiedot}
+        </p>
+      )}
+    </Box>
+  );
+}
+
+type Props = {
+  data: KaivuilmoitusData;
+  originalData: KaivuilmoitusData;
+  muutokset: string[];
+};
+
+export default function KaivuilmoitusAreaSummary({
+  data,
+  originalData,
+  muutokset,
+}: Readonly<Props>) {
+  const { t } = useTranslation();
+  const { startTime, endTime, areas: taydennysAreas } = data;
+  const startTimeChanged = muutokset.includes('startTime');
+  const endTimeChanged = muutokset.includes('endTime');
+  const changedAreas: PartialExcept<KaivuilmoitusAlue, 'tyoalueet'>[] = taydennysAreas
+    .map((kaivuilmoitusAlue, index) => {
+      return {
+        ...kaivuilmoitusAlue,
+        katuosoite: muutokset.includes(`areas[${index}].katuosoite`)
+          ? kaivuilmoitusAlue.katuosoite
+          : undefined,
+        tyonTarkoitukset: muutokset.includes(`areas[${index}].tyonTarkoitukset`)
+          ? kaivuilmoitusAlue.tyonTarkoitukset
+          : undefined,
+        meluhaitta: muutokset.includes(`areas[${index}].meluhaitta`)
+          ? kaivuilmoitusAlue.meluhaitta
+          : undefined,
+        polyhaitta: muutokset.includes(`areas[${index}].polyhaitta`)
+          ? kaivuilmoitusAlue.polyhaitta
+          : undefined,
+        tarinahaitta: muutokset.includes(`areas[${index}].tarinahaitta`)
+          ? kaivuilmoitusAlue.tarinahaitta
+          : undefined,
+        kaistahaitta: muutokset.includes(`areas[${index}].kaistahaitta`)
+          ? kaivuilmoitusAlue.kaistahaitta
+          : undefined,
+        kaistahaittojenPituus: muutokset.includes(`areas[${index}].kaistahaittojenPituus`)
+          ? kaivuilmoitusAlue.kaistahaittojenPituus
+          : undefined,
+        lisatiedot: muutokset.includes(`areas[${index}].lisatiedot`)
+          ? kaivuilmoitusAlue.lisatiedot
+          : undefined,
+        // If there are changes to any work areas, include all work areas
+        tyoalueet:
+          kaivuilmoitusAlue.tyoalueet.filter((_, tyoalueIndex) => {
+            return muutokset.includes(`areas[${index}].tyoalueet[${tyoalueIndex}]`);
+          }).length > 0
+            ? kaivuilmoitusAlue.tyoalueet
+            : [],
+      };
+    })
+    .filter((_, index) => {
+      return muutokset.includes(`areas[${index}]`);
+    });
+
+  const removedAreas = differenceBy(originalData.areas, taydennysAreas, 'hankealueId');
+
+  if (
+    changedAreas.length === 0 &&
+    removedAreas.length === 0 &&
+    !startTimeChanged &&
+    !endTimeChanged
+  ) {
+    return null;
+  }
+
+  const geometries: Geometry[] = changedAreas
+    .flatMap((area) => area.tyoalueet)
+    .map((alue) => getAreaGeometry(alue));
+  const totalSurfaceArea = getTotalSurfaceArea(geometries);
+
+  return (
+    <>
+      <SectionTitle>{t('hankeForm:hankkeenAlueForm:header')}</SectionTitle>
+      <FormSummarySection>
+        {totalSurfaceArea > 0 && (
+          <>
+            <SectionItemTitle>{t('form:labels:kokonaisAla')}</SectionItemTitle>
+            <SectionItemContent>
+              <p>{totalSurfaceArea} m²</p>
+            </SectionItemContent>
+          </>
+        )}
+        {startTimeChanged && (
+          <>
+            <SectionItemTitle>{t('kaivuilmoitusForm:alueet:startDate')}</SectionItemTitle>
+            <SectionItemContent>
+              {startTime && <p>{formatToFinnishDate(startTime)}</p>}
+            </SectionItemContent>
+          </>
+        )}
+        {endTimeChanged && (
+          <>
+            <SectionItemTitle>{t('kaivuilmoitusForm:alueet:endDate')}</SectionItemTitle>
+            <SectionItemContent>
+              {endTime && <p>{formatToFinnishDate(endTime)}</p>}
+            </SectionItemContent>
+          </>
+        )}
+        {(changedAreas.length > 0 || removedAreas.length > 0) && (
+          <>
+            <SectionItemTitle>{t('hankeForm:hankkeenAlueForm:header')}</SectionItemTitle>
+            <SectionItemContent>
+              {changedAreas.map((area) => (
+                <AreaDetail key={area.hankealueId} area={area} />
+              ))}
+              {removedAreas.length > 0 && (
+                <SectionItemContentRemoved>
+                  {removedAreas.map((area) => (
+                    <AreaDetail key={area.hankealueId} area={area} />
+                  ))}
+                </SectionItemContentRemoved>
+              )}
+            </SectionItemContent>
+          </>
+        )}
+      </FormSummarySection>
+    </>
+  );
+}

--- a/src/domain/application/taydennys/components/summary/KaivuilmoitusBasicInformationSummary.test.tsx
+++ b/src/domain/application/taydennys/components/summary/KaivuilmoitusBasicInformationSummary.test.tsx
@@ -1,0 +1,111 @@
+import { cloneDeep } from 'lodash';
+import { render, screen } from '../../../../../testUtils/render';
+import BasicInformationSummary from './KaivuilmoitusBasicInformationSummary';
+import { KaivuilmoitusData } from '../../../types/application';
+import applications from '../../../../mocks/data/hakemukset-data';
+
+const testApplication = cloneDeep(applications[12].applicationData as KaivuilmoitusData);
+
+const mockData: KaivuilmoitusData = {
+  ...testApplication,
+  name: 'Test Name',
+  workDescription: 'Test Description',
+};
+
+describe('Kaivuilmoitus taydennys BasicInformationSummary', () => {
+  test('renders nothing if no changes are detected', () => {
+    const { container } = render(
+      <BasicInformationSummary data={mockData} originalData={mockData} muutokset={[]} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders name change', () => {
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, name: 'New Name' }}
+        originalData={mockData}
+        muutokset={['name']}
+      />,
+    );
+
+    expect(screen.getByText('New Name')).toBeInTheDocument();
+  });
+
+  test('renders work description change', () => {
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, workDescription: 'New Description' }}
+        originalData={mockData}
+        muutokset={['workDescription']}
+      />,
+    );
+
+    expect(screen.getByText('New Description')).toBeInTheDocument();
+  });
+
+  test('renders work is about changes', () => {
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, constructionWork: true }}
+        originalData={mockData}
+        muutokset={['constructionWork']}
+      />,
+    );
+
+    expect(screen.getByText('Uuden rakenteen tai johdon rakentamisesta')).toBeInTheDocument();
+  });
+
+  test('renders removed work is about changes', () => {
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, constructionWork: false }}
+        originalData={{ ...mockData, constructionWork: true }}
+        muutokset={['constructionWork']}
+      />,
+    );
+
+    expect(screen.getByText(/poistettu/i)).toBeInTheDocument();
+    expect(screen.getByText('Uuden rakenteen tai johdon rakentamisesta')).toBeInTheDocument();
+  });
+
+  test('renders cable reports change', () => {
+    const cableReports = ['JS2500001', 'JS2500002'];
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, cableReports }}
+        originalData={mockData}
+        muutokset={['cableReports']}
+      />,
+    );
+
+    expect(screen.getByText(cableReports.join(', '))).toBeInTheDocument();
+  });
+
+  test('renders placement contracts change', () => {
+    const placementContracts = ['SL0000001', 'SL0000002'];
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, placementContracts }}
+        originalData={mockData}
+        muutokset={['placementContracts']}
+      />,
+    );
+
+    expect(screen.getByText(placementContracts.join(', '))).toBeInTheDocument();
+  });
+
+  test('renders required competence change', () => {
+    render(
+      <BasicInformationSummary
+        data={{ ...mockData, requiredCompetence: false }}
+        originalData={mockData}
+        muutokset={['requiredCompetence']}
+      />,
+    );
+
+    expect(screen.getByText('Työhön vaadittava pätevyys')).toBeInTheDocument();
+    expect(screen.getByText('Ei')).toBeInTheDocument();
+  });
+});

--- a/src/domain/application/taydennys/components/summary/KaivuilmoitusBasicInformationSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/KaivuilmoitusBasicInformationSummary.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  FormSummarySection,
+  SectionItemContent,
+  SectionItemContentRemoved,
+  SectionItemTitle,
+  SectionTitle,
+} from '../../../../forms/components/FormSummarySection';
+import { KaivuilmoitusData } from '../../../types/application';
+
+type Props = {
+  data: KaivuilmoitusData;
+  originalData: KaivuilmoitusData;
+  muutokset: string[];
+  children?: React.ReactNode;
+};
+
+export default function BasicInformationSummary({
+  data,
+  originalData,
+  muutokset,
+  children,
+}: Readonly<Props>) {
+  const { t } = useTranslation();
+  const { name, workDescription, cableReports, placementContracts, requiredCompetence } = data;
+
+  const nameChanged = muutokset.includes('name');
+  const workDescriptionChanged = muutokset.includes('workDescription');
+  const workIsAboutChanged: string[] = muutokset.filter((muutos) =>
+    ['constructionWork', 'maintenanceWork', 'emergencyWork'].includes(muutos),
+  );
+  const workIsAboutRemoved: string[] = workIsAboutChanged.filter(
+    (muutos) => !data[muutos as keyof KaivuilmoitusData],
+  );
+  const workIsAboutChangedButNotRemoved = workIsAboutChanged.filter(
+    (muutos) => !workIsAboutRemoved.includes(muutos),
+  );
+  const cableReportsChanged = muutokset.includes('cableReports');
+  const placementContractsChanged = muutokset.includes('placementContracts');
+  const requiredCompetenceChanged = muutokset.includes('requiredCompetence');
+
+  if (
+    !nameChanged &&
+    !workIsAboutChanged.length &&
+    !workDescriptionChanged &&
+    !cableReportsChanged &&
+    !placementContractsChanged &&
+    !requiredCompetenceChanged
+  ) {
+    return null;
+  }
+
+  return (
+    <>
+      <SectionTitle>{t('hankeForm:perustiedotForm:header')}</SectionTitle>
+      <FormSummarySection>
+        {nameChanged && (
+          <>
+            <SectionItemTitle>{t('hakemus:labels:nimi')}</SectionItemTitle>
+            {!name ? (
+              <SectionItemContentRemoved>
+                <p>{originalData.name}</p>
+              </SectionItemContentRemoved>
+            ) : (
+              <SectionItemContent>
+                <p>{name}</p>
+              </SectionItemContent>
+            )}
+          </>
+        )}
+        {workIsAboutChanged.length > 0 && (
+          <>
+            <SectionItemTitle>{t('hakemus:labels:tyossaKyse')}</SectionItemTitle>
+            <SectionItemContent>
+              {workIsAboutChangedButNotRemoved.length > 0 && (
+                <>
+                  {workIsAboutChangedButNotRemoved.map((changed) => (
+                    <p key={changed}>{t(`hakemus:labels:${changed}`)}</p>
+                  ))}
+                </>
+              )}
+              {workIsAboutRemoved.length > 0 && (
+                <SectionItemContentRemoved>
+                  {workIsAboutRemoved.map((removed) => (
+                    <p key={removed}>{t(`hakemus:labels:${removed}`)}</p>
+                  ))}
+                </SectionItemContentRemoved>
+              )}
+            </SectionItemContent>
+          </>
+        )}
+        {workDescriptionChanged && (
+          <>
+            <SectionItemTitle>{t('hakemus:labels:kuvaus')}</SectionItemTitle>
+            {!workDescription ? (
+              <SectionItemContentRemoved>
+                <p style={{ whiteSpace: 'pre-wrap' }}>{originalData.workDescription}</p>
+              </SectionItemContentRemoved>
+            ) : (
+              <SectionItemContent>
+                <p style={{ whiteSpace: 'pre-wrap' }}>{workDescription}</p>
+              </SectionItemContent>
+            )}
+          </>
+        )}
+        {cableReportsChanged && (
+          <>
+            <SectionItemTitle>{t('hakemus:labels:cableReports')}</SectionItemTitle>
+            <SectionItemContent>
+              <p>{cableReports?.join(', ')}</p>
+            </SectionItemContent>
+          </>
+        )}
+        {placementContractsChanged && (
+          <>
+            <SectionItemTitle>{t('hakemus:labels:placementContractsTitle')}</SectionItemTitle>
+            <SectionItemContent>
+              <p>{placementContracts?.join(', ')}</p>
+            </SectionItemContent>
+          </>
+        )}
+        {requiredCompetenceChanged && (
+          <>
+            <SectionItemTitle>{t('hakemus:labels:requiredCompetenceTitle')}</SectionItemTitle>
+            <SectionItemContent>
+              <p>{requiredCompetence ? t('common:yes') : t('common:no')}</p>
+            </SectionItemContent>
+          </>
+        )}
+        {children}
+      </FormSummarySection>
+    </>
+  );
+}

--- a/src/domain/application/taydennys/components/summary/KaivuilmoitusHaittojenhallintaSummary.test.tsx
+++ b/src/domain/application/taydennys/components/summary/KaivuilmoitusHaittojenhallintaSummary.test.tsx
@@ -1,0 +1,57 @@
+import { cloneDeep } from 'lodash';
+import KaivuilmoitusHaittojenhallintaSummary from './KaivuilmoitusHaittojenhallintaSummary';
+import { KaivuilmoitusData } from '../../../types/application';
+import hankkeet from '../../../../mocks/data/hankkeet-data';
+import applications from '../../../../mocks/data/hakemukset-data';
+import { render, screen } from '../../../../../testUtils/render';
+
+const testHanke = cloneDeep(hankkeet[1]);
+const testApplication = cloneDeep(applications[12].applicationData as KaivuilmoitusData);
+
+const mockData: KaivuilmoitusData = {
+  ...testApplication,
+};
+
+describe('Kaivuilmoitus taydennys HaittojenhallintaSummary', () => {
+  test('renders nothing if no changes', () => {
+    const { container } = render(
+      <KaivuilmoitusHaittojenhallintaSummary
+        hankealueet={testHanke.alueet!}
+        kaivuilmoitusAlueet={mockData.areas}
+        muutokset={[]}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders haittojenhallinta changes', () => {
+    render(
+      <KaivuilmoitusHaittojenhallintaSummary
+        hankealueet={testHanke.alueet!}
+        kaivuilmoitusAlueet={[
+          {
+            ...mockData.areas[0],
+            haittojenhallintasuunnitelma: {
+              PYORALIIKENNE: 'Pyöräliikenteen haitat',
+              MUUT: 'Muut haitat',
+            },
+          },
+        ]}
+        muutokset={[
+          'areas[0].haittojenhallintasuunnitelma[PYORALIIKENNE]',
+          'areas[0].haittojenhallintasuunnitelma[MUUT]',
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Työalueet (Hankealue 2)')).toBeInTheDocument();
+    expect(screen.getByText('Pyöräliikenteen merkittävyys')).toBeInTheDocument();
+    expect(screen.getByText('Pyöräliikenteen haitat')).toBeInTheDocument();
+    expect(screen.getByText('Muut haittojenhallintatoimet')).toBeInTheDocument();
+    expect(screen.getByText('Muut haitat')).toBeInTheDocument();
+    expect(screen.queryByText('Linja-autojen paikallisliikenne')).not.toBeInTheDocument();
+    expect(screen.queryByText('Autoliikenteen ruuhkautuminen')).not.toBeInTheDocument();
+    expect(screen.queryByText('Raitioliikenne')).not.toBeInTheDocument();
+  });
+});

--- a/src/domain/application/taydennys/components/summary/KaivuilmoitusHaittojenhallintaSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/KaivuilmoitusHaittojenhallintaSummary.tsx
@@ -1,0 +1,70 @@
+import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { $enum } from 'ts-enum-util';
+import { HankeAlue } from '../../../../types/hanke';
+import { KaivuilmoitusAlue } from '../../../types/application';
+import { HaittojenhallintasuunnitelmaInfo } from '../../../../kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo';
+import { HAITTOJENHALLINTATYYPPI } from '../../../../common/haittojenhallinta/types';
+import { SectionTitle } from '../../../../forms/components/FormSummarySection';
+
+const haittojenhallintaTyypit = $enum(
+  HAITTOJENHALLINTATYYPPI,
+).getKeys() as HAITTOJENHALLINTATYYPPI[];
+
+type Props = {
+  hankealueet: HankeAlue[];
+  kaivuilmoitusAlueet: KaivuilmoitusAlue[];
+  muutokset: string[];
+};
+
+export default function HaittojenhallintaSummary({
+  hankealueet,
+  kaivuilmoitusAlueet,
+  muutokset,
+}: Readonly<Props>) {
+  const { t } = useTranslation();
+  const changedKaivuilmoitusAlueet = kaivuilmoitusAlueet.filter((_, kaivuilmoitusAlueIndex) => {
+    return (
+      muutokset.find((muutos) =>
+        muutos.includes(`areas[${kaivuilmoitusAlueIndex}].haittojenhallintasuunnitelma`),
+      ) !== undefined
+    );
+  });
+
+  if (changedKaivuilmoitusAlueet.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <SectionTitle>{t('hankePortfolio:tabit:haittojenHallinta')}</SectionTitle>
+      <Tabs>
+        <TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+          {changedKaivuilmoitusAlueet.map((alue) => {
+            return (
+              <Tab key={alue.hankealueId}>
+                {t('hakemus:labels:workAreaPlural') + ' (' + alue.name + ')'}
+              </Tab>
+            );
+          })}
+        </TabList>
+        {changedKaivuilmoitusAlueet.map((alue, index) => {
+          const hankealue = hankealueet?.find((ha) => ha.id === alue.hankealueId);
+          const visibleHaittojenhallintaTyypit = haittojenhallintaTyypit.filter((tyyppi) => {
+            return muutokset.includes(`areas[${index}].haittojenhallintasuunnitelma[${tyyppi}]`);
+          });
+          return (
+            <TabPanel key={alue.hankealueId}>
+              <HaittojenhallintasuunnitelmaInfo
+                key={alue.hankealueId}
+                kaivuilmoitusAlue={alue}
+                hankealue={hankealue}
+                visibleHaittojenhallintaTyypit={visibleHaittojenhallintaTyypit}
+              />
+            </TabPanel>
+          );
+        })}
+      </Tabs>
+    </>
+  );
+}

--- a/src/domain/johtoselvitysTaydennys/ReviewAndSend.tsx
+++ b/src/domain/johtoselvitysTaydennys/ReviewAndSend.tsx
@@ -18,7 +18,7 @@ import { Box } from '@chakra-ui/react';
 import { Taydennys } from '../application/taydennys/types';
 import TaydennysBasicInformationSummary from '../application/taydennys/components/summary/JohtoselvitysBasicInformationSummary';
 import TaydennysAreaSummary from '../application/taydennys/components/summary/JohtoselvitysAreaSummary';
-import TaydennysContactsSummary from '../application/taydennys/components/summary/JohtoselvitysContactsSummary';
+import TaydennysContactsSummary from '../application/taydennys/components/summary/ContactsSummary';
 import AttachmentSummary from '../application/components/summary/AttachmentSummary';
 import TaydennysAttachmentsList from '../application/taydennys/components/TaydennysAttachmentsList';
 

--- a/src/domain/kaivuilmoitus/ReviewAndSend.tsx
+++ b/src/domain/kaivuilmoitus/ReviewAndSend.tsx
@@ -11,42 +11,7 @@ import AttachmentSummary from '../application/components/summary/KaivuilmoitusAt
 import { ApplicationAttachmentMetadata } from '../application/types/application';
 import AreaSummary from './components/AreaSummary';
 import { HankeAlue } from '../types/hanke';
-import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
-import { HaittojenhallintasuunnitelmaInfo } from './components/HaittojenhallintasuunnitelmaInfo';
-
-const HaittojenhallintaSummary: React.FC<{
-  hankealueet: HankeAlue[];
-  formData: KaivuilmoitusFormValues;
-}> = ({ hankealueet, formData }) => {
-  const { t } = useTranslation();
-  const kaivuilmoitusAlueet = formData.applicationData.areas;
-
-  return (
-    <Tabs>
-      <TabList style={{ marginBottom: 'var(--spacing-m)' }}>
-        {kaivuilmoitusAlueet.map((alue) => {
-          return (
-            <Tab key={alue.hankealueId}>
-              {t('hakemus:labels:workAreaPlural') + ' (' + alue.name + ')'}
-            </Tab>
-          );
-        })}
-      </TabList>
-      {kaivuilmoitusAlueet.map((alue) => {
-        const hankealue = hankealueet?.find((ha) => ha.id === alue.hankealueId);
-        return (
-          <TabPanel key={alue.hankealueId}>
-            <HaittojenhallintasuunnitelmaInfo
-              key={alue.hankealueId}
-              kaivuilmoitusAlue={alue}
-              hankealue={hankealue}
-            />
-          </TabPanel>
-        );
-      })}
-    </Tabs>
-  );
-};
+import HaittojenhallintaSummary from './components/HaittojenhallintaSummary';
 
 type Props = {
   hankealueet: HankeAlue[];

--- a/src/domain/kaivuilmoitus/components/AreaSummary.tsx
+++ b/src/domain/kaivuilmoitus/components/AreaSummary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Geometry from 'ol/geom/Geometry';
 import { useTranslation } from 'react-i18next';
 import { Box } from '@chakra-ui/react';
@@ -16,9 +15,7 @@ import { KaivuilmoitusAlue } from '../../application/types/application';
 
 function AreaDetail({ area }: Readonly<{ area: KaivuilmoitusAlue }>) {
   const { t } = useTranslation();
-  const totalSurfaceArea = getTotalSurfaceArea(
-    area.tyoalueet.map((alue) => alue.openlayersFeature!.getGeometry()!),
-  );
+  const totalSurfaceArea = getTotalSurfaceArea(area.tyoalueet.map((alue) => getAreaGeometry(alue)));
 
   return (
     <Box marginBottom="var(--spacing-m)">
@@ -93,7 +90,7 @@ const AreaSummary: React.FC<Props> = ({ formData }) => {
 
   const geometries: Geometry[] = areas
     .flatMap((area) => area.tyoalueet)
-    .map((alue) => alue.openlayersFeature!.getGeometry()!);
+    .map((alue) => getAreaGeometry(alue));
   const totalSurfaceArea = getTotalSurfaceArea(geometries);
 
   return (

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaSummary.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaSummary.tsx
@@ -1,0 +1,41 @@
+import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { HankeAlue } from '../../types/hanke';
+import { Application, KaivuilmoitusData } from '../../application/types/application';
+import { HaittojenhallintasuunnitelmaInfo } from './HaittojenhallintasuunnitelmaInfo';
+
+type Props = {
+  hankealueet: HankeAlue[];
+  formData: Application<KaivuilmoitusData>;
+};
+
+export default function HaittojenhallintaSummary({ hankealueet, formData }: Readonly<Props>) {
+  const { t } = useTranslation();
+  const kaivuilmoitusAlueet = formData.applicationData.areas;
+
+  return (
+    <Tabs>
+      <TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+        {kaivuilmoitusAlueet.map((alue) => {
+          return (
+            <Tab key={alue.hankealueId}>
+              {t('hakemus:labels:workAreaPlural') + ' (' + alue.name + ')'}
+            </Tab>
+          );
+        })}
+      </TabList>
+      {kaivuilmoitusAlueet.map((alue) => {
+        const hankealue = hankealueet?.find((ha) => ha.id === alue.hankealueId);
+        return (
+          <TabPanel key={alue.hankealueId}>
+            <HaittojenhallintasuunnitelmaInfo
+              key={alue.hankealueId}
+              kaivuilmoitusAlue={alue}
+              hankealue={hankealue}
+            />
+          </TabPanel>
+        );
+      })}
+    </Tabs>
+  );
+}

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.module.scss
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.module.scss
@@ -1,0 +1,3 @@
+.haittojenhallintaSection:nth-child(even) {
+  background-color: var(--color-black-5);
+}

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { $enum } from 'ts-enum-util';
 import { calculateLiikennehaittaindeksienYhteenveto } from '../utils';
 import { sortedLiikenneHaittojenhallintatyyppi } from '../../common/haittojenhallinta/utils';
 import {
@@ -15,13 +16,15 @@ import { HankeAlue } from '../../types/hanke';
 import HaittaIndex from '../../common/haittaIndexes/HaittaIndex';
 import HaittaTooltipContent from '../../common/haittaIndexes/HaittaTooltipContent';
 import Text from '../../../common/components/text/Text';
+import styles from './HaittojenhallintasuunnitelmaInfo.module.scss';
+
+const haittojenhallintaTyypit = $enum(HAITTOJENHALLINTATYYPPI).getKeys();
 
 type LiikennehaitanHallintasuunnitelmaProps = {
   tyyppi: HAITTOJENHALLINTATYYPPI;
   indeksi: number;
   alue: KaivuilmoitusAlue;
   hankealue?: HankeAlue;
-  background?: string;
 };
 
 const LiikennehaitanHallintasuunnitelmaInfo: React.FC<LiikennehaitanHallintasuunnitelmaProps> = ({
@@ -29,14 +32,13 @@ const LiikennehaitanHallintasuunnitelmaInfo: React.FC<LiikennehaitanHallintasuun
   indeksi,
   alue,
   hankealue,
-  background,
 }) => {
   const { t } = useTranslation();
   return (
     <FormSummarySection
-      background={background ?? 'var(--color-white)'}
       padding="var(--spacing-s)"
       marginBottom="var(--spacing-xs)"
+      className={styles.haittojenhallintaSection}
     >
       <SectionItemTitle>
         {t(`hankeForm:haittojenHallintaForm:nuisanceType:${tyyppi}`)}
@@ -76,37 +78,47 @@ const LiikennehaitanHallintasuunnitelmaInfo: React.FC<LiikennehaitanHallintasuun
 type HaittojenHallintaProps = {
   kaivuilmoitusAlue: KaivuilmoitusAlue;
   hankealue?: HankeAlue;
+  visibleHaittojenhallintaTyypit?: HAITTOJENHALLINTATYYPPI[];
 };
 
 export const HaittojenhallintasuunnitelmaInfo: React.FC<HaittojenHallintaProps> = ({
   kaivuilmoitusAlue,
   hankealue,
+  visibleHaittojenhallintaTyypit = haittojenhallintaTyypit,
 }) => {
   const { t } = useTranslation();
   const tormaystarkasteluTulos = calculateLiikennehaittaindeksienYhteenveto(kaivuilmoitusAlue);
-  const haittojenhallintatyypit = sortedLiikenneHaittojenhallintatyyppi(tormaystarkasteluTulos);
+  const haittojenhallintatyypit = sortedLiikenneHaittojenhallintatyyppi(
+    tormaystarkasteluTulos,
+  ).filter(([haitta]) => visibleHaittojenhallintaTyypit.includes(haitta));
 
   return (
     <>
-      <FormSummarySection padding="var(--spacing-s)" marginBottom="var(--spacing-xs)">
-        <SectionItemTitle>
-          {t('kaivuilmoitusForm:haittojenHallinta:labels:YLEINEN')}
-        </SectionItemTitle>
-        <SectionItemContent>
-          <Grid templateColumns="9fr 1fr" gap="var(--spacing-xs)">
-            <GridItem>
-              <HankkeenHaittojenhallintasuunnitelma
-                text={hankealue?.haittojenhallintasuunnitelma?.YLEINEN ?? ''}
-              />
-              <Box whiteSpace="pre-wrap" wordBreak="break-word" paddingTop="var(--spacing-s)">
-                {kaivuilmoitusAlue.haittojenhallintasuunnitelma?.YLEINEN ?? ''}
-              </Box>
-            </GridItem>
-            <GridItem width="80px"></GridItem>
-          </Grid>
-        </SectionItemContent>
-      </FormSummarySection>
-      {haittojenhallintatyypit.map(([haitta, indeksi], i) => {
+      {visibleHaittojenhallintaTyypit.includes(HAITTOJENHALLINTATYYPPI.YLEINEN) && (
+        <FormSummarySection
+          padding="var(--spacing-s)"
+          marginBottom="var(--spacing-xs)"
+          className={styles.haittojenhallintaSection}
+        >
+          <SectionItemTitle>
+            {t('kaivuilmoitusForm:haittojenHallinta:labels:YLEINEN')}
+          </SectionItemTitle>
+          <SectionItemContent>
+            <Grid templateColumns="9fr 1fr" gap="var(--spacing-xs)">
+              <GridItem>
+                <HankkeenHaittojenhallintasuunnitelma
+                  text={hankealue?.haittojenhallintasuunnitelma?.YLEINEN ?? ''}
+                />
+                <Box whiteSpace="pre-wrap" wordBreak="break-word" paddingTop="var(--spacing-s)">
+                  {kaivuilmoitusAlue.haittojenhallintasuunnitelma?.YLEINEN ?? ''}
+                </Box>
+              </GridItem>
+              <GridItem width="80px"></GridItem>
+            </Grid>
+          </SectionItemContent>
+        </FormSummarySection>
+      )}
+      {haittojenhallintatyypit.map(([haitta, indeksi]) => {
         return (
           <LiikennehaitanHallintasuunnitelmaInfo
             tyyppi={haitta}
@@ -114,35 +126,36 @@ export const HaittojenhallintasuunnitelmaInfo: React.FC<HaittojenHallintaProps> 
             alue={kaivuilmoitusAlue}
             hankealue={hankealue}
             key={haitta}
-            background={i % 2 === 0 ? 'var(--color-black-5)' : 'var(--color-white)'}
           />
         );
       })}
-      <FormSummarySection
-        padding="var(--spacing-s)"
-        marginBottom="var(--spacing-xs)"
-        background="var(--color-black-5)"
-      >
-        <SectionItemTitle>
-          {t('hankeForm:haittojenHallintaForm:nuisanceType:MUUT')}
-        </SectionItemTitle>
-        <SectionItemContent>
-          <Grid templateColumns="9fr 1fr" gap="var(--spacing-xs)">
-            <GridItem>
-              <HankkeenHaittojenhallintasuunnitelma
-                text={hankealue?.haittojenhallintasuunnitelma?.MUUT ?? ''}
-              />
-              <Text spacingTop="xs" weight="bold" styleAs="h6" tag="h6">
-                {t('kaivuilmoitusForm:haittojenHallinta:labels:YLEINEN')}
-              </Text>
-              <Box whiteSpace="pre-wrap" wordBreak="break-word" paddingTop="var(--spacing-xs)">
-                {kaivuilmoitusAlue.haittojenhallintasuunnitelma?.MUUT ?? ''}
-              </Box>
-            </GridItem>
-            <GridItem width="80px"></GridItem>
-          </Grid>
-        </SectionItemContent>
-      </FormSummarySection>
+      {visibleHaittojenhallintaTyypit.includes(HAITTOJENHALLINTATYYPPI.MUUT) && (
+        <FormSummarySection
+          padding="var(--spacing-s)"
+          marginBottom="var(--spacing-xs)"
+          className={styles.haittojenhallintaSection}
+        >
+          <SectionItemTitle>
+            {t('hankeForm:haittojenHallintaForm:nuisanceType:MUUT')}
+          </SectionItemTitle>
+          <SectionItemContent>
+            <Grid templateColumns="9fr 1fr" gap="var(--spacing-xs)">
+              <GridItem>
+                <HankkeenHaittojenhallintasuunnitelma
+                  text={hankealue?.haittojenhallintasuunnitelma?.MUUT ?? ''}
+                />
+                <Text spacingTop="xs" weight="bold" styleAs="h6" tag="h6">
+                  {t('kaivuilmoitusForm:haittojenHallinta:labels:YLEINEN')}
+                </Text>
+                <Box whiteSpace="pre-wrap" wordBreak="break-word" paddingTop="var(--spacing-xs)">
+                  {kaivuilmoitusAlue.haittojenhallintasuunnitelma?.MUUT ?? ''}
+                </Box>
+              </GridItem>
+              <GridItem width="80px"></GridItem>
+            </Grid>
+          </SectionItemContent>
+        </FormSummarySection>
+      )}
     </>
   );
 };

--- a/src/domain/kaivuilmoitus/components/TyoalueTable.tsx
+++ b/src/domain/kaivuilmoitus/components/TyoalueTable.tsx
@@ -211,6 +211,7 @@ export default function TyoalueTable({
       setValue(
         `applicationData.areas.${alueIndex}.tyoalueet`,
         tyoalueet.filter((_, i) => i !== areaToRemove.index),
+        { shouldValidate: true, shouldDirty: true },
       );
       drawSource.removeFeature(areaToRemove.feature!);
       setAreaToRemove(null);

--- a/src/domain/kaivuilmoitus/hooks/useFormErrorsByPage.ts
+++ b/src/domain/kaivuilmoitus/hooks/useFormErrorsByPage.ts
@@ -22,6 +22,7 @@ export function useFormErrorsByPage<T>(formData: T, context: AnyObject) {
     haittojenhallintaErrors,
     yhteystiedotErrors,
     [],
+    [],
   ];
 
   return formErrorsByPage;

--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
@@ -41,6 +41,7 @@ import useAttachments from '../application/hooks/useAttachments';
 import FormFieldsErrorSummary from '../forms/components/FormFieldsErrorSummary';
 import { mapValidationErrorToErrorListItem } from '../kaivuilmoitus/mapValidationErrorToErrorListItem';
 import { useFormErrorsByPage } from '../kaivuilmoitus/hooks/useFormErrorsByPage';
+import ReviewAndSend from './ReviewAndSend';
 
 type Props = {
   taydennys: Taydennys<KaivuilmoitusData>;
@@ -177,6 +178,19 @@ export default function KaivuilmoitusTaydennysContainer({
         />
       ),
       label: t('hankePortfolio:tabit:liitteet'),
+      state: StepState.available,
+    },
+    {
+      element: (
+        <ReviewAndSend
+          taydennys={taydennys}
+          muutokset={taydennys.muutokset}
+          originalApplication={originalApplication}
+          originalAttachments={originalAttachments ?? []}
+          hankealueet={hankeData.alueet}
+        />
+      ),
+      label: t('form:headers:yhteenveto'),
       state: StepState.available,
     },
   ];

--- a/src/domain/kaivuilmoitusTaydennys/ReviewAndSend.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/ReviewAndSend.tsx
@@ -1,0 +1,162 @@
+import { useTranslation } from 'react-i18next';
+import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
+import { Box } from '@chakra-ui/layout';
+import { Taydennys } from '../application/taydennys/types';
+import {
+  Application,
+  ApplicationAttachmentMetadata,
+  KaivuilmoitusData,
+} from '../application/types/application';
+import {
+  FormSummarySection,
+  SectionItemContent,
+  SectionItemTitle,
+  SectionTitle,
+} from '../forms/components/FormSummarySection';
+import BasicInformationSummary from '../application/components/summary/KaivuilmoitusBasicInformationSummary';
+import AreaSummary from '../kaivuilmoitus/components/AreaSummary';
+import ContactsSummary from '../application/components/summary/ContactsSummary';
+import InvoicingCustomerSummary from '../application/components/summary/InvoicingCustomerSummary';
+import AttachmentSummary from '../application/components/summary/KaivuilmoitusAttachmentSummary';
+import HaittojenhallintaSummary from '../kaivuilmoitus/components/HaittojenhallintaSummary';
+import { HankeAlue } from '../types/hanke';
+import TaydennysBasicInformationSummary from '../application/taydennys/components/summary/KaivuilmoitusBasicInformationSummary';
+import TaydennysAreasSummary from '../application/taydennys/components/summary/KaivuilmoitusAreaSummary';
+import TaydennysHaittojenhallintaSummary from '../application/taydennys/components/summary/KaivuilmoitusHaittojenhallintaSummary';
+import TaydennysContactsSummary from '../application/taydennys/components/summary/ContactsSummary';
+import TaydennysAttachmentsList from '../application/taydennys/components/TaydennysAttachmentsList';
+
+type Props = {
+  taydennys: Taydennys<KaivuilmoitusData>;
+  muutokset: string[];
+  originalApplication: Application<KaivuilmoitusData>;
+  originalAttachments: ApplicationAttachmentMetadata[];
+  hankealueet: HankeAlue[];
+};
+
+export default function ReviewAndSend({
+  taydennys,
+  muutokset,
+  originalApplication,
+  originalAttachments,
+  hankealueet,
+}: Readonly<Props>) {
+  const { t } = useTranslation();
+  const trafficArrangementPlans = taydennys.liitteet?.filter(
+    (attachment) => attachment.attachmentType === 'LIIKENNEJARJESTELY',
+  );
+  const mandates = taydennys.liitteet?.filter(
+    (attachment) => attachment.attachmentType === 'VALTAKIRJA',
+  );
+  const otherAttachments = taydennys.liitteet?.filter(
+    (attachment) => attachment.attachmentType === 'MUU',
+  );
+
+  return (
+    <Tabs>
+      <TabList>
+        <Tab>{t('taydennys:labels:taydennykset')}</Tab>
+        <Tab>{t('taydennys:labels:originalInformation')}</Tab>
+      </TabList>
+      <TabPanel>
+        <Box mt="var(--spacing-s)">
+          <TaydennysBasicInformationSummary
+            data={taydennys.applicationData}
+            originalData={originalApplication.applicationData}
+            muutokset={muutokset}
+          />
+          <TaydennysAreasSummary
+            data={taydennys.applicationData}
+            originalData={originalApplication.applicationData}
+            muutokset={muutokset}
+          />
+          <TaydennysHaittojenhallintaSummary
+            hankealueet={hankealueet}
+            kaivuilmoitusAlueet={taydennys.applicationData.areas}
+            muutokset={muutokset}
+          />
+          <TaydennysContactsSummary
+            data={taydennys.applicationData}
+            originalData={originalApplication.applicationData}
+            muutokset={muutokset}
+          />
+          {taydennys.liitteet?.length > 0 && (
+            <>
+              <SectionTitle>{t('form:headers:liitteetJaLisatiedot')}</SectionTitle>
+              <FormSummarySection>
+                {trafficArrangementPlans.length > 0 && (
+                  <>
+                    <SectionItemTitle>
+                      {t('taydennys:labels:addedTrafficArrangementPlan')}
+                    </SectionItemTitle>
+                    <SectionItemContent>
+                      <TaydennysAttachmentsList attachments={trafficArrangementPlans} />
+                    </SectionItemContent>
+                  </>
+                )}
+                {mandates.length > 0 && (
+                  <>
+                    <SectionItemTitle>{t('taydennys:labels:addedMandate')}</SectionItemTitle>
+                    <SectionItemContent>
+                      <TaydennysAttachmentsList attachments={mandates} allowDownload={false} />
+                    </SectionItemContent>
+                  </>
+                )}
+                {otherAttachments.length > 0 && (
+                  <>
+                    <SectionItemTitle>
+                      {t('taydennys:labels:addedOtherAttachments')}
+                    </SectionItemTitle>
+                    <SectionItemContent>
+                      <TaydennysAttachmentsList attachments={otherAttachments} />
+                    </SectionItemContent>
+                  </>
+                )}
+              </FormSummarySection>
+            </>
+          )}
+        </Box>
+      </TabPanel>
+      <TabPanel>
+        <Box mt="var(--spacing-s)">
+          <SectionTitle>{t('form:headers:perustiedot')}</SectionTitle>
+          <BasicInformationSummary formData={originalApplication} />
+
+          <SectionTitle>{t('hankeForm:hankkeenAlueForm:header')}</SectionTitle>
+          <AreaSummary formData={originalApplication} />
+
+          <SectionTitle>{t('hankePortfolio:tabit:haittojenHallinta')}</SectionTitle>
+          <HaittojenhallintaSummary hankealueet={hankealueet} formData={originalApplication} />
+
+          <SectionTitle>{t('form:yhteystiedot:header')}</SectionTitle>
+          <FormSummarySection>
+            <ContactsSummary
+              customerWithContacts={originalApplication.applicationData.customerWithContacts}
+              title={t('form:yhteystiedot:titles:customerWithContacts')}
+            />
+            <ContactsSummary
+              customerWithContacts={originalApplication.applicationData.contractorWithContacts}
+              title={t('form:yhteystiedot:titles:contractorWithContacts')}
+            />
+            <ContactsSummary
+              customerWithContacts={
+                originalApplication.applicationData.propertyDeveloperWithContacts
+              }
+              title={t('form:yhteystiedot:titles:rakennuttajat')}
+            />
+            <ContactsSummary
+              customerWithContacts={originalApplication.applicationData.representativeWithContacts}
+              title={t('form:yhteystiedot:titles:representativeWithContacts')}
+            />
+            <InvoicingCustomerSummary
+              invoicingCustomer={originalApplication.applicationData.invoicingCustomer}
+            />
+          </FormSummarySection>
+
+          <SectionTitle>{t('form:headers:liitteetJaLisatiedot')}</SectionTitle>
+          <AttachmentSummary formData={originalApplication} attachments={originalAttachments} />
+        </Box>
+      </TabPanel>
+    </Tabs>
+  );
+}

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1426,7 +1426,10 @@
       "cancelTitle": "Peru täydennysluonnos?",
       "cancelDescription": "Haluatko varmasti perua täydennyspyyntöön vastaamisen? Tehdyt muutokset poistetaan.",
       "originalAttachments": "Alkuperäiset liitteet",
-      "addedAttachments": "Lisätyt liitetiedostot"
+      "addedAttachments": "Lisätyt liitetiedostot",
+      "addedTrafficArrangementPlan": "Lisätyt tilapäisiä liikennejärjestelyitä koskevat suunnitelmat",
+      "addedMandate": "Lisätty valtakirja",
+      "addedOtherAttachments": "Lisätyt muut liitteet"
     },
     "buttons": {
       "createTaydennys": "Täydennä",


### PR DESCRIPTION
# Description

There are täydennykset and alkuperäiset tabs in summary page. Alkuperäiset tab displays the original data of the application. Täydennykset tab displays only information that has changed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3322

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check that when making changes in kaivuilmoitus täydennys form, they are shown in summary page in "Täydennykset" tab.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
