### PR TITLE
HAI-133 Show info hover on hanke and hakemus areas

### DIFF
--- a/src/domain/map/components/FeatureInfoOverlay/FeatureInfoOverlay.tsx
+++ b/src/domain/map/components/FeatureInfoOverlay/FeatureInfoOverlay.tsx
@@ -38,13 +38,23 @@ function HoverElement({
  */
 function FeatureInfoOverlay({
   render,
+  all = false,
 }: {
   render: (feature?: FeatureLike | null) => React.ReactNode;
+  all?: boolean;
 }) {
   const drawInteraction = useDrawInteraction();
   const isModifying = useIsModifying();
 
   const hoveredFeaturesWithPixel = useFeaturesAtPixel();
+  let hoveredFeatures = hoveredFeaturesWithPixel.map((f) => f?.feature);
+  if (all) {
+    // last feature is the Hanke feature which should be rendered at the top
+    hoveredFeatures = hoveredFeatures.reverse();
+  } else {
+    // only show the top feature info overlay
+    hoveredFeatures = hoveredFeatures.slice(0, 1);
+  }
 
   const {
     state: { selectedFeature },
@@ -65,7 +75,11 @@ function FeatureInfoOverlay({
       {/* Use div element for hovered features. */}
       {!selectedFeature && !drawInteraction?.getActive() && !isModifying && (
         <HoverElement position={hoveredFeaturesWithPixel[0]?.featurePixel}>
-          {render(hoveredFeaturesWithPixel[0]?.feature)}
+          <>
+            {hoveredFeatures.map((feature, index) => (
+              <React.Fragment key={index}>{render(feature)}</React.Fragment>
+            ))}
+          </>
         </HoverElement>
       )}
     </>

--- a/src/domain/map/components/Layers/HakemusLayer.tsx
+++ b/src/domain/map/components/Layers/HakemusLayer.tsx
@@ -6,6 +6,7 @@ import { ApplicationArea, KaivuilmoitusAlue } from '../../../application/types/a
 import VectorLayer from '../../../../common/components/map/layers/VectorLayer';
 import useApplicationFeatures from '../../hooks/useApplicationFeatures';
 import { OverlayProps } from '../../../../common/components/map/types';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
   hakemusId: number;
@@ -18,6 +19,7 @@ export default function HakemusLayer({
   layerStyle,
   featureProperties = {},
 }: Readonly<Props>) {
+  const { t } = useTranslation();
   const source = useRef(new VectorSource());
   const { data: application } = useApplication(hakemusId);
   let tyoalueet: ApplicationArea[] = [];
@@ -30,7 +32,7 @@ export default function HakemusLayer({
           );
   }
 
-  useApplicationFeatures(source.current, tyoalueet, {
+  useApplicationFeatures(source.current, t, tyoalueet, {
     overlayProps: new OverlayProps({
       heading: application
         ? `${application.applicationData.name} (${application.applicationIdentifier})`

--- a/src/domain/map/components/OwnHankeMap/OwnHankeMap.tsx
+++ b/src/domain/map/components/OwnHankeMap/OwnHankeMap.tsx
@@ -9,25 +9,33 @@ import { styleFunction } from '../../utils/geometryStyle';
 import FitSource from '../interations/FitSource';
 import useHankeFeatures from '../../hooks/useHankeFeatures';
 import styles from './OwnHankeMap.module.scss';
-import { ApplicationArea } from '../../../application/types/application';
+import { ApplicationArea, Tyoalue } from '../../../application/types/application';
 import useApplicationFeatures from '../../hooks/useApplicationFeatures';
+import { useTranslation } from 'react-i18next';
+import FeatureInfoOverlay from '../FeatureInfoOverlay/FeatureInfoOverlay';
+import { OverlayProps } from '../../../../common/components/map/types';
+import AreaOverlay from '../AreaOverlay/AreaOverlay';
+import DrawProvider from '../../../../common/components/map/modules/draw/DrawProvider';
 
 type Props = {
   hanke: HankeData;
-  tyoalueet?: ApplicationArea[];
+  tyoalueet?: ApplicationArea[] | Tyoalue[];
 };
 
 const OwnHankeMap: React.FC<Props> = ({ hanke, tyoalueet }) => {
+  const { t } = useTranslation();
+
   const hankeSource = useRef(new VectorSource());
-  useHankeFeatures(hankeSource.current, [hanke]);
+  useHankeFeatures(hankeSource.current, [hanke], false);
 
   const applicationSource = useRef(new VectorSource());
-  useApplicationFeatures(applicationSource.current, tyoalueet);
+  useApplicationFeatures(applicationSource.current, t, tyoalueet);
 
   return (
     <div className={styles.mapContainer}>
       <Map zoom={9} mapClassName={styles.mapContainer__inner} showAttribution={false}>
         <Kantakartta />
+
         <VectorLayer
           source={hankeSource.current}
           zIndex={100}
@@ -41,7 +49,18 @@ const OwnHankeMap: React.FC<Props> = ({ hanke, tyoalueet }) => {
           className="applicationGeometryLayer"
           style={(feature: FeatureLike) => styleFunction(feature, undefined, true)}
         />
+
         <FitSource source={tyoalueet?.length ? applicationSource.current : hankeSource.current} />
+
+        <DrawProvider source={applicationSource.current}>
+          <FeatureInfoOverlay
+            render={(feature) => {
+              const overlayProperties = feature?.get('overlayProps') as OverlayProps | undefined;
+              return <AreaOverlay overlayProps={overlayProperties} />;
+            }}
+            all={true}
+          />
+        </DrawProvider>
       </Map>
     </div>
   );

--- a/src/domain/map/hooks/useApplicationFeatures.ts
+++ b/src/domain/map/hooks/useApplicationFeatures.ts
@@ -27,7 +27,6 @@ export default function useApplicationFeatures(
 
         feature.setProperties(
           {
-            workAreaName: areaName,
             overlayProps: new OverlayProps({
               heading: areaName,
               backgroundColor: 'var(--color-suomenlinna-light)',
@@ -45,5 +44,5 @@ export default function useApplicationFeatures(
       source.addFeatures(applicationFeatures);
       featuresAdded.current = true;
     }
-  }, [source, areas, featureProperties]);
+  }, [source, areas, featureProperties, t]);
 }

--- a/src/domain/map/hooks/useApplicationFeatures.ts
+++ b/src/domain/map/hooks/useApplicationFeatures.ts
@@ -3,25 +3,35 @@ import { Vector } from 'ol/source';
 import GeoJSON from 'ol/format/GeoJSON';
 import { Feature } from 'ol';
 import { Geometry } from 'ol/geom';
-import { ApplicationArea } from '../../application/types/application';
+import { ApplicationArea, Tyoalue } from '../../application/types/application';
+import { getAreaDefaultName } from '../../application/utils';
+import { TFunction } from 'i18next';
+import { OverlayProps } from '../../../common/components/map/types';
 
 /**
  * Add features from application areas to map
  */
 export default function useApplicationFeatures(
   source: Vector,
-  areas?: ApplicationArea[],
+  t: TFunction,
+  areas?: ApplicationArea[] | Tyoalue[],
   featureProperties: { [x: string]: unknown } = {},
 ) {
   const featuresAdded = useRef(false);
 
   useEffect(() => {
     if (areas && areas.length > 0 && !featuresAdded.current) {
-      const applicationFeatures = areas.map((area) => {
+      const applicationFeatures = areas.map((area, index) => {
         const feature = new GeoJSON().readFeatures(area.geometry)[0] as Feature<Geometry>;
+        const areaName = getAreaDefaultName(t, index, areas.length);
 
         feature.setProperties(
           {
+            workAreaName: areaName,
+            overlayProps: new OverlayProps({
+              heading: areaName,
+              backgroundColor: 'var(--color-suomenlinna-light)',
+            }),
             liikennehaittaindeksi: area.tormaystarkasteluTulos
               ? area.tormaystarkasteluTulos.liikennehaittaindeksi.indeksi
               : null,

--- a/src/domain/map/hooks/useApplicationFeatures.ts
+++ b/src/domain/map/hooks/useApplicationFeatures.ts
@@ -40,7 +40,7 @@ export default function useApplicationFeatures(
         );
 
         return feature;
-      }) as Feature<Geometry>[];
+      });
       source.addFeatures(applicationFeatures);
       featuresAdded.current = true;
     }

--- a/src/domain/map/hooks/useHankeFeatures.ts
+++ b/src/domain/map/hooks/useHankeFeatures.ts
@@ -11,7 +11,11 @@ import { OverlayProps } from '../../../common/components/map/types';
  * and add liikennehaittaindeksi as property
  * for each feature
  */
-export default function useHankeFeatures(source: Vector, hankkeet: HankeData[]) {
+export default function useHankeFeatures(
+  source: Vector,
+  hankkeet: HankeData[],
+  fullDetails = true,
+) {
   useEffect(() => {
     source.clear();
     hankkeet.forEach((hanke) => {
@@ -35,9 +39,9 @@ export default function useHankeFeatures(source: Vector, hankkeet: HankeData[]) 
               id: alue.id,
               overlayProps: new OverlayProps({
                 heading: alue.nimi,
-                subHeading: `${hanke.nimi} (${hanke.hankeTunnus})`,
-                startDate: alue.haittaAlkuPvm,
-                endDate: alue.haittaLoppuPvm,
+                subHeading: fullDetails ? `${hanke.nimi} (${hanke.hankeTunnus})` : null,
+                startDate: fullDetails ? alue.haittaAlkuPvm : null,
+                endDate: fullDetails ? alue.haittaLoppuPvm : null,
                 backgroundColor: 'var(--color-summer-light)',
                 enableCopyArea: true,
               }),

--- a/src/domain/map/hooks/useHankeFeatures.ts
+++ b/src/domain/map/hooks/useHankeFeatures.ts
@@ -56,5 +56,5 @@ export default function useHankeFeatures(
       }
     });
     source.dispatchEvent('featuresAdded');
-  }, [source, hankkeet]);
+  }, [source, hankkeet, fullDetails]);
 }


### PR DESCRIPTION
# Description

Show info hover overlay in hanke and application view maps.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-133

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Have some applications and work areas in them
2. Check application view map - the name of hanke area with the name of the work area should be shown in hover overlay
3. Check hanke view map - the name of hanke area should be shown in hover overlay

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
