### PR TITLE
Fix area calculation

### DIFF
--- a/src/common/components/map/utils.test.ts
+++ b/src/common/components/map/utils.test.ts
@@ -1,5 +1,31 @@
-import { Polygon } from 'ol/geom';
-import { isPolygonSelfIntersecting } from './utils';
+import { Point, Polygon } from 'ol/geom';
+import { getSurfaceArea, isPolygonSelfIntersecting } from './utils';
+
+describe('surface area', () => {
+  test('should return correct surface area for a polygon', () => {
+    const polygonToCheck = new Polygon([
+      [
+        [25496681.078125, 6673024.67578125],
+        [25496905.16015625, 6673024.67578125],
+        [25496905.16015625, 6673156.75],
+        [25496681.078125, 6673156.75],
+        [25496681.078125, 6673024.67578125],
+      ],
+    ]);
+
+    const result = getSurfaceArea(polygonToCheck);
+
+    expect(result).toBeCloseTo(29595.459213256836, 1);
+  });
+
+  test('should return NaN when the geometry is not a polygon', () => {
+    const pointToCheck = new Point([25496681.078125, 6673024.67578125]);
+
+    const result = getSurfaceArea(pointToCheck);
+
+    expect(result).toBe(NaN);
+  });
+});
 
 describe('self-intersecting polygon', () => {
   test('should return true if polygon is self-intersecting', () => {

--- a/src/common/components/map/utils.ts
+++ b/src/common/components/map/utils.ts
@@ -1,7 +1,6 @@
 import proj4 from 'proj4';
 import { register } from 'ol/proj/proj4';
 import { get as getProjection } from 'ol/proj';
-import { getArea } from 'ol/sphere';
 import Geometry from 'ol/geom/Geometry';
 import Polygon from 'ol/geom/Polygon';
 import { polygon } from '@turf/helpers';
@@ -18,7 +17,11 @@ export const projection = getProjection('EPSG:3879');
 projection?.setExtent([25440000, 6630000, 25571072, 6761072]);
 
 export function getSurfaceArea(geometry: Geometry) {
-  return getArea(geometry, { projection: projection || undefined });
+  if (geometry.getType() == 'Polygon') {
+    return (geometry as Polygon).getArea();
+  } else {
+    return NaN;
+  }
 }
 
 /**

--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -543,7 +543,7 @@ describe('Cable report application view', () => {
         ),
       ).toBeInTheDocument();
       expect(screen.getByText('Ei')).toBeInTheDocument();
-      expect(screen.getByText('264 m²')).toBeInTheDocument();
+      expect(screen.getByText('266 m²')).toBeInTheDocument();
     });
 
     test('Shows changed information in areas tab', async () => {
@@ -629,7 +629,7 @@ describe('Cable report application view', () => {
       await user.click(screen.getByRole('tab', { name: /alueet/i }));
 
       expect(screen.getAllByText('Täydennys:').length).toBe(2);
-      expect(screen.getByText('264 m²')).toBeInTheDocument();
+      expect(screen.getByText('266 m²')).toBeInTheDocument();
     });
 
     test('Shows changed information in contacts tab', async () => {
@@ -824,10 +824,10 @@ describe('Excavation notification application view', () => {
     expect(queryByText('Aidasmäentie 5')).toBeInTheDocument();
     expect(queryByText('Vesi, Viemäri')).toBeInTheDocument();
     expect(queryByText('Työalue 1')).toBeInTheDocument();
-    expect(queryByText('Pinta-ala: 158 m²')).toBeInTheDocument();
+    expect(queryByText('Pinta-ala: 159 m²')).toBeInTheDocument();
     expect(queryByText('Työalue 2')).toBeInTheDocument();
-    expect(queryByText('Pinta-ala: 30 m²')).toBeInTheDocument();
-    expect(queryByText('188 m²')).toBeInTheDocument();
+    expect(queryByText('Pinta-ala: 31 m²')).toBeInTheDocument();
+    expect(queryByText('190 m²')).toBeInTheDocument();
     expect(screen.getByTestId('test-pyoraliikenneindeksi')).toHaveTextContent('3');
     expect(screen.getByTestId('test-autoliikenneindeksi')).toHaveTextContent('3');
     expect(screen.getByTestId('test-linjaautoliikenneindeksi')).toHaveTextContent('0');

--- a/src/domain/application/applicationView/Sidebar.test.tsx
+++ b/src/domain/application/applicationView/Sidebar.test.tsx
@@ -46,13 +46,13 @@ describe('Sidebar', () => {
       const { user } = render(<Sidebar hanke={hanke} application={application} />);
 
       expect(screen.getByText('Täydennykset')).toBeInTheDocument();
-      expect(screen.getByText('Työalue 1 (234 m²)')).toBeInTheDocument();
-      expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
+      expect(screen.getByText('Työalue 1 (235 m²)')).toBeInTheDocument();
+      expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
 
       await user.click(screen.getByText('Alkuperäiset'));
 
-      expect(screen.getByText('Työalue (234 m²)')).toBeInTheDocument();
-      expect(screen.queryByText('Työalue 2 (30 m²)')).not.toBeInTheDocument();
+      expect(screen.getByText('Työalue (235 m²)')).toBeInTheDocument();
+      expect(screen.queryByText('Työalue 2 (31 m²)')).not.toBeInTheDocument();
     });
 
     test('If there is no taydennys, should not show taydennys tabs', async () => {

--- a/src/domain/application/applicationView/__snapshots__/ApplicationView.test.tsx.snap
+++ b/src/domain/application/applicationView/__snapshots__/ApplicationView.test.tsx.snap
@@ -108,7 +108,7 @@ exports[`Excavation notification application view Shows correct information in s
           >
             Työalue 1
              (
-            158 m²
+            159 m²
             )
           </p>
           <p>
@@ -125,7 +125,7 @@ exports[`Excavation notification application view Shows correct information in s
           >
             Työalue 2
              (
-            30 m²
+            31 m²
             )
           </p>
           <p>

--- a/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.test.tsx
+++ b/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.test.tsx
@@ -51,7 +51,7 @@ describe('JohtoselvitysAreaSummary', () => {
     );
 
     expect(screen.getByText('Työalue')).toBeInTheDocument();
-    expect(screen.getByText('Pinta-ala: 234 m²')).toBeInTheDocument();
+    expect(screen.getByText('Pinta-ala: 235 m²')).toBeInTheDocument();
     expect(screen.queryByText(/poistettu/i)).not.toBeInTheDocument();
   });
 
@@ -66,6 +66,6 @@ describe('JohtoselvitysAreaSummary', () => {
 
     expect(screen.getByText(/poistettu/i)).toBeInTheDocument();
     expect(screen.getByText('Työalue')).toBeInTheDocument();
-    expect(screen.getByText('Pinta-ala: 234 m²')).toBeInTheDocument();
+    expect(screen.getByText('Pinta-ala: 235 m²')).toBeInTheDocument();
   });
 });

--- a/src/domain/application/taydennys/components/summary/KaivuilmoitusAreaSummary.test.tsx
+++ b/src/domain/application/taydennys/components/summary/KaivuilmoitusAreaSummary.test.tsx
@@ -87,9 +87,9 @@ describe('Kaivuilmoitus taydennys AreaSummary', () => {
           element?.tagName === 'P' && element?.textContent === 'Työalueet (Hankealue 2)',
       ),
     ).toBeInTheDocument();
-    expect(screen.getByText('Työalue 1 (158 m²)')).toBeInTheDocument();
-    expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
-    expect(screen.getByText('Pinta-ala: 188 m²')).toBeInTheDocument();
+    expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
+    expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
+    expect(screen.getByText('Pinta-ala: 190 m²')).toBeInTheDocument();
     expect(screen.getByText('Katuosoite: Aidasmäentie 6')).toBeInTheDocument();
     expect(screen.getByText('Työn tarkoitus: Viemäri, Kaukolämpö')).toBeInTheDocument();
     expect(screen.getByText('Meluhaitta: Jatkuva meluhaitta')).toBeInTheDocument();
@@ -114,9 +114,9 @@ describe('Kaivuilmoitus taydennys AreaSummary', () => {
     );
 
     expect(screen.getByText(/poistettu/i)).toBeInTheDocument();
-    expect(screen.getByText('Työalue 1 (158 m²)')).toBeInTheDocument();
-    expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
-    expect(screen.getByText('Pinta-ala: 188 m²')).toBeInTheDocument();
+    expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
+    expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
+    expect(screen.getByText('Pinta-ala: 190 m²')).toBeInTheDocument();
     expect(screen.getByText('Katuosoite: Aidasmäentie 5')).toBeInTheDocument();
     expect(screen.getByText('Työn tarkoitus: Vesi')).toBeInTheDocument();
     expect(screen.getByText('Meluhaitta: Toistuva meluhaitta')).toBeInTheDocument();

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -112,10 +112,10 @@ test('Correct information about hanke should be displayed', async () => {
   expect(screen.queryByText('Ohjelmointi')).toBeInTheDocument();
   expect(screen.queryByText('Kaukolämpö')).toBeInTheDocument();
   expect(screen.queryByText('Ei')).toBeInTheDocument();
-  expect(screen.queryByText('11974 m²')).toBeInTheDocument();
+  expect(screen.queryByText('12041 m²')).toBeInTheDocument();
 
   // Data in sidebar
-  expect(screen.queryByText('Hankealue 1 (11974 m²)')).toBeInTheDocument();
+  expect(screen.queryByText('Hankealue 1 (12041 m²)')).toBeInTheDocument();
   expect(screen.queryByText('2.1.2023–24.2.2023')).toBeInTheDocument();
 
   // Change to areas tab
@@ -128,7 +128,7 @@ test('Correct information about hanke should be displayed', async () => {
   expect(screen.getByTestId('test-raitioliikenneindeksi')).toHaveTextContent('2');
   expect(screen.getByTestId('test-linjaautoliikenneindeksi')).toHaveTextContent('0');
   expect(screen.getByTestId('test-autoliikenneindeksi')).toHaveTextContent('3');
-  expect(screen.queryByText('11974 m²')).toBeInTheDocument();
+  expect(screen.queryByText('12041 m²')).toBeInTheDocument();
   expect(screen.queryByText('Meluhaitta: Satunnainen meluhaitta')).toBeInTheDocument();
   expect(screen.queryByText('Pölyhaitta: Toistuva pölyhaitta')).toBeInTheDocument();
   expect(screen.queryByText('Tärinähaitta: Jatkuva tärinähaitta')).toBeInTheDocument();

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -496,9 +496,9 @@ test('Should be able to fill form pages and show filled information in summary p
   // Areas information
   expect(screen.getByText(startDate)).toBeInTheDocument();
   expect(screen.getByText(endDate)).toBeInTheDocument();
-  expect(screen.getByText('Työalue 1 (158 m²)')).toBeInTheDocument();
-  expect(screen.getByText('Työalue 2 (30 m²)')).toBeInTheDocument();
-  expect(screen.getByText('Pinta-ala: 188 m²')).toBeInTheDocument();
+  expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
+  expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
+  expect(screen.getByText('Pinta-ala: 190 m²')).toBeInTheDocument();
   expect(screen.getByText('Katuosoite: Aidasmäentie 5')).toBeInTheDocument();
   expect(screen.getByText('Työn tarkoitus: Vesi, Viemäri')).toBeInTheDocument();
   expect(screen.getByText('Meluhaitta: Toistuva meluhaitta')).toBeInTheDocument();

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -481,7 +481,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 158.4294946899533,
+              area: 159.32433261766946,
               tormaystarkasteluTulos: {
                 liikennehaittaindeksi: {
                   indeksi: 3,
@@ -519,7 +519,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 30.345726208334995,
+              area: 30.517131072352957,
               tormaystarkasteluTulos: {
                 liikennehaittaindeksi: {
                   indeksi: 5,
@@ -683,7 +683,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 158.4294946899533,
+              area: 159.32433261766946,
             },
             {
               geometry: {
@@ -704,7 +704,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 30.345726208334995,
+              area: 30.517131072352957,
             },
           ],
           katuosoite: 'Aidasmäentie 5',
@@ -833,7 +833,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 158.4294946899533,
+              area: 159.32433261766946,
             },
             {
               geometry: {
@@ -854,7 +854,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 30.345726208334995,
+              area: 30.517131072352957,
             },
           ],
           katuosoite: 'Aidasmäentie 5',
@@ -1128,7 +1128,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 158.4294946899533,
+              area: 159.32433261766946,
             },
             {
               geometry: {
@@ -1149,7 +1149,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 30.345726208334995,
+              area: 30.517131072352957,
             },
           ],
           katuosoite: 'Aidasmäentie 5',
@@ -1475,7 +1475,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 158.4294946899533,
+              area: 159.32433261766946,
             },
             {
               geometry: {
@@ -1496,7 +1496,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 30.345726208334995,
+              area: 30.517131072352957,
             },
           ],
           katuosoite: 'Aidasmäentie 5',
@@ -1682,7 +1682,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 158.4294946899533,
+              area: 159.32433261766946,
               tormaystarkasteluTulos: {
                 liikennehaittaindeksi: {
                   indeksi: 3,
@@ -1720,7 +1720,7 @@ const hakemukset: Application[] = [
                   ],
                 ],
               },
-              area: 30.345726208334995,
+              area: 30.517131072352957,
               tormaystarkasteluTulos: {
                 liikennehaittaindeksi: {
                   indeksi: 3,


### PR DESCRIPTION
# Description

The area was calculated on a spherical surface, but the projection we use is projected on a flat plane, so the area calculations were wrong.

Use `Polygon.getArea()` to properly calculate the area to use the flat projection.

### Jira Issue:

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Other

# Checklist:

- [X] I have written new tests (if applicable)
- [X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: