### PR TITLE
HAI-131 Fix validation context for haittojenhallinta in hanke and kaivuilmoitus

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -491,6 +491,7 @@ function ApplicationView({
             <FormPagesErrorSummary
               data={taydennys ?? application}
               schema={validationSchema}
+              validationContext={{ application: taydennys ?? application }}
               notificationLabel={t('hakemus:missingFields:notification:hakemusLabel')}
             />
           </Box>

--- a/src/domain/application/hooks/useSaveApplication.ts
+++ b/src/domain/application/hooks/useSaveApplication.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useQueryClient } from 'react-query';
 import {
   createApplication,
   modifyDataAfterReceive,
@@ -32,6 +33,7 @@ export default function useSaveApplication<
   const [showSaveNotification, setShowSaveNotification] = useState<'create' | 'update' | null>(
     null,
   );
+  const queryClient = useQueryClient();
 
   const applicationCreateMutation = useDebouncedMutation(
     createApplication<ApplicationData, CreateData>,
@@ -57,6 +59,7 @@ export default function useSaveApplication<
         setShowSaveNotification(null);
       },
       onSuccess(application: Application<ApplicationData>) {
+        queryClient.setQueryData(['application', application.id], application);
         const modifiedData = modifyDataAfterReceive(application);
         onUpdateSuccess(modifiedData);
       },

--- a/src/domain/forms/MultipageForm.tsx
+++ b/src/domain/forms/MultipageForm.tsx
@@ -61,6 +61,7 @@ interface Props {
    */
   stepChangeValidator?: (changeStep: () => void, stepIndex: number) => void;
   formData?: unknown;
+  validationContext?: AnyObject;
 }
 
 /**
@@ -79,6 +80,7 @@ const MultipageForm: React.FC<Props> = ({
   stepChangeValidator,
   topElement,
   formData,
+  validationContext,
 }) => {
   const locale = useLocale();
 
@@ -113,20 +115,23 @@ const MultipageForm: React.FC<Props> = ({
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
     stepIndex: number,
   ) {
-    handleStepChange({ type: ACTION_TYPE.SET_ACTIVE, payload: { stepIndex, formData } });
+    handleStepChange({
+      type: ACTION_TYPE.SET_ACTIVE,
+      payload: { stepIndex, formData, validationContext },
+    });
   }
 
   function handlePrevious() {
     handleStepChange({
       type: ACTION_TYPE.SET_ACTIVE,
-      payload: { stepIndex: state.activeStepIndex - 1, formData },
+      payload: { stepIndex: state.activeStepIndex - 1, formData, validationContext },
     });
   }
 
   function handleNext() {
     handleStepChange({
       type: ACTION_TYPE.COMPLETE_STEP,
-      payload: { stepIndex: state.activeStepIndex, formData },
+      payload: { stepIndex: state.activeStepIndex, formData, validationContext },
     });
   }
 

--- a/src/domain/forms/components/FormPagesErrorSummary.tsx
+++ b/src/domain/forms/components/FormPagesErrorSummary.tsx
@@ -16,6 +16,7 @@ function sortPages(a: string, b: string) {
 type Props<T> = {
   data: T;
   schema: ObjectSchema<AnyObject>;
+  validationContext?: AnyObject;
   notificationLabel: string;
   /** Additional class names to apply to the notification */
   className?: string;
@@ -28,12 +29,13 @@ type Props<T> = {
 export default function FormPagesErrorSummary<T>({
   data,
   schema,
+  validationContext,
   notificationLabel,
   className,
   testId,
 }: Readonly<Props<T>>) {
   const { t } = useTranslation();
-  const validationErrors = useValidationErrors(schema, data);
+  const validationErrors = useValidationErrors(schema, data, validationContext);
   const schemasWithErrors = validationErrors.map(
     (error) => reach(schema, error.path as string).describe() as SchemaDescription,
   );

--- a/src/domain/forms/formStepReducer.ts
+++ b/src/domain/forms/formStepReducer.ts
@@ -19,7 +19,7 @@ export function createStepReducer(totalSteps: number) {
                 state:
                   !step.validationSchema ||
                   step.validationSchema.isValidSync(action.payload.formData, {
-                    context: step.context,
+                    context: action.payload.validationContext,
                   })
                     ? StepState.completed
                     : StepState.attention,
@@ -52,7 +52,7 @@ export function createStepReducer(totalSteps: number) {
                 state:
                   !step.validationSchema ||
                   step.validationSchema.isValidSync(action.payload.formData, {
-                    context: step.context,
+                    context: action.payload.validationContext,
                   })
                     ? StepState.completed
                     : StepState.attention,

--- a/src/domain/forms/types.ts
+++ b/src/domain/forms/types.ts
@@ -10,8 +10,6 @@ export interface StepperStep {
   label: string;
   state: StepState;
   validationSchema?: ObjectSchema<AnyObject>;
-  /** Context object for validation */
-  context?: AnyObject;
 }
 
 export interface State {
@@ -21,7 +19,7 @@ export interface State {
 
 export interface Action {
   type: ACTION_TYPE;
-  payload: { stepIndex: number; formData?: unknown };
+  payload: { stepIndex: number; formData?: unknown; validationContext?: AnyObject };
 }
 
 export enum FORM_PAGES {

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -339,7 +339,7 @@ const HankeView: React.FC<Props> = ({
 
       <InformationViewHeader backgroundColor="var(--color-summer-light)">
         <MainHeading>{hankeData?.nimi}</MainHeading>
-        <Text tag="h2" styleAs="h3" weight="bold" spacingBottom="l">
+        <Text tag="h2" styleAs="h3" weight="bold" spacingBottom="l" data-testid="hanke-tunnus">
           {hankeData?.hankeTunnus}
         </Text>
         <Text tag="p" styleAs="body-s" spacingBottom="l">
@@ -416,6 +416,7 @@ const HankeView: React.FC<Props> = ({
             <FormPagesErrorSummary
               data={hankeData}
               schema={hankeSchema}
+              validationContext={{ hanke: hankeData }}
               notificationLabel={t('hankePortfolio:draftState:labels:insufficientPhases')}
               testId="hankeDraftStateNotification"
             />

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -99,11 +99,12 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
       propertyDeveloperWithContacts: null,
     },
   };
+  const [validationContext, setValidationContext] = useState({ application });
   const formContext = useForm<KaivuilmoitusFormValues>({
     mode: 'onTouched',
     defaultValues: merge(initialValues, convertApplicationDataToFormState(application)),
     resolver: yupResolver(validationSchema),
-    context: { application },
+    context: validationContext,
   });
   const {
     getValues,
@@ -130,18 +131,21 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
     showSaveNotification,
     setShowSaveNotification,
   } = useSaveApplication<KaivuilmoitusData, KaivuilmoitusCreateData, KaivuilmoitusUpdateData>({
-    onCreateSuccess({ id }) {
-      setValue('id', id);
+    onCreateSuccess(data) {
+      setValidationContext({ application: data });
+      setValue('id', data.id);
     },
-    onUpdateSuccess({
-      applicationData: {
-        customerWithContacts,
-        contractorWithContacts,
-        propertyDeveloperWithContacts,
-        representativeWithContacts,
-        invoicingCustomer,
-      },
-    }) {
+    onUpdateSuccess(data) {
+      setValidationContext({ application: data });
+      const {
+        applicationData: {
+          customerWithContacts,
+          contractorWithContacts,
+          propertyDeveloperWithContacts,
+          representativeWithContacts,
+          invoicingCustomer,
+        },
+      } = data;
       if (customerWithContacts) {
         setValue(
           'applicationData.customerWithContacts.customer.yhteystietoId',
@@ -305,7 +309,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
       label: t('hankeForm:haittojenHallintaForm:header'),
       state: StepState.available,
       validationSchema: haittojenhallintaSuunnitelmaSchema,
-      context: { application },
     },
     {
       element: <Contacts hankeTunnus={hankeData.hankeTunnus} />,
@@ -360,11 +363,12 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
         topElement={
           <FormErrorsNotification
             data={watchFormValues}
-            validationContext={{ application }}
+            validationContext={{ application: watchFormValues }}
             activeStepIndex={activeStepIndex}
             lastStep={lastStep}
           />
         }
+        validationContext={{ application: watchFormValues }}
         onStepChange={handleStepChange}
         isLoading={attachmentsUploading}
         isLoadingText={attachmentsUploadingText}

--- a/src/domain/kaivuilmoitus/components/FormErrorsNotification.tsx
+++ b/src/domain/kaivuilmoitus/components/FormErrorsNotification.tsx
@@ -29,6 +29,7 @@ export default function FormErrorsNotification({
       <FormPagesErrorSummary
         data={data}
         schema={validationSchema}
+        validationContext={validationContext}
         notificationLabel={t('hakemus:missingFields:notification:hakemusLabel')}
       />
     );

--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
@@ -173,7 +173,6 @@ export default function KaivuilmoitusTaydennysContainer({
       label: t('hankeForm:haittojenHallintaForm:header'),
       state: StepState.available,
       validationSchema: haittojenhallintaSuunnitelmaSchema,
-      context: { application: taydennys },
     },
     {
       element: <Contacts hankeTunnus={hankeData.hankeTunnus} />,
@@ -280,6 +279,7 @@ export default function KaivuilmoitusTaydennysContainer({
         subHeading={`${hankeData.nimi} (${hankeData.hankeTunnus})`}
         formSteps={formSteps}
         formData={watchFormValues}
+        validationContext={{ application: watchFormValues }}
         topElement={
           <>
             <TaydennyspyyntoNotification
@@ -289,7 +289,7 @@ export default function KaivuilmoitusTaydennysContainer({
             <Box mt="var(--spacing-s)">
               <FormErrorsNotification
                 data={watchFormValues}
-                validationContext={{ application: taydennys }}
+                validationContext={{ application: watchFormValues }}
                 activeStepIndex={activeStepIndex}
                 lastStep={lastStep}
               />


### PR DESCRIPTION
# Description

There was a problem with validation context object not updating when making changes to hanke or work areas. This caused problems for haittojenhallinta liikennemuoto fields validation which depend on context given to validation.

Fixed this by making sure context object is always updated when saving in hanke, kaivuilmoitus and kaivuilmoitus taydennys forms.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-131

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create new kaivuilmoitus
2. Create work area(s) so that for example "Raitioliikenne" and "Linja-autojen paikallisliikenne" have haittaindeksi above 0
3. Go to haittojenhallinta page and check that those liikennemuodot haittojenhallinta fields are required and that those errors are shown in notification on top of the form
4. Go back to alueet page and change area(s) so that at least one of those previously required fields become optional (their haittaindeksi is 0)
5. Go back to haittojenhallinta page and check that those errors are not shown in notification and if all required haittojenhallinta fields are filled and you move to another form page, step is marked as valid
6. You can also check the same for hanke and kaivuilmoitus täydennys

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
