### PR TITLE
HAI-682 Add two WMS layers for different zoom levels to maps

### DIFF
--- a/src/domain/map/components/Layers/Kantakartta.tsx
+++ b/src/domain/map/components/Layers/Kantakartta.tsx
@@ -17,36 +17,62 @@ const Kantakartta = () => {
     attributions: [t('map:attribution')],
   };
 
+  const WMSRequestParams = {
+    FORMAT: 'image/jpeg',
+    WIDTH: 256,
+    HEIGHT: 256,
+    VERSION: '1.1.1',
+    TRANSPARENT: 'false',
+  };
+
   return (
     <>
       <TileLayer
-        minZoom={9}
+        minZoom={10}
         source={
           new TileWMS({
             ...sourceOptions,
             params: {
+              ...WMSRequestParams,
               LAYERS: 'Kantakartta',
-              FORMAT: 'image/jpeg',
-              WIDTH: 256,
-              HEIGHT: 256,
-              VERSION: '1.1.1',
-              TRANSPARENT: 'false',
             },
           })
         }
       />
       <TileLayer
-        maxZoom={9}
+        maxZoom={10}
+        minZoom={8}
         source={
           new TileWMS({
             ...sourceOptions,
             params: {
+              ...WMSRequestParams,
+              LAYERS: 'Kiinteistokartan_maastotiedot',
+            },
+          })
+        }
+      />
+      <TileLayer
+        maxZoom={8}
+        minZoom={7}
+        source={
+          new TileWMS({
+            ...sourceOptions,
+            params: {
+              ...WMSRequestParams,
               LAYERS: 'Opaskartta_Helsinki',
-              FORMAT: 'image/jpeg',
-              WIDTH: 256,
-              HEIGHT: 256,
-              VERSION: '1.1.1',
-              TRANSPARENT: 'false',
+            },
+          })
+        }
+      />
+      <TileLayer
+        maxZoom={7}
+        source={
+          new TileWMS({
+            ...sourceOptions,
+            params: {
+              ...WMSRequestParams,
+              LAYERS: 'Opaskartta_Helsinki_harvanimi',
             },
           })
         }


### PR DESCRIPTION
# Description

For easier navigation and better experience for user when drawing hanke and work areas added 'Kiinteistokartan_maastotiedot' layer between 'Kantakartta' and 'Opaskartta_Helsinki' layers, which has maxZoom 10 and minZoom 8 and changed 'Kantakartta' minZoom from 9 to 10.

Also added 'Opaskartta_Helsinki_harvanimi' after 'Opaskartta_Helsinki' with maxZoom 7 and set 'Opaskartta_Helsinki' maxZoom to 8 and minZoom to 7.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-682

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check that layers in maps match https://kartta.hel.fi except that there are no "Yleiskartta" layers on outer zoom levels.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
