### PR TITLE
HAI-769 Add notification to kaivuilmoitus form to show summary of validation errors

### DIFF
--- a/src/domain/application/yupSchemas.ts
+++ b/src/domain/application/yupSchemas.ts
@@ -67,10 +67,10 @@ const postalAddressSchema = yup.object({
 
 const requiredPostalAddressSchema = yup.object({
   streetAddress: yup.object({
-    streetName: yup.string().required(),
+    streetName: yup.string().required().meta({ pageName: FORM_PAGES.YHTEYSTIEDOT }),
   }),
-  postalCode: yup.string().required(),
-  city: yup.string().required(),
+  postalCode: yup.string().required().meta({ pageName: FORM_PAGES.YHTEYSTIEDOT }),
+  city: yup.string().required().meta({ pageName: FORM_PAGES.YHTEYSTIEDOT }),
 });
 
 function ovtRequired(postalAddress: PostalAddress, type: ContactType) {
@@ -82,17 +82,29 @@ function ovtRequired(postalAddress: PostalAddress, type: ContactType) {
 
 export const invoicingCustomerSchema = yup.object().shape(
   {
-    name: yup.string().trim().max(100).required(),
+    name: yup.string().trim().max(100).required().meta({ pageName: FORM_PAGES.YHTEYSTIEDOT }),
     type: yup.mixed<ContactType>().required(),
-    registryKey: registryKeySchema.required(),
+    registryKey: registryKeySchema.required().meta({ pageName: FORM_PAGES.YHTEYSTIEDOT }),
     registryKeyHidden: yup.boolean().required(),
     postalAddress: postalAddressSchema.when(['ovt', 'invoicingOperator'], {
       is: (ovt: string, invoicingOperator: string) => !ovt || !invoicingOperator,
       then: () => requiredPostalAddressSchema,
       otherwise: (schema) => schema,
     }),
-    email: yup.string().nullable().trim().email().max(100),
-    phone: yup.string().nullable().phone().trim().max(20),
+    email: yup
+      .string()
+      .nullable()
+      .trim()
+      .email()
+      .max(100)
+      .meta({ pageName: FORM_PAGES.YHTEYSTIEDOT }),
+    phone: yup
+      .string()
+      .nullable()
+      .phone()
+      .trim()
+      .max(20)
+      .meta({ pageName: FORM_PAGES.YHTEYSTIEDOT }),
     ovt: yup
       .string()
       .nullable()
@@ -101,14 +113,16 @@ export const invoicingCustomerSchema = yup.object().shape(
       .when(['postalAddress', 'type'], {
         is: ovtRequired,
         then: (schema) => schema.required(),
-      }),
+      })
+      .meta({ pageName: FORM_PAGES.YHTEYSTIEDOT }),
     invoicingOperator: yup
       .string()
       .nullable()
       .when(['postalAddress', 'type'], {
         is: ovtRequired,
         then: (schema) => schema.required(),
-      }),
+      })
+      .meta({ pageName: FORM_PAGES.YHTEYSTIEDOT }),
     customerReference: yup.string().nullable(),
   },
   [

--- a/src/domain/forms/components/FormFieldsErrorSummary.tsx
+++ b/src/domain/forms/components/FormFieldsErrorSummary.tsx
@@ -1,3 +1,4 @@
+import { Children } from 'react';
 import { Notification } from 'hds-react';
 import { Box } from '@chakra-ui/react';
 
@@ -7,6 +8,10 @@ type Props = {
 };
 
 export default function FormFieldsErrorSummary({ notificationLabel, children }: Readonly<Props>) {
+  if (Children.count(children) === 0) {
+    return null;
+  }
+
   return (
     <Notification label={notificationLabel} type="alert">
       <Box as="ul" marginLeft="var(--spacing-m)">

--- a/src/domain/kaivuilmoitus/components/FormErrorsNotification.tsx
+++ b/src/domain/kaivuilmoitus/components/FormErrorsNotification.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next';
+import { AnyObject } from 'yup';
+import FormFieldsErrorSummary from '../../forms/components/FormFieldsErrorSummary';
+import FormPagesErrorSummary from '../../forms/components/FormPagesErrorSummary';
+import { useFormErrorsByPage } from '../hooks/useFormErrorsByPage';
+import { validationSchema } from '../validationSchema';
+import { mapValidationErrorToErrorListItem } from '../mapValidationErrorToErrorListItem';
+import { KaivuilmoitusFormValues } from '../types';
+import { KaivuilmoitusTaydennysFormValues } from '../../kaivuilmoitusTaydennys/types';
+
+type Props = {
+  data: KaivuilmoitusFormValues | KaivuilmoitusTaydennysFormValues;
+  validationContext: AnyObject;
+  activeStepIndex: number;
+  lastStep: boolean;
+};
+
+export default function FormErrorsNotification({
+  data,
+  validationContext,
+  activeStepIndex,
+  lastStep,
+}: Readonly<Props>) {
+  const { t } = useTranslation();
+  const formErrorsByPage = useFormErrorsByPage(data, validationContext);
+
+  if (lastStep) {
+    return (
+      <FormPagesErrorSummary
+        data={data}
+        schema={validationSchema}
+        notificationLabel={t('hakemus:missingFields:notification:hakemusLabel')}
+      />
+    );
+  }
+
+  return (
+    <FormFieldsErrorSummary notificationLabel={t('hakemus:missingFields:notification:pageLabel')}>
+      {formErrorsByPage[activeStepIndex].map((error) =>
+        mapValidationErrorToErrorListItem(error, t, data),
+      )}
+    </FormFieldsErrorSummary>
+  );
+}

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
@@ -177,6 +177,7 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
                   variant="supplementary"
                   iconLeft={<IconPlusCircle />}
                   onClick={() => setVisible(haitta)}
+                  data-testid={`lisaa_${haitta}`}
                 >
                   {t('hankeForm:haittojenHallintaForm:addControlPlan')}
                 </Button>

--- a/src/domain/kaivuilmoitus/mapValidationErrorToErrorListItem.tsx
+++ b/src/domain/kaivuilmoitus/mapValidationErrorToErrorListItem.tsx
@@ -1,10 +1,13 @@
-import { FieldPath, FieldValues, UseFormGetValues } from 'react-hook-form';
 import { ValidationError } from 'yup';
 import { TFunction } from 'i18next';
 import { ContactType } from '../application/types/application';
 import { Link } from 'hds-react';
+import { KaivuilmoitusFormValues } from './types';
+import { KaivuilmoitusTaydennysFormValues } from '../kaivuilmoitusTaydennys/types';
 
-function getTranslationContextForContactType(contactType: keyof typeof ContactType | null) {
+function getTranslationContextForContactType(
+  contactType: keyof typeof ContactType | null | undefined,
+) {
   if (contactType === 'PERSON') {
     return 'person';
   } else if (contactType === 'OTHER') {
@@ -12,10 +15,10 @@ function getTranslationContextForContactType(contactType: keyof typeof ContactTy
   }
 }
 
-export function mapValidationErrorToErrorListItem<T extends FieldValues>(
+export function mapValidationErrorToErrorListItem(
   error: ValidationError,
   t: TFunction,
-  getValues: UseFormGetValues<T>,
+  formData: KaivuilmoitusFormValues | KaivuilmoitusTaydennysFormValues,
 ) {
   const errorPath = error.path?.replace('[', '.').replace(']', '');
   const pathParts = errorPath?.match(/(\w+)/g)?.filter((part) => part !== 'applicationData') || [];
@@ -27,13 +30,11 @@ export function mapValidationErrorToErrorListItem<T extends FieldValues>(
   let context;
   if (pathParts[0] === 'customerWithContacts') {
     context = getTranslationContextForContactType(
-      getValues('applicationData.customerWithContacts.customer.type' as FieldPath<T>),
+      formData.applicationData.customerWithContacts?.customer.type,
     );
   }
   if (pathParts[0] === 'invoicingCustomer') {
-    context = getTranslationContextForContactType(
-      getValues('applicationData.invoicingCustomer.type' as FieldPath<T>),
-    );
+    context = getTranslationContextForContactType(formData.applicationData.invoicingCustomer?.type);
   }
   if (pathParts[0] === 'startTime') {
     context = 'kaivuilmoitus';
@@ -52,7 +53,7 @@ export function mapValidationErrorToErrorListItem<T extends FieldValues>(
 
   const linkText = t(langKey, {
     count: Number(pathParts[1]) + 1,
-    areaName: getValues(`applicationData.areas.${pathParts[1]}.name` as FieldPath<T>),
+    areaName: formData.applicationData.areas[Number(pathParts[1])]?.name,
     context,
   });
 

--- a/src/domain/kaivuilmoitus/validationSchema.ts
+++ b/src/domain/kaivuilmoitus/validationSchema.ts
@@ -20,6 +20,7 @@ import {
 import { HaittaIndexData } from '../common/haittaIndexes/types';
 import { Taydennys, Taydennyspyynto } from '../application/taydennys/types';
 import haittojenhallintaSchema from '../common/haittojenhallinta/haittojenhallintaSchema';
+import { FORM_PAGES } from '../forms/types';
 
 const tyoalueSchema = yup.object({
   geometry: geometrySchema.required(),
@@ -31,13 +32,26 @@ const kaivuilmoitusAlueSchema = yup.object({
   name: yup.string().required(),
   hankealueId: yup.number().required(),
   tyoalueet: yup.array(tyoalueSchema).defined(),
-  katuosoite: yup.string().required(),
-  tyonTarkoitukset: yup.array(yup.mixed<HANKE_TYOMAATYYPPI_KEY>().defined()).min(1).required(),
-  meluhaitta: yup.mixed<HANKE_MELUHAITTA_KEY>().required(),
-  polyhaitta: yup.mixed<HANKE_POLYHAITTA_KEY>().required(),
-  tarinahaitta: yup.mixed<HANKE_TARINAHAITTA_KEY>().required(),
-  kaistahaitta: yup.mixed<HANKE_KAISTAHAITTA_KEY>().required(),
-  kaistahaittojenPituus: yup.mixed<HANKE_KAISTAPITUUSHAITTA_KEY>().required(),
+  katuosoite: yup.string().required().meta({ pageName: FORM_PAGES.ALUEET }),
+  tyonTarkoitukset: yup
+    .array(yup.mixed<HANKE_TYOMAATYYPPI_KEY>().defined())
+    .min(1)
+    .required()
+    .meta({ pageName: FORM_PAGES.ALUEET }),
+  meluhaitta: yup.mixed<HANKE_MELUHAITTA_KEY>().required().meta({ pageName: FORM_PAGES.ALUEET }),
+  polyhaitta: yup.mixed<HANKE_POLYHAITTA_KEY>().required().meta({ pageName: FORM_PAGES.ALUEET }),
+  tarinahaitta: yup
+    .mixed<HANKE_TARINAHAITTA_KEY>()
+    .required()
+    .meta({ pageName: FORM_PAGES.ALUEET }),
+  kaistahaitta: yup
+    .mixed<HANKE_KAISTAHAITTA_KEY>()
+    .required()
+    .meta({ pageName: FORM_PAGES.ALUEET }),
+  kaistahaittojenPituus: yup
+    .mixed<HANKE_KAISTAPITUUSHAITTA_KEY>()
+    .required()
+    .meta({ pageName: FORM_PAGES.ALUEET }),
   lisatiedot: yup.string(),
   haittojenhallintasuunnitelma: haittojenhallintaSchema,
 });
@@ -64,8 +78,8 @@ const customerWithContactsSchemaForKaivuilmoitus = customerWithContactsSchema
 export const applicationDataSchema = yup.object().shape(
   {
     applicationType: applicationTypeSchema,
-    name: yup.string().trim().required(),
-    workDescription: yup.string().trim().required(),
+    name: yup.string().trim().required().meta({ pageName: FORM_PAGES.PERUSTIEDOT }),
+    workDescription: yup.string().trim().required().meta({ pageName: FORM_PAGES.PERUSTIEDOT }),
     rockExcavation: yup
       .boolean()
       .defined()
@@ -77,18 +91,24 @@ export const applicationDataSchema = yup.object().shape(
       .when(['maintenanceWork', 'emergencyWork'], {
         is: false,
         then: (schema) => schema.isTrue(),
-      }),
+      })
+      .meta({ pageName: FORM_PAGES.PERUSTIEDOT }),
     maintenanceWork: yup.boolean().defined(),
     emergencyWork: yup.boolean().defined(),
-    cableReportDone: yup.boolean().required(),
+    cableReportDone: yup.boolean().required().meta({ pageName: FORM_PAGES.PERUSTIEDOT }),
     cableReports: yup
       .array()
       .of(yup.string().required())
       .when(['cableReportDone'], {
         is: true,
         then: (schema) => schema.min(1),
-      }),
-    requiredCompetence: yup.boolean().required().isTrue(),
+      })
+      .meta({ pageName: FORM_PAGES.PERUSTIEDOT }),
+    requiredCompetence: yup
+      .boolean()
+      .required()
+      .isTrue()
+      .meta({ pageName: FORM_PAGES.PERUSTIEDOT }),
     contractorWithContacts: customerWithContactsSchemaForKaivuilmoitus,
     customerWithContacts: customerWithContactsSchemaForKaivuilmoitusForTyostaVastaava,
     propertyDeveloperWithContacts: customerWithContactsSchemaForKaivuilmoitus.nullable(),
@@ -104,7 +124,8 @@ export const applicationDataSchema = yup.object().shape(
         }
       })
       .nullable()
-      .required(),
+      .required()
+      .meta({ pageName: FORM_PAGES.ALUEET }),
     endTime: yup
       .date()
       .when('startTime', (startTime: Date[], schema: yup.DateSchema) => {
@@ -115,7 +136,8 @@ export const applicationDataSchema = yup.object().shape(
         }
       })
       .nullable()
-      .required(),
+      .required()
+      .meta({ pageName: FORM_PAGES.ALUEET }),
     areas: yup.array(kaivuilmoitusAlueSchema).min(1).required(),
     additionalInfo: yup.string().max(2000).nullable(),
   },

--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
@@ -45,14 +45,12 @@ import ApplicationSaveNotification from '../application/components/ApplicationSa
 import TaydennysCancel from '../application/taydennys/components/TaydennysCancel';
 import Attachments from './Attachments';
 import useAttachments from '../application/hooks/useAttachments';
-import FormFieldsErrorSummary from '../forms/components/FormFieldsErrorSummary';
-import { mapValidationErrorToErrorListItem } from '../kaivuilmoitus/mapValidationErrorToErrorListItem';
-import { useFormErrorsByPage } from '../kaivuilmoitus/hooks/useFormErrorsByPage';
 import ReviewAndSend from './ReviewAndSend';
 import { isContactIn } from '../application/utils';
 import useSendTaydennys from '../application/taydennys/hooks/useSendTaydennys';
 import { usePermissionsForHanke } from '../hanke/hankeUsers/hooks/useUserRightsForHanke';
 import ConfirmationDialog from '../../common/components/HDSConfirmationDialog/ConfirmationDialog';
+import FormErrorsNotification from '../kaivuilmoitus/components/FormErrorsNotification';
 
 type Props = {
   taydennys: Taydennys<KaivuilmoitusData>;
@@ -211,15 +209,7 @@ export default function KaivuilmoitusTaydennysContainer({
   ];
 
   const [activeStepIndex, setActiveStepIndex] = useState(0);
-  const formErrorsByPage = useFormErrorsByPage(watchFormValues, { application: taydennys });
-
-  const formErrorsNotification = formErrorsByPage[activeStepIndex].length > 0 && (
-    <FormFieldsErrorSummary notificationLabel={t('hakemus:missingFields:notification:pageLabel')}>
-      {formErrorsByPage[activeStepIndex].map((error) =>
-        mapValidationErrorToErrorListItem(error, t, getValues),
-      )}
-    </FormFieldsErrorSummary>
-  );
+  const lastStep = activeStepIndex === formSteps.length - 1;
 
   function saveTaydennys(handleSuccess?: () => void) {
     const formData = getValues();
@@ -296,7 +286,14 @@ export default function KaivuilmoitusTaydennysContainer({
               taydennyspyynto={originalApplication.taydennyspyynto!}
               applicationType="EXCAVATION_NOTIFICATION"
             />
-            <Box mt="var(--spacing-s)">{formErrorsNotification}</Box>
+            <Box mt="var(--spacing-s)">
+              <FormErrorsNotification
+                data={watchFormValues}
+                validationContext={{ application: taydennys }}
+                activeStepIndex={activeStepIndex}
+                lastStep={lastStep}
+              />
+            </Box>
           </>
         }
         isLoading={attachmentsUploading}
@@ -316,7 +313,6 @@ export default function KaivuilmoitusTaydennysContainer({
             }
           }
 
-          const lastStep = activeStepIndex === formSteps.length - 1;
           const showSendButton =
             lastStep &&
             isValid &&


### PR DESCRIPTION
# Description

Notification shows validation errors in each page and list of pages with errors in the summary page.

Also added the list of pages with errors to kaivuilmoitus taydennys summary page.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-769

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check that when editing kaivuilmoitus form validation errors for current page are shown in notification in top of the form and a list of pages with errors in summary page.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
