### PR TITLE
HAI-681: Add nuisance control tips to kaivuilmoitus

### DIFF
--- a/src/domain/common/haittaIndexes/ProcedureTips.tsx
+++ b/src/domain/common/haittaIndexes/ProcedureTips.tsx
@@ -40,7 +40,13 @@ export default function ProcedureTips({ haittojenhallintaTyyppi, haittaIndex }: 
   return (
     <>
       <Box mb="var(--spacing-s)">
-        <Button iconLeft={buttonIcon} variant="secondary" theme="black" {...accordionButtonProps}>
+        <Button
+          iconLeft={buttonIcon}
+          variant="secondary"
+          theme="black"
+          {...accordionButtonProps}
+          data-testid={`show-tips-button-${haittojenhallintaTyyppi}`}
+        >
           {t('hankeForm:haittojenHallintaForm:procedureTips:showTipsButton')}
         </Button>
       </Box>

--- a/src/domain/common/haittaIndexes/__snapshots__/ProcedureTips.test.tsx.snap
+++ b/src/domain/common/haittaIndexes/__snapshots__/ProcedureTips.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Should show correct tips for AUTOLIIKENNE and haittaindex 3 1`] = `
     <button
       aria-expanded="false"
       class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4"
+      data-testid="show-tips-button-AUTOLIIKENNE"
       type="button"
     >
       <div
@@ -145,6 +146,7 @@ exports[`Should show correct tips for AUTOLIIKENNE and haittaindex 4 1`] = `
     <button
       aria-expanded="false"
       class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4"
+      data-testid="show-tips-button-AUTOLIIKENNE"
       type="button"
     >
       <div
@@ -291,6 +293,7 @@ exports[`Should show correct tips for LINJAAUTOLIIKENNE and haittaindex 3 1`] = 
     <button
       aria-expanded="false"
       class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4"
+      data-testid="show-tips-button-LINJAAUTOLIIKENNE"
       type="button"
     >
       <div
@@ -420,6 +423,7 @@ exports[`Should show correct tips for MUUT and haittaindex 0 1`] = `
     <button
       aria-expanded="false"
       class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4"
+      data-testid="show-tips-button-MUUT"
       type="button"
     >
       <div
@@ -572,6 +576,7 @@ exports[`Should show correct tips for PYORALIIKENNE and haittaindex 4 1`] = `
     <button
       aria-expanded="false"
       class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4"
+      data-testid="show-tips-button-PYORALIIKENNE"
       type="button"
     >
       <div
@@ -685,6 +690,7 @@ exports[`Should show correct tips for PYORALIIKENNE and haittaindex 5 1`] = `
     <button
       aria-expanded="false"
       class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4"
+      data-testid="show-tips-button-PYORALIIKENNE"
       type="button"
     >
       <div
@@ -804,6 +810,7 @@ exports[`Should show correct tips for RAITIOLIIKENNE and haittaindex 4 1`] = `
     <button
       aria-expanded="false"
       class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4"
+      data-testid="show-tips-button-RAITIOLIIKENNE"
       type="button"
     >
       <div
@@ -984,6 +991,7 @@ exports[`Should show correct tips for RAITIOLIIKENNE and haittaindex 5 1`] = `
     <button
       aria-expanded="false"
       class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-black__m8giY button_hds-button--theme-black__3K_k4"
+      data-testid="show-tips-button-RAITIOLIIKENNE"
       type="button"
     >
       <div

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1743,6 +1743,7 @@ describe('Haittojenhallintasuunnitelma', () => {
       screen.getByText('Pyöräliikenteelle koituvien työalueen haittojen hallintasuunnitelma'),
     ).toBeInTheDocument();
     expect(screen.getByTestId('test-PYORALIIKENNE')).toHaveTextContent('3');
+    expect(screen.getByTestId('show-tips-button-PYORALIIKENNE')).toBeInTheDocument();
     expect(
       screen.getByTestId('applicationData.areas.0.haittojenhallintasuunnitelma.PYORALIIKENNE'),
     ).toBeRequired();
@@ -1750,11 +1751,13 @@ describe('Haittojenhallintasuunnitelma', () => {
       screen.getByText('Autoliikenteelle koituvien työalueen haittojen hallintasuunnitelma'),
     ).toBeInTheDocument();
     expect(screen.getByTestId('test-AUTOLIIKENNE')).toHaveTextContent('3');
+    expect(screen.getByTestId('show-tips-button-AUTOLIIKENNE')).toBeInTheDocument();
     expect(
       screen.getByTestId('applicationData.areas.0.haittojenhallintasuunnitelma.AUTOLIIKENNE'),
     ).toBeRequired();
     expect(screen.getByText('Linja-autojen paikallisliikenne')).toBeInTheDocument();
     expect(screen.queryByTestId('test-LINJAAUTOLIIKENNE')).toHaveTextContent('0');
+    expect(screen.queryByTestId('show-tips-button-LINJAAUTOLIIKENNE')).not.toBeInTheDocument();
     expect(
       screen.getByText(
         'Haitaton ei löytänyt tätä kohderyhmää alueelta. Voit tarvittaessa lisätä toimet haittojen hallintaan.',
@@ -1767,10 +1770,12 @@ describe('Haittojenhallintasuunnitelma', () => {
       screen.getByText('Raitioliikenteelle koituvien työalueen haittojen hallintasuunnitelma'),
     ).toBeInTheDocument();
     expect(screen.getByTestId('test-RAITIOLIIKENNE')).toHaveTextContent('5');
+    expect(screen.getByTestId('show-tips-button-RAITIOLIIKENNE')).toBeInTheDocument();
     expect(screen.getByText('Muiden työalueen haittojen hallintasuunnitelma')).toBeInTheDocument();
     expect(screen.getByTestId('test-meluHaitta')).toHaveTextContent('3');
     expect(screen.getByTestId('test-polyHaitta')).toHaveTextContent('5');
     expect(screen.getByTestId('test-tarinaHaitta')).toHaveTextContent('5');
+    expect(screen.getByTestId('show-tips-button-MUUT')).toBeInTheDocument();
   });
 
   test('Nuisance control plan can be filled', async () => {

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
@@ -24,6 +24,7 @@ import {
 import styles from './HaittojenhallintaSuunnitelma.module.scss';
 import HaittojenhallintaMap from './HaittojenhallintaMap';
 import useIsHaittojenhallintaSectionVisible from '../../common/haittojenhallinta/useIsHaittojenhallintaSectionVisible';
+import ProcedureTips from '../../common/haittaIndexes/ProcedureTips';
 
 type Props = {
   hankeAlue: HankeAlue;
@@ -161,13 +162,18 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
               )}
             </Box>
             {isVisible[haitta] ? (
-              <TextArea
-                name={`applicationData.areas.${index}.haittojenhallintasuunnitelma.${haitta}`}
-                label={t(`kaivuilmoitusForm:haittojenHallinta:labels:${haitta}`)}
-                testId={`applicationData.areas.${index}.haittojenhallintasuunnitelma.${haitta}`}
-                required={indeksi > 0}
-                helperText={t('kaivuilmoitusForm:haittojenHallinta:helperText')}
-              />
+              <>
+                <Box mt="var(--spacing-s)">
+                  <ProcedureTips haittojenhallintaTyyppi={haitta} haittaIndex={indeksi} />
+                </Box>
+                <TextArea
+                  name={`applicationData.areas.${index}.haittojenhallintasuunnitelma.${haitta}`}
+                  label={t(`kaivuilmoitusForm:haittojenHallinta:labels:${haitta}`)}
+                  testId={`applicationData.areas.${index}.haittojenhallintasuunnitelma.${haitta}`}
+                  required={indeksi > 0}
+                  helperText={t('kaivuilmoitusForm:haittojenHallinta:helperText')}
+                />
+              </>
             ) : (
               <>
                 <Box as="p" mb="var(--spacing-s)">
@@ -230,6 +236,9 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
           showIndex={false}
           className={styles.muutHaittojenHallintaToimetSubSection}
         />
+        <Box mt="var(--spacing-s)">
+          <ProcedureTips haittojenhallintaTyyppi="MUUT" haittaIndex={0} />
+        </Box>
         <Box mt="var(--spacing-m)">
           <TextArea
             name={`applicationData.areas.${index}.haittojenhallintasuunnitelma.${HAITTOJENHALLINTATYYPPI.MUUT}`}


### PR DESCRIPTION
# Description

Adds nuisance control tip accordions to kaivuilmoitus

### Jira Issue: HAI-681

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Nuisance control tips are shown in kaivuilmoitus. They are hidden by default if the index is zero for the area.

# Checklist:

- [x] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: