### PR TITLE
HAI-628 Show notification if haitta indexes increase when changing hanke areas

### DIFF
--- a/src/domain/common/haittaIndexes/utils.test.ts
+++ b/src/domain/common/haittaIndexes/utils.test.ts
@@ -1,0 +1,69 @@
+import { haveHaittaIndexesIncreased } from './utils';
+import { HAITTA_INDEX_TYPE, HaittaIndexData } from './types';
+
+describe('haveHaittaIndexesIncreased', () => {
+  const previousData: HaittaIndexData = {
+    liikennehaittaindeksi: {
+      indeksi: 4,
+      tyyppi: HAITTA_INDEX_TYPE.PYORALIIKENNEINDEKSI,
+    },
+    autoliikenne: {
+      indeksi: 2.5,
+      haitanKesto: 3,
+      katuluokka: 3,
+      liikennemaara: 3,
+      kaistahaitta: 1,
+      kaistapituushaitta: 1,
+    },
+    linjaautoliikenneindeksi: 2,
+    raitioliikenneindeksi: 3,
+    pyoraliikenneindeksi: 4,
+  };
+
+  test('should return false if previousData is not provided', () => {
+    const data: HaittaIndexData = { ...previousData };
+    expect(haveHaittaIndexesIncreased(data)).toBe(false);
+  });
+
+  test('should return false if all indexes are the same', () => {
+    const data: HaittaIndexData = { ...previousData };
+    expect(haveHaittaIndexesIncreased(data, previousData)).toBe(false);
+  });
+
+  test('should return true if autoliikenne index has increased', () => {
+    const data: HaittaIndexData = {
+      ...previousData,
+      autoliikenne: { ...previousData.autoliikenne, indeksi: 3 },
+    };
+    expect(haveHaittaIndexesIncreased(data, previousData)).toBe(true);
+  });
+
+  test('should return true if linjaautoliikenneindeksi has increased', () => {
+    const data: HaittaIndexData = { ...previousData, linjaautoliikenneindeksi: 3 };
+    expect(haveHaittaIndexesIncreased(data, previousData)).toBe(true);
+  });
+
+  test('should return true if raitioliikenneindeksi has increased', () => {
+    const data: HaittaIndexData = { ...previousData, raitioliikenneindeksi: 4 };
+    expect(haveHaittaIndexesIncreased(data, previousData)).toBe(true);
+  });
+
+  test('should return true if pyoraliikenneindeksi has increased', () => {
+    const data: HaittaIndexData = { ...previousData, pyoraliikenneindeksi: 5 };
+    expect(haveHaittaIndexesIncreased(data, previousData)).toBe(true);
+  });
+
+  test('should return false if all indexes have decreased or stayed the same', () => {
+    const data: HaittaIndexData = {
+      liikennehaittaindeksi: {
+        indeksi: 3,
+        tyyppi: HAITTA_INDEX_TYPE.PYORALIIKENNEINDEKSI,
+      },
+      autoliikenne: { ...previousData.autoliikenne, indeksi: 2 },
+      linjaautoliikenneindeksi: 1,
+      raitioliikenneindeksi: 2,
+      pyoraliikenneindeksi: 3,
+    };
+    expect(haveHaittaIndexesIncreased(data, previousData)).toBe(false);
+  });
+});

--- a/src/domain/common/haittaIndexes/utils.tsx
+++ b/src/domain/common/haittaIndexes/utils.tsx
@@ -1,0 +1,17 @@
+import { HaittaIndexData } from './types';
+
+// Check if any of the haitta indexes have increased
+export function haveHaittaIndexesIncreased(
+  data: HaittaIndexData,
+  previousData?: HaittaIndexData | null,
+) {
+  if (!previousData) {
+    return false;
+  }
+  return (
+    data.autoliikenne.indeksi > previousData.autoliikenne.indeksi ||
+    data.linjaautoliikenneindeksi > previousData.linjaautoliikenneindeksi ||
+    data.raitioliikenneindeksi > previousData.raitioliikenneindeksi ||
+    data.pyoraliikenneindeksi > previousData.pyoraliikenneindeksi
+  );
+}

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -854,6 +854,18 @@ describe('HankeForm', () => {
       expect(screen.getByTestId('test-raitioliikenneindeksi')).toHaveTextContent('3');
     });
   });
+
+  test('Should show notification if haitta indexes increase', async () => {
+    const { feature } = await setupHaittaIndexUpdateTest();
+
+    feature.changed();
+
+    expect(
+      await screen.findByText(
+        'Hankealueille lasketut liikennehaittaindeksit ovat muuttuneet. Tarkista haittojenhallintasuunnitelma.',
+      ),
+    ).toBeInTheDocument();
+  });
 });
 
 describe('New contact person form and contact person dropdown', () => {

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -115,6 +115,7 @@ export const hankeSchema: yup.ObjectSchema<HankeDataFormState> = yup.object().sh
   [FORMFIELD.TOTEUTTAJAT]: yup.array(yhteystietoSchema).defined(),
   [FORMFIELD.MUUTTAHOT]: yup.array(muuYhteystietoSchema).defined(),
   geometriesChanged: yup.boolean(),
+  haittaIndexesIncreased: yup.boolean().isFalse(),
   id: yup.number(),
   hankeTunnus: yup.string(),
   onYKTHanke: yup.boolean().nullable(),

--- a/src/domain/hanke/edit/types.ts
+++ b/src/domain/hanke/edit/types.ts
@@ -66,6 +66,7 @@ export interface HankeAlueFormState extends HankeAlue {
 
 export interface HankeDataFormState extends PartialExcept<HankeData, HankeContactTypeKey> {
   geometriesChanged?: boolean; // "virtualField"
+  haittaIndexesIncreased?: boolean; // "virtualField"
   alueet?: HankeAlueFormState[];
 }
 

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -707,7 +707,8 @@
       "noAlueet": "Piirrä alue kartalle merkitäksesi haitta-arviot.",
       "haitatHeader": "Alueen haitta-arviot",
       "haitatInstructions": "Anna arvio suurimmista mahdollisista vaikutuksista hankealueella.",
-      "removeAreaButton": "Poista alue"
+      "removeAreaButton": "Poista alue",
+      "haittaIndexesChanged": "Hankealueille lasketut liikennehaittaindeksit ovat muuttuneet. Tarkista haittojenhallintasuunnitelma."
     },
     "tyomaanTiedotForm": {
       "header": "Hankkeen lisätiedot"


### PR DESCRIPTION
# Description

In hanke form areas page for public hanke when changing hanke areas and haitta indexes are recalculated, if index for any liikennemuoto is increased, alert notification is displayed for user that haitta indexes have changed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-628

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Edit hanke that is public
2. Edit hanke area geometry or nuisance estimates (for example nuisance start date or dust nuisance) so that nuisance index of any liikennemuoto is increased)
3. There should appear a notification "Hankealueille lasketut liikennehaittaindeksit ovat muuttuneet. Tarkista haittojenhallintasuunnitelma." under the map

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
