### PR TITLE
HAI-3293 Kaivuilmoitus täydennys data in application view

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -1409,6 +1409,248 @@ describe('Excavation notification application view', () => {
       expect(await screen.findByText('Tapahtui virhe. Yritä uudestaan.')).toBeInTheDocument();
     });
 
+    test('Shows changed information in basic information tab', async () => {
+      const application = cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>);
+      const name = 'New name';
+      const workDescription = 'New work description';
+      application.taydennys = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+        applicationData: {
+          ...application.applicationData,
+          name,
+          workDescription,
+          constructionWork: false,
+          maintenanceWork: true,
+          emergencyWork: true,
+          cableReports: [...(application.applicationData.cableReports || []), 'JS2300003'],
+          placementContracts: [
+            ...(application.applicationData.placementContracts || []),
+            'SL1234568',
+          ],
+          areas: [
+            {
+              ...application.applicationData.areas[0],
+              tyoalueet: [
+                ...application.applicationData.areas[0].tyoalueet,
+                {
+                  area: 10,
+                  geometry: {
+                    type: 'Polygon',
+                    crs: {
+                      type: 'name',
+                      properties: {
+                        name: 'urn:ogc:def:crs:EPSG::3879',
+                      },
+                    },
+                    coordinates: [
+                      [
+                        [25498581.440262634, 6679345.526261961],
+                        [25498582.233686976, 6679350.99321805],
+                        [25498576.766730886, 6679351.786642391],
+                        [25498575.973306544, 6679346.319686302],
+                        [25498581.440262634, 6679345.526261961],
+                      ],
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        muutokset: [
+          'name',
+          'workDescription',
+          'constructionWork',
+          'maintenanceWork',
+          'emergencyWork',
+          'cableReports',
+          'placementContracts',
+        ],
+        liitteet: [],
+      };
+      await setup(application);
+
+      expect(screen.getAllByText('Täydennys:').length).toBe(6);
+      expect(screen.getAllByText('Poistettu:').length).toBe(1);
+      expect(screen.getByText(name)).toBeInTheDocument();
+      expect(screen.getByText(workDescription)).toBeInTheDocument();
+      expect(screen.getByText('Olemassaolevan rakenteen kunnossapitotyöstä')).toBeInTheDocument();
+      expect(screen.getAllByText('Uuden rakenteen tai johdon rakentamisesta').length).toBe(2);
+      expect(
+        screen.getByText(
+          'Kaivutyö on aloitettu ennen johtoselvityksen tilaamista merkittävien vahinkojen välttämiseksi',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText('JS2300003')).toBeInTheDocument();
+      expect(screen.getByText('SL1234568')).toBeInTheDocument();
+      expect(screen.getByText('188 m²')).toBeInTheDocument();
+    });
+
+    test('Shows changed information in areas tab', async () => {
+      const application = cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>);
+      application.taydennys = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+        applicationData: {
+          ...application.applicationData,
+          areas: [
+            {
+              ...application.applicationData.areas[0],
+              tyoalueet: [
+                ...application.applicationData.areas[0].tyoalueet.slice(0, 1),
+                {
+                  area: 10,
+                  geometry: {
+                    type: 'Polygon',
+                    crs: {
+                      type: 'name',
+                      properties: {
+                        name: 'urn:ogc:def:crs:EPSG::3879',
+                      },
+                    },
+                    coordinates: [
+                      [
+                        [25498574.56194478, 6679282.528783048],
+                        [25498582.990384366, 6679282.528783048],
+                        [25498582.990384366, 6679310.418567079],
+                        [25498574.56194478, 6679310.418567079],
+                        [25498574.56194478, 6679282.528783048],
+                      ],
+                    ],
+                  },
+                },
+              ],
+              tyonTarkoitukset: ['VESI', 'TIETOLIIKENNE'],
+              meluhaitta: 'SATUNNAINEN_MELUHAITTA',
+              polyhaitta: 'SATUNNAINEN_POLYHAITTA',
+              tarinahaitta: 'TOISTUVA_TARINAHAITTA',
+              kaistahaitta: 'YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA',
+              kaistahaittojenPituus: 'PITUUS_ALLE_10_METRIA',
+              lisatiedot: 'Lisätiedot',
+            },
+          ],
+        },
+        muutokset: [
+          'areas[0].tyoalueet[1]',
+          'areas[0].tyonTarkoitukset',
+          'areas[0].meluhaitta',
+          'areas[0].polyhaitta',
+          'areas[0].tarinahaitta',
+          'areas[0].kaistahaitta',
+          'areas[0].kaistahaittojenPituus',
+          'areas[0].lisatiedot',
+        ],
+        liitteet: [],
+      };
+      const { user } = await setup(application);
+      await user.click(screen.getByRole('tab', { name: /alueet/i }));
+
+      expect(screen.getAllByText('Täydennys:').length).toBe(8);
+      screen.debug(undefined, 100000);
+      expect(screen.getByText('392 m²')).toBeInTheDocument();
+    });
+
+    test('Shows changed information in haittojen hallinta tab', async () => {
+      const application = cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>);
+      application.applicationData.propertyDeveloperWithContacts = cloneDeep(
+        application.applicationData.customerWithContacts,
+      );
+      application.taydennys = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+        applicationData: {
+          ...application.applicationData,
+          areas: [
+            {
+              ...application.applicationData.areas[0],
+              haittojenhallintasuunnitelma: {
+                YLEINEN: 'Täydennetty työalueen yleisten haittojen hallintasuunnitelma',
+                PYORALIIKENNE:
+                  'Täydennetty pyöräliikenteelle koituvien työalueen haittojen hallintasuunnitelma',
+                AUTOLIIKENNE:
+                  'Täydennetty autoliikenteelle koituvien työalueen haittojen hallintasuunnitelma',
+                LINJAAUTOLIIKENNE:
+                  'Linja-autoliikenteelle koituvien työalueen haittojen hallintasuunnitelma',
+                RAITIOLIIKENNE:
+                  'Täydennetty raitioliikenteelle koituvien työalueen haittojen hallintasuunnitelma',
+                MUUT: '',
+              },
+            },
+          ],
+        },
+        muutokset: [
+          'areas[0].haittojenhallintasuunnitelma[YLEINEN]',
+          'areas[0].haittojenhallintasuunnitelma[PYORALIIKENNE]',
+          'areas[0].haittojenhallintasuunnitelma[AUTOLIIKENNE]',
+          'areas[0].haittojenhallintasuunnitelma[LINJAAUTOLIIKENNE]',
+          'areas[0].haittojenhallintasuunnitelma[RAITOLIIKENNE]',
+          'areas[0].haittojenhallintasuunnitelma[MUUT]',
+        ],
+        liitteet: [],
+      };
+      const { user } = await setup(application);
+      await user.click(screen.getByRole('tab', { name: /haittojen hallinta/i }));
+
+      expect(screen.getAllByText('Täydennys:').length).toBe(6);
+    });
+
+    test('Shows changed information in contacts tab', async () => {
+      const application = cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>);
+      application.applicationData.propertyDeveloperWithContacts = cloneDeep(
+        application.applicationData.customerWithContacts,
+      );
+      application.taydennys = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+        applicationData: {
+          ...application.applicationData,
+          customerWithContacts: {
+            customer: {
+              ...application.applicationData.customerWithContacts!.customer,
+              name: 'New name',
+              email: 'newMail@test.com',
+            },
+            contacts: application.applicationData.customerWithContacts!.contacts,
+          },
+          propertyDeveloperWithContacts: null,
+          invoicingCustomer: {
+            ...application.applicationData.invoicingCustomer!,
+            name: 'Uusi Laskutus Oy',
+          },
+        },
+        muutokset: ['customerWithContacts', 'propertyDeveloperWithContacts', 'invoicingCustomer'],
+        liitteet: [],
+      };
+      const { user } = await setup(application);
+      await user.click(screen.getByRole('tab', { name: /yhteystiedot/i }));
+
+      expect(screen.getAllByText('Täydennys:').length).toBe(2);
+      expect(screen.getAllByText('Poistettu:').length).toBe(1);
+      expect(screen.getByText('New name')).toBeInTheDocument();
+      expect(screen.getByText('newMail@test.com')).toBeInTheDocument();
+      expect(screen.getByText('Uusi Laskutus Oy')).toBeInTheDocument();
+    });
+
+    test('Shows changed information in attachments tab', async () => {
+      const taydennysId = 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c';
+      const taydennysAttachments = createTaydennysAttachments(taydennysId, [
+        { attachmentType: 'LIIKENNEJARJESTELY' },
+        { attachmentType: 'VALTAKIRJA' },
+        { attachmentType: 'MUU' },
+      ]);
+      const application = cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>);
+      application.taydennys = {
+        id: taydennysId,
+        applicationData: application.applicationData,
+        muutokset: [],
+        liitteet: taydennysAttachments,
+      };
+      const { user } = await setup(application);
+      await user.click(screen.getByRole('tab', { name: /liitteet/i }));
+
+      expect(screen.getAllByText('Täydennys:').length).toBe(3);
+      taydennysAttachments.forEach((attachment) => {
+        expect(screen.getByText(attachment.fileName)).toBeInTheDocument();
+      });
+    });
+
     test('Taydennys can be sent', async () => {
       const application = cloneDeep(hakemukset[12]) as Application<KaivuilmoitusData>;
       application.taydennys = {

--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -1545,7 +1545,6 @@ describe('Excavation notification application view', () => {
       await user.click(screen.getByRole('tab', { name: /alueet/i }));
 
       expect(screen.getAllByText('Täydennys:').length).toBe(8);
-      screen.debug(undefined, 100000);
       expect(screen.getByText('392 m²')).toBeInTheDocument();
     });
 

--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -1483,7 +1483,7 @@ describe('Excavation notification application view', () => {
       ).toBeInTheDocument();
       expect(screen.getByText('JS2300003')).toBeInTheDocument();
       expect(screen.getByText('SL1234568')).toBeInTheDocument();
-      expect(screen.getByText('188 m²')).toBeInTheDocument();
+      expect(screen.getByText('221 m²')).toBeInTheDocument();
     });
 
     test('Shows changed information in areas tab', async () => {
@@ -1545,7 +1545,7 @@ describe('Excavation notification application view', () => {
       await user.click(screen.getByRole('tab', { name: /alueet/i }));
 
       expect(screen.getAllByText('Täydennys:').length).toBe(8);
-      expect(screen.getByText('392 m²')).toBeInTheDocument();
+      expect(screen.getByText('394 m²')).toBeInTheDocument();
     });
 
     test('Shows changed information in haittojen hallinta tab', async () => {

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -994,10 +994,15 @@ function ApplicationView({
               </FormSummarySection>
             </TabPanel>
             <TabPanel>
+              {/* Attachments panel */}
               {applicationType === 'EXCAVATION_NOTIFICATION' ? (
                 <KaivuilmoitusAttachmentSummary
                   formData={application as Application<KaivuilmoitusData>}
                   attachments={attachments}
+                  taydennysAttachments={taydennys?.liitteet}
+                  taydennysAdditionalInfo={
+                    (taydennys?.applicationData as KaivuilmoitusData).additionalInfo
+                  }
                 />
               ) : attachments ? (
                 <AttachmentSummary

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -213,7 +213,15 @@ function JohtoselvitysAreasInfo({
   );
 }
 
-function KaivuilmoitusAreasInfo({ areas }: { areas: KaivuilmoitusAlue[] | null }) {
+function KaivuilmoitusAreasInfo({
+  areas,
+  changedAreas,
+  muutokset,
+}: {
+  areas: KaivuilmoitusAlue[] | null;
+  changedAreas?: KaivuilmoitusAlue[];
+  muutokset?: string[];
+}) {
   const { t } = useTranslation();
   const locale = useLocale();
 
@@ -221,8 +229,27 @@ function KaivuilmoitusAreasInfo({ areas }: { areas: KaivuilmoitusAlue[] | null }
     return null;
   }
 
-  return areas.map((alue) => {
-    const { tyoalueet } = alue;
+  const areasChanged =
+    changedAreas &&
+    muutokset &&
+    changedAreas.filter((_, index) => muutokset.includes(`areas[${index}]`)).length > 0;
+
+  return areas.map((alue, index) => {
+    const changedAlue = changedAreas?.at(index);
+    const changedPropertyPrefix = `areas[${index}]`;
+    const { tyoalueet: originalTyoalueet } = alue;
+    const { tyoalueet: changedTyoalueet } = changedAlue ?? {};
+    const haittaIndexes = calculateLiikennehaittaindeksienYhteenveto(alue);
+    const changedHaittaIndexes =
+      changedAlue && calculateLiikennehaittaindeksienYhteenveto(changedAlue);
+    const haittaIndexesChanged = changedHaittaIndexes && haittaIndexes !== changedHaittaIndexes;
+    const tyonTarkoituksetAdded = changedAlue?.tyonTarkoitukset?.filter(
+      (tyonTarkoitus) => !alue?.tyonTarkoitukset?.includes(tyonTarkoitus),
+    );
+    const tyonTarkoituksetRemoved = alue.tyonTarkoitukset?.filter(
+      (tyonTarkoitus) => !changedAlue?.tyonTarkoitukset?.includes(tyonTarkoitus),
+    );
+
     return (
       <Accordion
         language={locale}
@@ -233,24 +260,70 @@ function KaivuilmoitusAreasInfo({ areas }: { areas: KaivuilmoitusAlue[] | null }
       >
         <FormSummarySection style={{ marginBottom: 'var(--spacing-l)' }}>
           <SectionItemTitle>{t('form:yhteystiedot:labels:osoite')}</SectionItemTitle>
-          <SectionItemContent>{alue.katuosoite}</SectionItemContent>
+          <SectionItemContent>
+            {alue.katuosoite}
+            {changedAlue &&
+              muutokset &&
+              muutokset.includes(`${changedPropertyPrefix}.katuosoite`) && (
+                <Box marginTop="var(--spacing-s)">
+                  {!changedAlue.katuosoite ? (
+                    <SectionItemContentRemoved>
+                      <p>{alue.katuosoite}</p>
+                    </SectionItemContentRemoved>
+                  ) : (
+                    <SectionItemContentAdded>
+                      <p>{changedAlue.katuosoite}</p>
+                    </SectionItemContentAdded>
+                  )}
+                </Box>
+              )}
+          </SectionItemContent>
           <SectionItemTitle>{t('hakemus:labels:tyonTarkoitus')}</SectionItemTitle>
           <SectionItemContent>
             {alue.tyonTarkoitukset?.map((tyyppi) => t(`hanke:tyomaaTyyppi:${tyyppi}`)).join(', ')}
+            {(tyonTarkoituksetAdded?.length || 0) > 0 && (
+              <SectionItemContentAdded marginTop="var(--spacing-s)">
+                {tyonTarkoituksetAdded?.map((changed) => (
+                  <p key={changed}>{t(`hanke:tyomaaTyyppi:${changed}`)}</p>
+                ))}
+              </SectionItemContentAdded>
+            )}
+            {(tyonTarkoituksetRemoved?.length || 0) > 0 && (
+              <SectionItemContentRemoved marginTop="var(--spacing-s)">
+                {tyonTarkoituksetRemoved?.map((removed) => (
+                  <p key={removed}>{t(`hanke:tyomaaTyyppi:${removed}`)}</p>
+                ))}
+              </SectionItemContentRemoved>
+            )}
           </SectionItemContent>
-          <SectionItemTitle>{t('form:headers:alueet')}</SectionItemTitle>
-          <SectionItemContent>
-            <TyoalueetList tyoalueet={tyoalueet} />
-          </SectionItemContent>
+          {!areasChanged && (
+            <>
+              <SectionItemTitle>{t('form:headers:alueet')}</SectionItemTitle>
+              <SectionItemContent>
+                <TyoalueetList tyoalueet={originalTyoalueet} />
+              </SectionItemContent>
+            </>
+          )}
           <SectionItemTitle>{t('form:labels:kokonaisAla')}</SectionItemTitle>
           <SectionItemContent>
-            <TotalSurfaceArea tyoalueet={tyoalueet} />
+            <TotalSurfaceArea tyoalueet={originalTyoalueet} changedAreas={changedTyoalueet} />
           </SectionItemContent>
         </FormSummarySection>
+        {haittaIndexesChanged && (
+          <Box marginBottom="var(--spacing-l)">
+            <Notification
+              type="alert"
+              size="small"
+              label={t('hanke:alue:haittaIndexesChangedLabel')}
+            >
+              {t('hanke:alue:haittaIndexesChanged')}
+            </Notification>
+          </Box>
+        )}
         <Box marginBottom="var(--spacing-l)">
           <HaittaIndexes
             heading={`${t('kaivuilmoitusForm:alueet:liikennehaittaindeksienYhteenveto')} (0-5)`}
-            haittaIndexData={calculateLiikennehaittaindeksienYhteenveto(alue)}
+            haittaIndexData={calculateLiikennehaittaindeksienYhteenveto(changedAlue ?? alue)}
             initiallyOpen
             autoHaitanKestoHeading={t(
               'kaivuilmoitusForm:haittojenHallinta:carTrafficNuisanceType:haitanKesto',
@@ -265,27 +338,89 @@ function KaivuilmoitusAreasInfo({ areas }: { areas: KaivuilmoitusAlue[] | null }
           <SectionItemTitle>{t('hankeForm:labels:meluHaitta')}</SectionItemTitle>
           <SectionItemContent>
             {alue.meluhaitta ? t(`hanke:meluHaitta:${alue.meluhaitta}`) : '-'}
+            {changedAlue &&
+              muutokset &&
+              muutokset.includes(`${changedPropertyPrefix}.meluhaitta`) && (
+                <Box marginTop="var(--spacing-s)">
+                  <SectionItemContentAdded>
+                    <p>{t(`hanke:meluHaitta:${changedAlue.meluhaitta}`)}</p>
+                  </SectionItemContentAdded>
+                </Box>
+              )}
           </SectionItemContent>
           <SectionItemTitle>{t('hankeForm:labels:polyHaitta')}</SectionItemTitle>
           <SectionItemContent>
             {alue.polyhaitta ? t(`hanke:polyHaitta:${alue.polyhaitta}`) : '-'}
+            {changedAlue &&
+              muutokset &&
+              muutokset.includes(`${changedPropertyPrefix}.polyhaitta`) && (
+                <Box marginTop="var(--spacing-s)">
+                  <SectionItemContentAdded>
+                    <p>{t(`hanke:polyHaitta:${changedAlue.polyhaitta}`)}</p>
+                  </SectionItemContentAdded>
+                </Box>
+              )}
           </SectionItemContent>
           <SectionItemTitle>{t('hankeForm:labels:tarinaHaitta')}</SectionItemTitle>
           <SectionItemContent>
             {alue.tarinahaitta ? t(`hanke:tarinaHaitta:${alue.tarinahaitta}`) : '-'}
+            {changedAlue &&
+              muutokset &&
+              muutokset.includes(`${changedPropertyPrefix}.tarinahaitta`) && (
+                <Box marginTop="var(--spacing-s)">
+                  <SectionItemContentAdded>
+                    <p>{t(`hanke:tarinaHaitta:${changedAlue.tarinahaitta}`)}</p>
+                  </SectionItemContentAdded>
+                </Box>
+              )}
           </SectionItemContent>
           <SectionItemTitle>{t('hankeForm:labels:kaistaHaitta')}</SectionItemTitle>
           <SectionItemContent>
             {alue.kaistahaitta ? t(`hanke:kaistaHaitta:${alue.kaistahaitta}`) : '-'}
+            {changedAlue &&
+              muutokset &&
+              muutokset.includes(`${changedPropertyPrefix}.kaistahaitta`) && (
+                <Box marginTop="var(--spacing-s)">
+                  <SectionItemContentAdded>
+                    <p>{t(`hanke:kaistaHaitta:${changedAlue.kaistahaitta}`)}</p>
+                  </SectionItemContentAdded>
+                </Box>
+              )}
           </SectionItemContent>
           <SectionItemTitle>{t('hankeForm:labels:kaistaPituusHaitta')}</SectionItemTitle>
           <SectionItemContent>
             {alue.kaistahaittojenPituus
               ? t(`hanke:kaistaPituusHaitta:${alue.kaistahaittojenPituus}`)
               : '-'}
+            {changedAlue &&
+              muutokset &&
+              muutokset.includes(`${changedPropertyPrefix}.kaistahaittojenPituus`) && (
+                <Box marginTop="var(--spacing-s)">
+                  <SectionItemContentAdded>
+                    <p>{t(`hanke:kaistaPituusHaitta:${changedAlue.kaistahaittojenPituus}`)}</p>
+                  </SectionItemContentAdded>
+                </Box>
+              )}
           </SectionItemContent>
           <SectionItemTitle>{t('hakemus:labels:areaAdditionalInfo')}</SectionItemTitle>
-          <SectionItemContent>{alue.lisatiedot ? alue.lisatiedot : '-'}</SectionItemContent>
+          <SectionItemContent>
+            {alue.lisatiedot ? alue.lisatiedot : '-'}
+            {changedAlue &&
+              muutokset &&
+              muutokset.includes(`${changedPropertyPrefix}.lisatiedot`) && (
+                <Box marginTop="var(--spacing-s)">
+                  {!changedAlue.lisatiedot ? (
+                    <SectionItemContentRemoved>
+                      <p>{alue.lisatiedot}</p>
+                    </SectionItemContentRemoved>
+                  ) : (
+                    <SectionItemContentAdded>
+                      <p>{changedAlue.lisatiedot}</p>
+                    </SectionItemContentAdded>
+                  )}
+                </Box>
+              )}
+          </SectionItemContent>
         </FormSummarySection>
       </Accordion>
     );
@@ -673,10 +808,12 @@ function ApplicationView({
               {applicationType === 'EXCAVATION_NOTIFICATION' && (
                 <KaivuilmoitusBasicInformationSummary
                   formData={application as Application<KaivuilmoitusData>}
+                  changedData={taydennys?.applicationData as KaivuilmoitusData}
+                  muutokset={taydennys?.muutokset}
                 >
                   <SectionItemTitle>{t('hakemus:labels:totalSurfaceArea')}</SectionItemTitle>
                   <SectionItemContent>
-                    <TotalSurfaceArea tyoalueet={tyoalueet} />
+                    <TotalSurfaceArea tyoalueet={tyoalueet} changedAreas={taydennysTyoalueet} />
                   </SectionItemContent>
                 </KaivuilmoitusBasicInformationSummary>
               )}
@@ -731,7 +868,11 @@ function ApplicationView({
                 />
               )}
               {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                <KaivuilmoitusAreasInfo areas={kaivuilmoitusAlueet} />
+                <KaivuilmoitusAreasInfo
+                  areas={kaivuilmoitusAlueet}
+                  changedAreas={taydennys?.applicationData?.areas as KaivuilmoitusAlue[]}
+                  muutokset={taydennys?.muutokset}
+                />
               )}
             </TabPanel>
             <TabPanel>

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -529,12 +529,14 @@ function ApplicationView({
     applicationType === 'CABLE_REPORT'
       ? (areas as ApplicationArea[])
       : (areas as KaivuilmoitusAlue[]).flatMap((area) => area.tyoalueet);
+  const kaivuilmoitusTaydennysAlueet =
+    applicationType === 'EXCAVATION_NOTIFICATION'
+      ? (application.taydennys?.applicationData.areas as KaivuilmoitusAlue[] | undefined)
+      : null;
   const taydennysTyoalueet =
     applicationType === 'CABLE_REPORT'
       ? (application.taydennys?.applicationData.areas as ApplicationArea[] | undefined)
-      : (application.taydennys?.applicationData.areas as KaivuilmoitusAlue[] | undefined)?.flatMap(
-          (area) => area.tyoalueet,
-        );
+      : kaivuilmoitusTaydennysAlueet?.flatMap((area) => area.tyoalueet);
   const kaivuilmoitusAlueet =
     applicationType === 'EXCAVATION_NOTIFICATION' ? (areas as KaivuilmoitusAlue[]) : null;
   const hankealueet = hanke?.alueet;
@@ -880,6 +882,9 @@ function ApplicationView({
               {applicationType === 'EXCAVATION_NOTIFICATION' &&
                 kaivuilmoitusAlueet?.map((alue, index) => {
                   const hankealue = hankealueet?.find((ha) => ha.id === alue.hankealueId);
+                  const taydennysAlue = kaivuilmoitusTaydennysAlueet?.find(
+                    (ta) => ta.hankealueId === alue.hankealueId,
+                  );
                   return (
                     <Accordion
                       language={locale}
@@ -892,7 +897,8 @@ function ApplicationView({
                     >
                       <HaittojenhallintasuunnitelmaInfo
                         key={alue.hankealueId}
-                        kaivuilmoitusAlue={alue}
+                        alue={alue}
+                        taydennysAlue={taydennysAlue}
                         hankealue={hankealue}
                       />
                     </Accordion>

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -984,7 +984,7 @@ function ApplicationView({
                     invoicingCustomer={(applicationData as KaivuilmoitusData).invoicingCustomer}
                     taydennysInvoicingCustomer={
                       (application.taydennys?.applicationData as KaivuilmoitusData)
-                        .invoicingCustomer
+                        ?.invoicingCustomer
                     }
                   />
                 )}
@@ -1001,7 +1001,7 @@ function ApplicationView({
                   attachments={attachments}
                   taydennysAttachments={taydennys?.liitteet}
                   taydennysAdditionalInfo={
-                    (taydennys?.applicationData as KaivuilmoitusData).additionalInfo
+                    (taydennys?.applicationData as KaivuilmoitusData)?.additionalInfo
                   }
                 />
               ) : attachments ? (

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -982,13 +982,29 @@ function ApplicationView({
                   />
                 )}
                 {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                  <InvoicingCustomerSummary
-                    invoicingCustomer={(applicationData as KaivuilmoitusData).invoicingCustomer}
-                    taydennysInvoicingCustomer={
+                  <>
+                    <InvoicingCustomerSummary
+                      invoicingCustomer={(applicationData as KaivuilmoitusData).invoicingCustomer}
+                      title={t('form:yhteystiedot:titles:invoicingCustomerInfo')}
+                    />
+                    {application.taydennys?.muutokset.includes('invoicingCustomer') &&
                       (application.taydennys?.applicationData as KaivuilmoitusData)
-                        ?.invoicingCustomer
-                    }
-                  />
+                        .invoicingCustomer && (
+                        <InvoicingCustomerSummary
+                          invoicingCustomer={
+                            (application.taydennys?.applicationData as KaivuilmoitusData)
+                              .invoicingCustomer ??
+                            (applicationData as KaivuilmoitusData).invoicingCustomer
+                          }
+                          title={
+                            !(applicationData as KaivuilmoitusData).invoicingCustomer
+                              ? t('form:yhteystiedot:titles:invoicingCustomerInfo')
+                              : undefined
+                          }
+                          ContentContainer={SectionItemContentAdded}
+                        />
+                      )}
+                  </>
                 )}
                 {paperDecisionReceiver && (
                   <PaperDecisionReceiverSummary paperDecisionReceiver={paperDecisionReceiver} />

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -243,6 +243,8 @@ function KaivuilmoitusAreasInfo({
     const changedHaittaIndexes =
       changedAlue && calculateLiikennehaittaindeksienYhteenveto(changedAlue);
     const haittaIndexesChanged = changedHaittaIndexes && haittaIndexes !== changedHaittaIndexes;
+    const tyonTarkoituksetChanged =
+      changedAlue && muutokset?.includes(`${changedPropertyPrefix}.tyonTarkoitukset`);
     const tyonTarkoituksetAdded = changedAlue?.tyonTarkoitukset?.filter(
       (tyonTarkoitus) => !alue?.tyonTarkoitukset?.includes(tyonTarkoitus),
     );
@@ -281,14 +283,14 @@ function KaivuilmoitusAreasInfo({
           <SectionItemTitle>{t('hakemus:labels:tyonTarkoitus')}</SectionItemTitle>
           <SectionItemContent>
             {alue.tyonTarkoitukset?.map((tyyppi) => t(`hanke:tyomaaTyyppi:${tyyppi}`)).join(', ')}
-            {(tyonTarkoituksetAdded?.length || 0) > 0 && (
+            {tyonTarkoituksetChanged && (tyonTarkoituksetAdded?.length || 0) > 0 && (
               <SectionItemContentAdded marginTop="var(--spacing-s)">
                 {tyonTarkoituksetAdded?.map((changed) => (
                   <p key={changed}>{t(`hanke:tyomaaTyyppi:${changed}`)}</p>
                 ))}
               </SectionItemContentAdded>
             )}
-            {(tyonTarkoituksetRemoved?.length || 0) > 0 && (
+            {tyonTarkoituksetChanged && (tyonTarkoituksetRemoved?.length || 0) > 0 && (
               <SectionItemContentRemoved marginTop="var(--spacing-s)">
                 {tyonTarkoituksetRemoved?.map((removed) => (
                   <p key={removed}>{t(`hanke:tyomaaTyyppi:${removed}`)}</p>

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -982,6 +982,10 @@ function ApplicationView({
                 {applicationType === 'EXCAVATION_NOTIFICATION' && (
                   <InvoicingCustomerSummary
                     invoicingCustomer={(applicationData as KaivuilmoitusData).invoicingCustomer}
+                    taydennysInvoicingCustomer={
+                      (application.taydennys?.applicationData as KaivuilmoitusData)
+                        .invoicingCustomer
+                    }
                   />
                 )}
                 {paperDecisionReceiver && (

--- a/src/domain/application/applicationView/Sidebar.test.tsx
+++ b/src/domain/application/applicationView/Sidebar.test.tsx
@@ -47,13 +47,13 @@ describe('Sidebar', () => {
         const { user } = render(<Sidebar hanke={hanke} application={application} />);
 
         expect(screen.getByText('Täydennykset')).toBeInTheDocument();
-        expect(screen.getByText('Työalue 1 (234 m²)')).toBeInTheDocument();
-        expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 1 (235 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
 
         await user.click(screen.getByText('Alkuperäiset'));
 
-        expect(screen.getByText('Työalue (234 m²)')).toBeInTheDocument();
-        expect(screen.queryByText('Työalue 2 (30 m²)')).not.toBeInTheDocument();
+        expect(screen.getByText('Työalue (235 m²)')).toBeInTheDocument();
+        expect(screen.queryByText('Työalue 2 (31 m²)')).not.toBeInTheDocument();
       });
 
       test('If there is no taydennys, should not show taydennys tabs', async () => {
@@ -113,15 +113,15 @@ describe('Sidebar', () => {
 
         expect(screen.getByText('Täydennykset')).toBeInTheDocument();
         await user.click(screen.getByText('Hankealue 2'));
-        expect(screen.getByText('Työalue 1 (158 m²)')).toBeInTheDocument();
-        expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
-        expect(screen.getByText('Työalue 3 (30 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 3 (31 m²)')).toBeInTheDocument();
 
         await user.click(screen.getByText('Alkuperäiset'));
 
-        expect(screen.getByText('Työalue 1 (158 m²)')).toBeInTheDocument();
-        expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
-        expect(screen.queryByText('Työalue 3 (30 m²)')).not.toBeInTheDocument();
+        expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
+        expect(screen.queryByText('Työalue 3 (31 m²)')).not.toBeInTheDocument();
       });
 
       test('If there is no taydennys, should not show taydennys tabs', async () => {

--- a/src/domain/application/applicationView/Sidebar.test.tsx
+++ b/src/domain/application/applicationView/Sidebar.test.tsx
@@ -2,66 +2,136 @@ import { cloneDeep } from 'lodash';
 import { render, screen } from '../../../testUtils/render';
 import hankkeet from '../../mocks/data/hankkeet-data';
 import hakemukset from '../../mocks/data/hakemukset-data';
-import { Application, JohtoselvitysData } from '../types/application';
+import { Application, JohtoselvitysData, KaivuilmoitusData } from '../types/application';
 import Sidebar from './Sidebar';
 import { HankeData } from '../../types/hanke';
 
 describe('Sidebar', () => {
-  describe('Taydennys', () => {
-    test('Should show correct taydennys content', async () => {
-      const hanke = cloneDeep(hankkeet[1]) as HankeData;
-      const application = cloneDeep(hakemukset[10]) as Application<JohtoselvitysData>;
-      application.taydennys = {
-        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
-        applicationData: {
-          ...application.applicationData,
-          areas: [
-            ...application.applicationData.areas,
-            {
-              name: '',
-              geometry: {
-                type: 'Polygon',
-                crs: {
-                  type: 'name',
-                  properties: {
-                    name: 'urn:ogc:def:crs:EPSG::3879',
+  describe('Johtoselvitys', () => {
+    describe('Taydennys', () => {
+      test('Should show correct taydennys content', async () => {
+        const hanke = cloneDeep(hankkeet[1]) as HankeData;
+        const application = cloneDeep(hakemukset[10]) as Application<JohtoselvitysData>;
+        application.taydennys = {
+          id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+          applicationData: {
+            ...application.applicationData,
+            areas: [
+              ...application.applicationData.areas,
+              {
+                name: '',
+                geometry: {
+                  type: 'Polygon',
+                  crs: {
+                    type: 'name',
+                    properties: {
+                      name: 'urn:ogc:def:crs:EPSG::3879',
+                    },
                   },
-                },
-                coordinates: [
-                  [
-                    [25498581.440262634, 6679345.526261961],
-                    [25498582.233686976, 6679350.99321805],
-                    [25498576.766730886, 6679351.786642391],
-                    [25498575.973306544, 6679346.319686302],
-                    [25498581.440262634, 6679345.526261961],
+                  coordinates: [
+                    [
+                      [25498581.440262634, 6679345.526261961],
+                      [25498582.233686976, 6679350.99321805],
+                      [25498576.766730886, 6679351.786642391],
+                      [25498575.973306544, 6679346.319686302],
+                      [25498581.440262634, 6679345.526261961],
+                    ],
                   ],
+                },
+              },
+            ],
+          },
+          muutokset: ['areas[1]'],
+          liitteet: [],
+        };
+        const { user } = render(<Sidebar hanke={hanke} application={application} />);
+
+        expect(screen.getByText('Täydennykset')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 1 (234 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
+
+        await user.click(screen.getByText('Alkuperäiset'));
+
+        expect(screen.getByText('Työalue (234 m²)')).toBeInTheDocument();
+        expect(screen.queryByText('Työalue 2 (30 m²)')).not.toBeInTheDocument();
+      });
+
+      test('If there is no taydennys, should not show taydennys tabs', async () => {
+        const hanke = cloneDeep(hankkeet[1]) as HankeData;
+        const application = cloneDeep(hakemukset[10]) as Application<JohtoselvitysData>;
+        render(<Sidebar hanke={hanke} application={application} />);
+
+        expect(screen.queryByText('Täydennykset')).not.toBeInTheDocument();
+        expect(screen.queryByText('Alkuperäiset')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Kaivuilmoitus', () => {
+    describe('Taydennys', () => {
+      test('Should show correct taydennys content', async () => {
+        const hanke = cloneDeep(hankkeet[1]) as HankeData;
+        const application = cloneDeep(hakemukset[12]) as Application<KaivuilmoitusData>;
+        application.taydennys = {
+          id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+          applicationData: {
+            ...application.applicationData,
+            areas: [
+              {
+                ...application.applicationData.areas[0],
+                tyoalueet: [
+                  ...application.applicationData.areas[0].tyoalueet,
+                  {
+                    area: 10,
+                    geometry: {
+                      type: 'Polygon',
+                      crs: {
+                        type: 'name',
+                        properties: {
+                          name: 'urn:ogc:def:crs:EPSG::3879',
+                        },
+                      },
+                      coordinates: [
+                        [
+                          [25498581.440262634, 6679345.526261961],
+                          [25498582.233686976, 6679350.99321805],
+                          [25498576.766730886, 6679351.786642391],
+                          [25498575.973306544, 6679346.319686302],
+                          [25498581.440262634, 6679345.526261961],
+                        ],
+                      ],
+                    },
+                  },
                 ],
               },
-            },
-          ],
-        },
-        muutokset: ['areas[1]'],
-        liitteet: [],
-      };
-      const { user } = render(<Sidebar hanke={hanke} application={application} />);
+            ],
+          },
+          muutokset: ['areas[0].tyoalueet[2]'],
+          liitteet: [],
+        };
+        const { user } = render(<Sidebar hanke={hanke} application={application} />);
 
-      expect(screen.getByText('Täydennykset')).toBeInTheDocument();
-      expect(screen.getByText('Työalue 1 (235 m²)')).toBeInTheDocument();
-      expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Täydennykset')).toBeInTheDocument();
+        await user.click(screen.getByText('Hankealue 2'));
+        expect(screen.getByText('Työalue 1 (158 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 3 (30 m²)')).toBeInTheDocument();
 
-      await user.click(screen.getByText('Alkuperäiset'));
+        await user.click(screen.getByText('Alkuperäiset'));
 
-      expect(screen.getByText('Työalue (235 m²)')).toBeInTheDocument();
-      expect(screen.queryByText('Työalue 2 (31 m²)')).not.toBeInTheDocument();
-    });
+        expect(screen.getByText('Työalue 1 (158 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
+        expect(screen.queryByText('Työalue 3 (30 m²)')).not.toBeInTheDocument();
+      });
 
-    test('If there is no taydennys, should not show taydennys tabs', async () => {
-      const hanke = cloneDeep(hankkeet[1]) as HankeData;
-      const application = cloneDeep(hakemukset[10]) as Application<JohtoselvitysData>;
-      render(<Sidebar hanke={hanke} application={application} />);
+      test('If there is no taydennys, should not show taydennys tabs', async () => {
+        const hanke = cloneDeep(hankkeet[1]) as HankeData;
+        const application = cloneDeep(hakemukset[12]) as Application<KaivuilmoitusData>;
+        render(<Sidebar hanke={hanke} application={application} />);
 
-      expect(screen.queryByText('Täydennykset')).not.toBeInTheDocument();
-      expect(screen.queryByText('Alkuperäiset')).not.toBeInTheDocument();
+        expect(screen.queryByText('Täydennykset')).not.toBeInTheDocument();
+        expect(screen.queryByText('Alkuperäiset')).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/domain/application/applicationView/Sidebar.tsx
+++ b/src/domain/application/applicationView/Sidebar.tsx
@@ -59,7 +59,6 @@ function KaivuilmoitusAlueet({
 }: Readonly<KaivuilmoitusAlueetProps>) {
   return (
     <>
-      {' '}
       {kaivuilmoitusAlueet?.map((kaivuilmoitusAlue) => {
         const hankeAlue = hanke.alueet.find((alue) => alue.id === kaivuilmoitusAlue.hankealueId);
 

--- a/src/domain/application/applicationView/Sidebar.tsx
+++ b/src/domain/application/applicationView/Sidebar.tsx
@@ -1,7 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { Box } from '@chakra-ui/layout';
 import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
-import { Application, ApplicationArea, KaivuilmoitusAlue } from '../types/application';
+import {
+  Application,
+  ApplicationArea,
+  KaivuilmoitusAlue,
+  KaivuilmoitusData,
+} from '../types/application';
 import { getAreaDefaultName } from '../utils';
 import { getAreaGeometry } from '../../johtoselvitys/utils';
 import Text from '../../../common/components/text/Text';
@@ -41,6 +46,52 @@ function SidebarTyoalueet({ tyoalueet, startTime, endTime }: Readonly<SidebarTyo
   });
 }
 
+type KaivuilmoitusAlueetProps = {
+  kaivuilmoitusAlueet?: KaivuilmoitusAlue[] | null;
+  hanke: HankeData;
+  applicationData: KaivuilmoitusData;
+};
+
+function KaivuilmoitusAlueet({
+  kaivuilmoitusAlueet,
+  hanke,
+  applicationData,
+}: Readonly<KaivuilmoitusAlueetProps>) {
+  return (
+    <>
+      {' '}
+      {kaivuilmoitusAlueet?.map((kaivuilmoitusAlue) => {
+        const hankeAlue = hanke.alueet.find((alue) => alue.id === kaivuilmoitusAlue.hankealueId);
+
+        return (
+          <CustomAccordion
+            key={kaivuilmoitusAlue.hankealueId}
+            accordionBorderBottom
+            headingSize="s"
+            heading={kaivuilmoitusAlue.name}
+            subHeading={
+              <Box marginTop="var(--spacing-2-xs)">
+                <ApplicationDates
+                  startTime={hankeAlue?.haittaAlkuPvm ?? null}
+                  endTime={hankeAlue?.haittaLoppuPvm ?? null}
+                />
+              </Box>
+            }
+          >
+            <Box marginLeft="var(--spacing-s)">
+              <SidebarTyoalueet
+                tyoalueet={kaivuilmoitusAlue.tyoalueet}
+                startTime={applicationData.startTime}
+                endTime={applicationData.endTime}
+              />
+            </Box>
+          </CustomAccordion>
+        );
+      })}
+    </>
+  );
+}
+
 type SidebarProps = {
   hanke: HankeData;
   application: Application;
@@ -62,6 +113,10 @@ export default function Sidebar({ hanke, application }: Readonly<SidebarProps>) 
   const kaivuilmoitusAlueet =
     applicationType === 'EXCAVATION_NOTIFICATION'
       ? (applicationData.areas as KaivuilmoitusAlue[])
+      : null;
+  const taydennysKaivuilmoitusAlueet =
+    applicationType === 'EXCAVATION_NOTIFICATION'
+      ? (taydennys?.applicationData.areas as KaivuilmoitusAlue[] | undefined)
       : null;
 
   const filterHankeAlueet = useFilterHankeAlueetByApplicationDates({
@@ -103,34 +158,13 @@ export default function Sidebar({ hanke, application }: Readonly<SidebarProps>) 
           endTime={applicationData.endTime}
         />
       )}
-      {applicationType === 'EXCAVATION_NOTIFICATION' &&
-        kaivuilmoitusAlueet?.map((kaivuilmoitusAlue) => {
-          const hankeAlue = hanke.alueet.find((alue) => alue.id === kaivuilmoitusAlue.hankealueId);
-          return (
-            <CustomAccordion
-              key={kaivuilmoitusAlue.hankealueId}
-              accordionBorderBottom
-              headingSize="s"
-              heading={kaivuilmoitusAlue.name}
-              subHeading={
-                <Box marginTop="var(--spacing-2-xs)">
-                  <ApplicationDates
-                    startTime={hankeAlue?.haittaAlkuPvm ?? null}
-                    endTime={hankeAlue?.haittaLoppuPvm ?? null}
-                  />
-                </Box>
-              }
-            >
-              <Box marginLeft="var(--spacing-s)">
-                <SidebarTyoalueet
-                  tyoalueet={kaivuilmoitusAlue.tyoalueet}
-                  startTime={applicationData.startTime}
-                  endTime={applicationData.endTime}
-                />
-              </Box>
-            </CustomAccordion>
-          );
-        })}
+      {applicationType === 'EXCAVATION_NOTIFICATION' && (
+        <KaivuilmoitusAlueet
+          kaivuilmoitusAlueet={kaivuilmoitusAlueet}
+          hanke={hanke}
+          applicationData={applicationData as KaivuilmoitusData}
+        />
+      )}
     </>
   );
 
@@ -155,6 +189,13 @@ export default function Sidebar({ hanke, application }: Readonly<SidebarProps>) 
                 tyoalueet={taydennysTyoalueet ?? []}
                 startTime={taydennys.applicationData.startTime}
                 endTime={taydennys.applicationData.endTime}
+              />
+            )}
+            {applicationType === 'EXCAVATION_NOTIFICATION' && (
+              <KaivuilmoitusAlueet
+                kaivuilmoitusAlueet={taydennysKaivuilmoitusAlueet}
+                hanke={hanke}
+                applicationData={applicationData as KaivuilmoitusData}
               />
             )}
           </Box>

--- a/src/domain/application/components/summary/InvoicingCustomerSummary.tsx
+++ b/src/domain/application/components/summary/InvoicingCustomerSummary.tsx
@@ -1,6 +1,10 @@
 import { useTranslation } from 'react-i18next';
 import { Box } from '@chakra-ui/react';
-import { SectionItemContent, SectionItemTitle } from '../../../forms/components/FormSummarySection';
+import {
+  SectionItemContent,
+  SectionItemContentAdded,
+  SectionItemTitle,
+} from '../../../forms/components/FormSummarySection';
 import { InvoicingCustomer } from '../../types/application';
 
 function isInvoicingCustomerEmpty(invoicingCustomer: InvoicingCustomer) {
@@ -23,12 +27,19 @@ function isInvoicingCustomerEmpty(invoicingCustomer: InvoicingCustomer) {
 
 type Props = {
   invoicingCustomer?: InvoicingCustomer | null;
+  taydennysInvoicingCustomer?: InvoicingCustomer | null;
 };
 
-export default function InvoicingCustomerSummary({ invoicingCustomer }: Readonly<Props>) {
+export default function InvoicingCustomerSummary({
+  invoicingCustomer,
+  taydennysInvoicingCustomer,
+}: Readonly<Props>) {
   const { t } = useTranslation();
 
-  if (!invoicingCustomer || isInvoicingCustomerEmpty(invoicingCustomer)) {
+  if (
+    (!invoicingCustomer || isInvoicingCustomerEmpty(invoicingCustomer)) &&
+    (!taydennysInvoicingCustomer || isInvoicingCustomerEmpty(taydennysInvoicingCustomer))
+  ) {
     return null;
   }
 
@@ -36,27 +47,53 @@ export default function InvoicingCustomerSummary({ invoicingCustomer }: Readonly
     <>
       <SectionItemTitle>{t('form:yhteystiedot:titles:invoicingCustomerInfo')}</SectionItemTitle>
       <SectionItemContent>
-        <div>
-          <Box marginBottom="var(--spacing-s)">
-            <p>{invoicingCustomer.name}</p>
-            <p>{invoicingCustomer.registryKey}</p>
-          </Box>
-          <Box marginBottom="var(--spacing-s)">
-            <p>{invoicingCustomer.ovt}</p>
-            <p>{invoicingCustomer.invoicingOperator}</p>
-            <p>{invoicingCustomer.customerReference}</p>
-          </Box>
-          <Box marginBottom="var(--spacing-s)">
-            <p>{invoicingCustomer.postalAddress.streetAddress.streetName}</p>
-            <p>
-              {invoicingCustomer.postalAddress.postalCode} {invoicingCustomer?.postalAddress.city}
-            </p>
-          </Box>
+        {invoicingCustomer && (
           <div>
-            <p>{invoicingCustomer.phone}</p>
-            <p>{invoicingCustomer.email}</p>
+            <Box marginBottom="var(--spacing-s)">
+              <p>{invoicingCustomer.name}</p>
+              <p>{invoicingCustomer.registryKey}</p>
+            </Box>
+            <Box marginBottom="var(--spacing-s)">
+              <p>{invoicingCustomer.ovt}</p>
+              <p>{invoicingCustomer.invoicingOperator}</p>
+              <p>{invoicingCustomer.customerReference}</p>
+            </Box>
+            <Box marginBottom="var(--spacing-s)">
+              <p>{invoicingCustomer.postalAddress.streetAddress.streetName}</p>
+              <p>
+                {invoicingCustomer.postalAddress.postalCode} {invoicingCustomer?.postalAddress.city}
+              </p>
+            </Box>
+            <div>
+              <p>{invoicingCustomer.phone}</p>
+              <p>{invoicingCustomer.email}</p>
+            </div>
           </div>
-        </div>
+        )}
+        {taydennysInvoicingCustomer && taydennysInvoicingCustomer !== invoicingCustomer && (
+          <SectionItemContentAdded>
+            <Box marginBottom="var(--spacing-s)">
+              <p>{taydennysInvoicingCustomer.name}</p>
+              <p>{taydennysInvoicingCustomer.registryKey}</p>
+            </Box>
+            <Box marginBottom="var(--spacing-s)">
+              <p>{taydennysInvoicingCustomer.ovt}</p>
+              <p>{taydennysInvoicingCustomer.invoicingOperator}</p>
+              <p>{taydennysInvoicingCustomer.customerReference}</p>
+            </Box>
+            <Box marginBottom="var(--spacing-s)">
+              <p>{taydennysInvoicingCustomer.postalAddress.streetAddress.streetName}</p>
+              <p>
+                {taydennysInvoicingCustomer.postalAddress.postalCode}{' '}
+                {invoicingCustomer?.postalAddress.city}
+              </p>
+            </Box>
+            <div>
+              <p>{taydennysInvoicingCustomer.phone}</p>
+              <p>{taydennysInvoicingCustomer.email}</p>
+            </div>
+          </SectionItemContentAdded>
+        )}
       </SectionItemContent>
     </>
   );

--- a/src/domain/application/components/summary/InvoicingCustomerSummary.tsx
+++ b/src/domain/application/components/summary/InvoicingCustomerSummary.tsx
@@ -1,14 +1,10 @@
-import { useTranslation } from 'react-i18next';
 import { Box } from '@chakra-ui/react';
-import {
-  SectionItemContent,
-  SectionItemContentAdded,
-  SectionItemTitle,
-} from '../../../forms/components/FormSummarySection';
+import { SectionItemContent, SectionItemTitle } from '../../../forms/components/FormSummarySection';
 import { InvoicingCustomer } from '../../types/application';
+import React from 'react';
 
 function isInvoicingCustomerEmpty(invoicingCustomer: InvoicingCustomer) {
-  if (
+  return (
     !invoicingCustomer.name &&
     !invoicingCustomer.registryKey &&
     !invoicingCustomer.ovt &&
@@ -19,46 +15,40 @@ function isInvoicingCustomerEmpty(invoicingCustomer: InvoicingCustomer) {
     !invoicingCustomer.postalAddress.city &&
     !invoicingCustomer.email &&
     !invoicingCustomer.phone
-  ) {
-    return true;
-  }
-  return false;
+  );
 }
 
 type Props = {
   invoicingCustomer?: InvoicingCustomer | null;
-  taydennysInvoicingCustomer?: InvoicingCustomer | null;
+  ContentContainer?: JSX.ElementType;
+  title?: string;
 };
 
 export default function InvoicingCustomerSummary({
   invoicingCustomer,
-  taydennysInvoicingCustomer,
+  ContentContainer = SectionItemContent,
+  title,
 }: Readonly<Props>) {
-  const { t } = useTranslation();
-
-  if (
-    (!invoicingCustomer || isInvoicingCustomerEmpty(invoicingCustomer)) &&
-    (!taydennysInvoicingCustomer || isInvoicingCustomerEmpty(taydennysInvoicingCustomer))
-  ) {
+  if (!invoicingCustomer || isInvoicingCustomerEmpty(invoicingCustomer)) {
     return null;
   }
 
   return (
     <>
-      <SectionItemTitle>{t('form:yhteystiedot:titles:invoicingCustomerInfo')}</SectionItemTitle>
-      <SectionItemContent>
+      {title ? <SectionItemTitle>{title}</SectionItemTitle> : <div />}
+      <ContentContainer>
         {invoicingCustomer && (
           <div>
-            <Box marginBottom="var(--spacing-s)">
+            <Box marginBottom="var(--spacing-xs)">
               <p>{invoicingCustomer.name}</p>
               <p>{invoicingCustomer.registryKey}</p>
             </Box>
-            <Box marginBottom="var(--spacing-s)">
+            <Box marginBottom="var(--spacing-xs)">
               <p>{invoicingCustomer.ovt}</p>
               <p>{invoicingCustomer.invoicingOperator}</p>
               <p>{invoicingCustomer.customerReference}</p>
             </Box>
-            <Box marginBottom="var(--spacing-s)">
+            <Box marginBottom="var(--spacing-xs)">
               <p>{invoicingCustomer.postalAddress.streetAddress.streetName}</p>
               <p>
                 {invoicingCustomer.postalAddress.postalCode} {invoicingCustomer?.postalAddress.city}
@@ -70,31 +60,7 @@ export default function InvoicingCustomerSummary({
             </div>
           </div>
         )}
-        {taydennysInvoicingCustomer && taydennysInvoicingCustomer !== invoicingCustomer && (
-          <SectionItemContentAdded>
-            <Box marginBottom="var(--spacing-s)">
-              <p>{taydennysInvoicingCustomer.name}</p>
-              <p>{taydennysInvoicingCustomer.registryKey}</p>
-            </Box>
-            <Box marginBottom="var(--spacing-s)">
-              <p>{taydennysInvoicingCustomer.ovt}</p>
-              <p>{taydennysInvoicingCustomer.invoicingOperator}</p>
-              <p>{taydennysInvoicingCustomer.customerReference}</p>
-            </Box>
-            <Box marginBottom="var(--spacing-s)">
-              <p>{taydennysInvoicingCustomer.postalAddress.streetAddress.streetName}</p>
-              <p>
-                {taydennysInvoicingCustomer.postalAddress.postalCode}{' '}
-                {invoicingCustomer?.postalAddress.city}
-              </p>
-            </Box>
-            <div>
-              <p>{taydennysInvoicingCustomer.phone}</p>
-              <p>{taydennysInvoicingCustomer.email}</p>
-            </div>
-          </SectionItemContentAdded>
-        )}
-      </SectionItemContent>
+      </ContentContainer>
     </>
   );
 }

--- a/src/domain/application/components/summary/KaivuilmoitusAttachmentSummary.tsx
+++ b/src/domain/application/components/summary/KaivuilmoitusAttachmentSummary.tsx
@@ -71,7 +71,7 @@ function AttachmentSummary({
         {mandates && mandates.length > 0 && <FileDownloadList files={mandates} />}
         {taydennysMandates && taydennysMandates.length > 0 && (
           <SectionItemContentAdded mt="var(--spacing-xs)">
-            <TaydennysAttachmentsList attachments={taydennysMandates} />
+            <TaydennysAttachmentsList attachments={taydennysMandates} allowDownload={false} />
           </SectionItemContentAdded>
         )}
       </SectionItemContent>

--- a/src/domain/application/components/summary/KaivuilmoitusAttachmentSummary.tsx
+++ b/src/domain/application/components/summary/KaivuilmoitusAttachmentSummary.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import {
   FormSummarySection,
   SectionItemContent,
+  SectionItemContentAdded,
   SectionItemTitle,
 } from '../../../forms/components/FormSummarySection';
 import {
@@ -12,13 +13,22 @@ import {
 } from '../../types/application';
 import FileDownloadList from '../../../../common/components/fileDownloadList/FileDownloadList';
 import { getAttachmentFile } from '../../attachments';
+import { TaydennysAttachmentMetadata } from '../../taydennys/types';
+import TaydennysAttachmentsList from '../../taydennys/components/TaydennysAttachmentsList';
 
 type Props = {
   formData: Application<KaivuilmoitusData>;
   attachments: ApplicationAttachmentMetadata[] | undefined;
+  taydennysAttachments?: TaydennysAttachmentMetadata[];
+  taydennysAdditionalInfo?: string | null;
 };
 
-function AttachmentSummary({ formData, attachments }: Props) {
+function AttachmentSummary({
+  formData,
+  attachments,
+  taydennysAttachments,
+  taydennysAdditionalInfo,
+}: Props) {
   const { t } = useTranslation();
 
   const { additionalInfo } = formData.applicationData;
@@ -31,6 +41,15 @@ function AttachmentSummary({ formData, attachments }: Props) {
   );
   const mandates = attachments?.filter((attachment) => attachment.attachmentType === 'VALTAKIRJA');
   const otherAttachments = attachments?.filter((attachment) => attachment.attachmentType === 'MUU');
+  const taydennysTrafficArrangementPlans = taydennysAttachments?.filter(
+    (attachment) => attachment.attachmentType === 'LIIKENNEJARJESTELY',
+  );
+  const taydennysMandates = taydennysAttachments?.filter(
+    (attachment) => attachment.attachmentType === 'VALTAKIRJA',
+  );
+  const taydennysOtherAttachments = taydennysAttachments?.filter(
+    (attachment) => attachment.attachmentType === 'MUU',
+  );
 
   return (
     <FormSummarySection>
@@ -41,19 +60,32 @@ function AttachmentSummary({ formData, attachments }: Props) {
         {trafficArrangementPlans && trafficArrangementPlans.length > 0 && (
           <FileDownloadList files={trafficArrangementPlans} download={download} />
         )}
+        {taydennysTrafficArrangementPlans && taydennysTrafficArrangementPlans.length > 0 && (
+          <SectionItemContentAdded mt="var(--spacing-xs)">
+            <TaydennysAttachmentsList attachments={taydennysTrafficArrangementPlans} />
+          </SectionItemContentAdded>
+        )}
       </SectionItemContent>
-
       <SectionItemTitle>{t('kaivuilmoitusForm:liitteetJaLisatiedot:mandate')}</SectionItemTitle>
       <SectionItemContent>
         {mandates && mandates.length > 0 && <FileDownloadList files={mandates} />}
+        {taydennysMandates && taydennysMandates.length > 0 && (
+          <SectionItemContentAdded mt="var(--spacing-xs)">
+            <TaydennysAttachmentsList attachments={taydennysMandates} />
+          </SectionItemContentAdded>
+        )}
       </SectionItemContent>
-
       <SectionItemTitle>
         {t('kaivuilmoitusForm:liitteetJaLisatiedot:otherAttachments')}
       </SectionItemTitle>
       <SectionItemContent>
         {otherAttachments && otherAttachments.length > 0 && (
           <FileDownloadList files={otherAttachments} download={download} />
+        )}
+        {taydennysOtherAttachments && taydennysOtherAttachments.length > 0 && (
+          <SectionItemContentAdded mt="var(--spacing-xs)">
+            <TaydennysAttachmentsList attachments={taydennysOtherAttachments} />
+          </SectionItemContentAdded>
         )}
       </SectionItemContent>
 
@@ -62,6 +94,11 @@ function AttachmentSummary({ formData, attachments }: Props) {
       </SectionItemTitle>
       <SectionItemContent>
         <p>{additionalInfo}</p>
+        {taydennysAdditionalInfo && (
+          <SectionItemContentAdded mt="var(--spacing-xs)">
+            <p>{taydennysAdditionalInfo}</p>
+          </SectionItemContentAdded>
+        )}
       </SectionItemContent>
     </FormSummarySection>
   );

--- a/src/domain/application/components/summary/KaivuilmoitusBasicInformationSummary.tsx
+++ b/src/domain/application/components/summary/KaivuilmoitusBasicInformationSummary.tsx
@@ -3,16 +3,26 @@ import { useTranslation } from 'react-i18next';
 import {
   FormSummarySection,
   SectionItemContent,
+  SectionItemContentAdded,
+  SectionItemContentRemoved,
   SectionItemTitle,
 } from '../../../forms/components/FormSummarySection';
 import { Application, KaivuilmoitusData } from '../../types/application';
+import { Box } from '@chakra-ui/react';
 
 type Props = {
   formData: Application<KaivuilmoitusData>;
   children?: React.ReactNode;
+  changedData?: KaivuilmoitusData;
+  muutokset?: string[];
 };
 
-export default function BasicInformationSummary({ formData, children }: Readonly<Props>) {
+export default function BasicInformationSummary({
+  formData,
+  children,
+  changedData,
+  muutokset,
+}: Readonly<Props>) {
   const { t } = useTranslation();
 
   const {
@@ -28,21 +38,86 @@ export default function BasicInformationSummary({ formData, children }: Readonly
     requiredCompetence,
   } = formData.applicationData;
 
+  const workIsAboutChanged: string[] =
+    muutokset?.filter((muutos) =>
+      ['constructionWork', 'maintenanceWork', 'emergencyWork'].includes(muutos),
+    ) ?? [];
+  const workIsAboutRemoved: string[] = workIsAboutChanged.filter(
+    (muutos) => changedData && !changedData[muutos as keyof KaivuilmoitusData],
+  );
+  const workIsAboutChangedButNotRemoved = workIsAboutChanged.filter(
+    (muutos) => !workIsAboutRemoved.includes(muutos),
+  );
+
+  const cableReportsAdded = changedData?.cableReports?.filter(
+    (cableReport) => !cableReports?.includes(cableReport),
+  );
+  const cableReportsRemoved = cableReports?.filter(
+    (cableReport) => !changedData?.cableReports?.includes(cableReport),
+  );
+
+  const placementContractsAdded = changedData?.placementContracts?.filter(
+    (placementContract) => !placementContracts?.includes(placementContract),
+  );
+  const placementContractsRemoved = placementContracts?.filter(
+    (placementContract) => !changedData?.placementContracts?.includes(placementContract),
+  );
+
   return (
     <FormSummarySection>
       <SectionItemTitle>{t('hakemus:labels:nimi')}</SectionItemTitle>
       <SectionItemContent>
         <p>{name}</p>
+        {changedData && muutokset && muutokset.includes('name') && (
+          <Box marginTop="var(--spacing-s)">
+            {!changedData.name ? (
+              <SectionItemContentRemoved>
+                <p>{name}</p>
+              </SectionItemContentRemoved>
+            ) : (
+              <SectionItemContentAdded>
+                <p>{changedData.name}</p>
+              </SectionItemContentAdded>
+            )}
+          </Box>
+        )}
       </SectionItemContent>
       <SectionItemTitle>{t('hakemus:labels:kuvaus')}</SectionItemTitle>
       <SectionItemContent>
         <p style={{ whiteSpace: 'pre-wrap' }}>{workDescription}</p>
+        {changedData && muutokset && muutokset.includes('workDescription') && (
+          <Box marginTop="var(--spacing-s)">
+            {!changedData.name ? (
+              <SectionItemContentRemoved>
+                <p style={{ whiteSpace: 'pre-wrap' }}>{workDescription}</p>
+              </SectionItemContentRemoved>
+            ) : (
+              <SectionItemContentAdded>
+                <p style={{ whiteSpace: 'pre-wrap' }}>{changedData.workDescription}</p>
+              </SectionItemContentAdded>
+            )}
+          </Box>
+        )}
       </SectionItemContent>
       <SectionItemTitle>{t('hakemus:labels:tyossaKyse')}</SectionItemTitle>
       <SectionItemContent>
         {constructionWork && <p>{t('hakemus:labels:constructionWork')}</p>}
         {maintenanceWork && <p>{t('hakemus:labels:maintenanceWork')}</p>}
         {emergencyWork && <p>{t('hakemus:labels:emergencyWorkKaivuilmoitus')}</p>}
+        {workIsAboutChangedButNotRemoved.length > 0 && (
+          <SectionItemContentAdded marginTop="var(--spacing-s)">
+            {workIsAboutChangedButNotRemoved.map((changed) => (
+              <p key={changed}>{t(`hakemus:labels:${changed}`)}</p>
+            ))}
+          </SectionItemContentAdded>
+        )}
+        {workIsAboutRemoved.length > 0 && (
+          <SectionItemContentRemoved marginTop="var(--spacing-s)">
+            {workIsAboutRemoved.map((removed) => (
+              <p key={removed}>{t(`hakemus:labels:${removed}`)}</p>
+            ))}
+          </SectionItemContentRemoved>
+        )}
       </SectionItemContent>
       {!cableReportDone && (
         <>
@@ -58,14 +133,41 @@ export default function BasicInformationSummary({ formData, children }: Readonly
       <SectionItemTitle>{t('hakemus:labels:cableReports')}</SectionItemTitle>
       <SectionItemContent>
         <p>{cableReports?.join(', ')}</p>
+        {(cableReportsAdded?.length || 0) > 0 && (
+          <SectionItemContentAdded marginTop="var(--spacing-s)">
+            {cableReportsAdded?.map((changed) => <p key={changed}>{changed}</p>)}
+          </SectionItemContentAdded>
+        )}
+        {(cableReportsRemoved?.length || 0) > 0 && (
+          <SectionItemContentRemoved marginTop="var(--spacing-s)">
+            {cableReportsRemoved?.map((removed) => <p key={removed}>{removed}</p>)}
+          </SectionItemContentRemoved>
+        )}
       </SectionItemContent>
       <SectionItemTitle>{t('hakemus:labels:placementContractsTitle')}</SectionItemTitle>
       <SectionItemContent>
         <p>{placementContracts?.join(', ')}</p>
+        {(placementContractsAdded?.length || 0) > 0 && (
+          <SectionItemContentAdded marginTop="var(--spacing-s)">
+            {placementContractsAdded?.map((changed) => <p key={changed}>{changed}</p>)}
+          </SectionItemContentAdded>
+        )}
+        {(placementContractsRemoved?.length || 0) > 0 && (
+          <SectionItemContentRemoved marginTop="var(--spacing-s)">
+            {placementContractsRemoved?.map((removed) => <p key={removed}>{removed}</p>)}
+          </SectionItemContentRemoved>
+        )}
       </SectionItemContent>
       <SectionItemTitle>{t('hakemus:labels:requiredCompetenceTitle')}</SectionItemTitle>
       <SectionItemContent>
         <p>{requiredCompetence ? t('common:yes') : t('common:no')}</p>
+        {changedData && muutokset && muutokset.includes('requiredCompetence') && (
+          <Box marginTop="var(--spacing-s)">
+            <SectionItemContentAdded>
+              <p>{changedData.requiredCompetence ? t('common:yes') : t('common:no')}</p>
+            </SectionItemContentAdded>
+          </Box>
+        )}
       </SectionItemContent>
       {children}
     </FormSummarySection>

--- a/src/domain/application/components/summary/KaivuilmoitusBasicInformationSummary.tsx
+++ b/src/domain/application/components/summary/KaivuilmoitusBasicInformationSummary.tsx
@@ -49,6 +49,7 @@ export default function BasicInformationSummary({
     (muutos) => !workIsAboutRemoved.includes(muutos),
   );
 
+  const cableRepostsChanged = changedData && muutokset && muutokset.includes('cableReports');
   const cableReportsAdded = changedData?.cableReports?.filter(
     (cableReport) => !cableReports?.includes(cableReport),
   );
@@ -56,6 +57,8 @@ export default function BasicInformationSummary({
     (cableReport) => !changedData?.cableReports?.includes(cableReport),
   );
 
+  const placementContractsChanged =
+    changedData && muutokset && muutokset.includes('placementContracts');
   const placementContractsAdded = changedData?.placementContracts?.filter(
     (placementContract) => !placementContracts?.includes(placementContract),
   );
@@ -133,12 +136,12 @@ export default function BasicInformationSummary({
       <SectionItemTitle>{t('hakemus:labels:cableReports')}</SectionItemTitle>
       <SectionItemContent>
         <p>{cableReports?.join(', ')}</p>
-        {(cableReportsAdded?.length || 0) > 0 && (
+        {cableRepostsChanged && (cableReportsAdded?.length || 0) > 0 && (
           <SectionItemContentAdded marginTop="var(--spacing-s)">
             {cableReportsAdded?.map((changed) => <p key={changed}>{changed}</p>)}
           </SectionItemContentAdded>
         )}
-        {(cableReportsRemoved?.length || 0) > 0 && (
+        {cableRepostsChanged && (cableReportsRemoved?.length || 0) > 0 && (
           <SectionItemContentRemoved marginTop="var(--spacing-s)">
             {cableReportsRemoved?.map((removed) => <p key={removed}>{removed}</p>)}
           </SectionItemContentRemoved>
@@ -147,12 +150,12 @@ export default function BasicInformationSummary({
       <SectionItemTitle>{t('hakemus:labels:placementContractsTitle')}</SectionItemTitle>
       <SectionItemContent>
         <p>{placementContracts?.join(', ')}</p>
-        {(placementContractsAdded?.length || 0) > 0 && (
+        {placementContractsChanged && (placementContractsAdded?.length || 0) > 0 && (
           <SectionItemContentAdded marginTop="var(--spacing-s)">
             {placementContractsAdded?.map((changed) => <p key={changed}>{changed}</p>)}
           </SectionItemContentAdded>
         )}
-        {(placementContractsRemoved?.length || 0) > 0 && (
+        {placementContractsChanged && (placementContractsRemoved?.length || 0) > 0 && (
           <SectionItemContentRemoved marginTop="var(--spacing-s)">
             {placementContractsRemoved?.map((removed) => <p key={removed}>{removed}</p>)}
           </SectionItemContentRemoved>

--- a/src/domain/application/taydennys/components/summary/ContactsSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/ContactsSummary.tsx
@@ -81,7 +81,10 @@ export default function TaydennysContactsSummary({
           />
         )}
         {invoicingCustomerChanged && (
-          <InvoicingCustomerSummary invoicingCustomer={invoicingCustomer} />
+          <InvoicingCustomerSummary
+            invoicingCustomer={invoicingCustomer}
+            title={t('form:yhteystiedot:titles:invoicingCustomerInfo')}
+          />
         )}
       </FormSummarySection>
     </>

--- a/src/domain/application/taydennys/components/summary/KaivuilmoitusHaittojenhallintaSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/KaivuilmoitusHaittojenhallintaSummary.tsx
@@ -57,7 +57,7 @@ export default function HaittojenhallintaSummary({
             <TabPanel key={alue.hankealueId}>
               <HaittojenhallintasuunnitelmaInfo
                 key={alue.hankealueId}
-                kaivuilmoitusAlue={alue}
+                alue={alue}
                 hankealue={hankealue}
                 visibleHaittojenhallintaTyypit={visibleHaittojenhallintaTyypit}
               />

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1182,7 +1182,12 @@ test('Should highlight selected work area', async () => {
 
   await user.click(workAreaTwo);
   expect(workAreaOne).not.toHaveClass('selected');
-  expect(await screen.findByRole('button', { name: 'Työalue 2' })).toHaveClass('selected');
+  await waitFor(
+    () => {
+      expect(screen.queryByRole('button', { name: 'Työalue 2' })).toHaveClass('selected');
+    },
+    { timeout: 5000 },
+  );
 });
 
 test('Should show initial traffic nuisance index summary', async () => {

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaSummary.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaSummary.tsx
@@ -30,7 +30,7 @@ export default function HaittojenhallintaSummary({ hankealueet, formData }: Read
           <TabPanel key={alue.hankealueId}>
             <HaittojenhallintasuunnitelmaInfo
               key={alue.hankealueId}
-              kaivuilmoitusAlue={alue}
+              alue={alue}
               hankealue={hankealue}
             />
           </TabPanel>

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.tsx
@@ -6,6 +6,7 @@ import { sortedLiikenneHaittojenhallintatyyppi } from '../../common/haittojenhal
 import {
   FormSummarySection,
   SectionItemContent,
+  SectionItemContentAdded,
   SectionItemTitle,
 } from '../../forms/components/FormSummarySection';
 import { Box, Grid, GridItem } from '@chakra-ui/react';
@@ -24,6 +25,7 @@ type LiikennehaitanHallintasuunnitelmaProps = {
   tyyppi: HAITTOJENHALLINTATYYPPI;
   indeksi: number;
   alue: KaivuilmoitusAlue;
+  taydennysAlue?: KaivuilmoitusAlue;
   hankealue?: HankeAlue;
 };
 
@@ -31,6 +33,7 @@ const LiikennehaitanHallintasuunnitelmaInfo: React.FC<LiikennehaitanHallintasuun
   tyyppi,
   indeksi,
   alue,
+  taydennysAlue,
   hankealue,
 }) => {
   const { t } = useTranslation();
@@ -55,6 +58,15 @@ const LiikennehaitanHallintasuunnitelmaInfo: React.FC<LiikennehaitanHallintasuun
             <Box whiteSpace="pre-wrap" wordBreak="break-word" paddingTop="var(--spacing-xs)">
               {alue.haittojenhallintasuunnitelma?.[tyyppi] ?? ''}
             </Box>
+            {taydennysAlue &&
+              taydennysAlue.haittojenhallintasuunnitelma?.[tyyppi] !==
+                alue.haittojenhallintasuunnitelma?.[tyyppi] && (
+                <SectionItemContentAdded>
+                  <Box whiteSpace="pre-wrap" wordBreak="break-word" paddingTop="var(--spacing-xs)">
+                    {taydennysAlue.haittojenhallintasuunnitelma?.[tyyppi] ?? ''}
+                  </Box>
+                </SectionItemContentAdded>
+              )}
           </GridItem>
           <GridItem width="80px">
             <HaittaIndex
@@ -76,18 +88,20 @@ const LiikennehaitanHallintasuunnitelmaInfo: React.FC<LiikennehaitanHallintasuun
 };
 
 type HaittojenHallintaProps = {
-  kaivuilmoitusAlue: KaivuilmoitusAlue;
+  alue: KaivuilmoitusAlue;
+  taydennysAlue?: KaivuilmoitusAlue;
   hankealue?: HankeAlue;
   visibleHaittojenhallintaTyypit?: HAITTOJENHALLINTATYYPPI[];
 };
 
 export const HaittojenhallintasuunnitelmaInfo: React.FC<HaittojenHallintaProps> = ({
-  kaivuilmoitusAlue,
+  alue,
+  taydennysAlue,
   hankealue,
   visibleHaittojenhallintaTyypit = haittojenhallintaTyypit,
 }) => {
   const { t } = useTranslation();
-  const tormaystarkasteluTulos = calculateLiikennehaittaindeksienYhteenveto(kaivuilmoitusAlue);
+  const tormaystarkasteluTulos = calculateLiikennehaittaindeksienYhteenveto(taydennysAlue ?? alue);
   const haittojenhallintatyypit = sortedLiikenneHaittojenhallintatyyppi(
     tormaystarkasteluTulos,
   ).filter(([haitta]) => visibleHaittojenhallintaTyypit.includes(haitta));
@@ -110,8 +124,21 @@ export const HaittojenhallintasuunnitelmaInfo: React.FC<HaittojenHallintaProps> 
                   text={hankealue?.haittojenhallintasuunnitelma?.YLEINEN ?? ''}
                 />
                 <Box whiteSpace="pre-wrap" wordBreak="break-word" paddingTop="var(--spacing-s)">
-                  {kaivuilmoitusAlue.haittojenhallintasuunnitelma?.YLEINEN ?? ''}
+                  {alue.haittojenhallintasuunnitelma?.YLEINEN ?? ''}
                 </Box>
+                {taydennysAlue &&
+                  taydennysAlue.haittojenhallintasuunnitelma?.YLEINEN !==
+                    alue.haittojenhallintasuunnitelma?.YLEINEN && (
+                    <SectionItemContentAdded>
+                      <Box
+                        whiteSpace="pre-wrap"
+                        wordBreak="break-word"
+                        paddingTop="var(--spacing-s)"
+                      >
+                        {taydennysAlue.haittojenhallintasuunnitelma?.YLEINEN ?? ''}
+                      </Box>
+                    </SectionItemContentAdded>
+                  )}
               </GridItem>
               <GridItem width="80px"></GridItem>
             </Grid>
@@ -123,7 +150,8 @@ export const HaittojenhallintasuunnitelmaInfo: React.FC<HaittojenHallintaProps> 
           <LiikennehaitanHallintasuunnitelmaInfo
             tyyppi={haitta}
             indeksi={indeksi}
-            alue={kaivuilmoitusAlue}
+            alue={alue}
+            taydennysAlue={taydennysAlue}
             hankealue={hankealue}
             key={haitta}
           />
@@ -148,8 +176,21 @@ export const HaittojenhallintasuunnitelmaInfo: React.FC<HaittojenHallintaProps> 
                   {t('kaivuilmoitusForm:haittojenHallinta:labels:YLEINEN')}
                 </Text>
                 <Box whiteSpace="pre-wrap" wordBreak="break-word" paddingTop="var(--spacing-xs)">
-                  {kaivuilmoitusAlue.haittojenhallintasuunnitelma?.MUUT ?? ''}
+                  {alue.haittojenhallintasuunnitelma?.MUUT ?? ''}
                 </Box>
+                {taydennysAlue &&
+                  taydennysAlue.haittojenhallintasuunnitelma?.MUUT !==
+                    alue.haittojenhallintasuunnitelma?.MUUT && (
+                    <SectionItemContentAdded>
+                      <Box
+                        whiteSpace="pre-wrap"
+                        wordBreak="break-word"
+                        paddingTop="var(--spacing-xs)"
+                      >
+                        {taydennysAlue.haittojenhallintasuunnitelma?.MUUT ?? ''}
+                      </Box>
+                    </SectionItemContentAdded>
+                  )}
               </GridItem>
               <GridItem width="80px"></GridItem>
             </Grid>

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -1652,7 +1652,6 @@ const hakemukset: Application[] = [
       constructionWork: true,
       maintenanceWork: false,
       emergencyWork: false,
-      propertyConnectivity: false,
       rockExcavation: false,
       cableReportDone: true,
       requiredCompetence: true,

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -554,7 +554,9 @@
       "totalSurfaceAreaLong": "Hanke-alueiden kokonaispinta-ala",
       "liikenneverkollinenHaitta": "Hankealueen liikenneverkollinen haitta",
       "haittaMaarittelyt": "Hankealueen omat haittamäärittelyt",
-      "liikennehaittaIndeksit": "Hankealueen liikennehaittaindeksit"
+      "liikennehaittaIndeksit": "Hankealueen liikennehaittaindeksit",
+      "haittaIndexesChangedLabel": "Liikennehaittaindeksit ovat muuttuneet",
+      "haittaIndexesChanged": "Työalueille lasketut liikennehaittaindeksit ovat muuttuneet. Tarkista haittojenhallintasuunnitelma."
     }
   },
   "hankeForm": {


### PR DESCRIPTION
# Description

Show kaivuilmoitus täydennys information in application view.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3293
Also, this implements issue https://helsinkisolutionoffice.atlassian.net/browse/HAI-3297

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create a täydennys for kaivuilmoitus
2. Do changes in täydennys
3. Check the application view for täydennys changes (check also the map in sidebar (HAI-3297))
4. Check also that regular kaivuilmoitus does not have any täydennys sections in application view

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
