### PR TITLE
HAI-2088 Show dialog and prevent deletion of hanke area if there are application areas inside it

### DIFF
--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -459,7 +459,7 @@ describe('HankeForm', () => {
   });
 
   test('Should be able to save and quit', async () => {
-    const hanke = cloneDeep(hankkeet[0] as HankeDataFormState);
+    const hanke = cloneDeep(hankkeet[0]);
     const hankeName = hanke.nimi;
 
     const { user } = render(

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -17,8 +17,6 @@ import { Polygon } from 'ol/geom';
 import { waitForElementToBeRemoved } from '@testing-library/react';
 import { PathParams } from 'msw/lib/core/utils/matching/matchRequestUrl';
 import { Haittojenhallintasuunnitelma } from '../../common/haittojenhallinta/types';
-import hankkeenHakemukset from '../../mocks/data/hakemukset-data';
-import { hankealueContaisHakemusalues } from './utils';
 
 afterEach(cleanup);
 
@@ -784,11 +782,6 @@ describe('HankeForm', () => {
   test('Should not allow deletion of hanke area if there are application areas inside it', async () => {
     const hanke = cloneDeep(hankkeet[1] as HankeDataFormState);
     hanke.vaihe = 'OHJELMOINTI';
-    const hankealue = hanke.alueet![0];
-    console.log(hankealue.geometriat?.featureCollection.features);
-    const hakemukset = hankkeenHakemukset;
-    const x = hankealueContaisHakemusalues(hankealue, hakemukset);
-    console.log('Does hanke area contain hakemus areas?', x);
 
     const { user } = await setupAlueetPage(hanke);
 

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -17,6 +17,8 @@ import { Polygon } from 'ol/geom';
 import { waitForElementToBeRemoved } from '@testing-library/react';
 import { PathParams } from 'msw/lib/core/utils/matching/matchRequestUrl';
 import { Haittojenhallintasuunnitelma } from '../../common/haittojenhallinta/types';
+import hankkeenHakemukset from '../../mocks/data/hakemukset-data';
+import { hankealueContaisHakemusalues } from './utils';
 
 afterEach(cleanup);
 
@@ -457,7 +459,7 @@ describe('HankeForm', () => {
   });
 
   test('Should be able to save and quit', async () => {
-    const hanke = cloneDeep(hankkeet[1]);
+    const hanke = cloneDeep(hankkeet[0] as HankeDataFormState);
     const hankeName = hanke.nimi;
 
     const { user } = render(
@@ -473,8 +475,8 @@ describe('HankeForm', () => {
     fillBasicInformation({ name: hankeName });
     await user.click(screen.getByRole('button', { name: 'Tallenna ja keskeytä' }));
 
-    expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-2');
-    expect(screen.getByText(`Hanke ${hankeName} (HAI22-2) tallennettu omiin hankkeisiin.`));
+    expect(window.location.pathname).toBe('/fi/hankesalkku/HAI22-1');
+    expect(screen.getByText(`Hanke ${hankeName} (HAI22-1) tallennettu omiin hankkeisiin.`));
   });
 
   test('Should be able to save hanke in the last page', async () => {
@@ -652,6 +654,7 @@ describe('HankeForm', () => {
     const testHanke = {
       ...hankkeet[0],
       kuvaus: '',
+      tyomaaKatuosoite: '',
       vaihe: null,
     };
 
@@ -780,6 +783,13 @@ describe('HankeForm', () => {
 
   test('Should not allow deletion of hanke area if there are application areas inside it', async () => {
     const hanke = cloneDeep(hankkeet[1] as HankeDataFormState);
+    hanke.vaihe = 'OHJELMOINTI';
+    const hankealue = hanke.alueet![0];
+    console.log(hankealue.geometriat?.featureCollection.features);
+    const hakemukset = hankkeenHakemukset;
+    const x = hankealueContaisHakemusalues(hankealue, hakemukset);
+    console.log('Does hanke area contain hakemus areas?', x);
+
     const { user } = await setupAlueetPage(hanke);
 
     await user.click(screen.getByRole('button', { name: 'Poista alue' }));

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -778,6 +778,21 @@ describe('HankeForm', () => {
     expect(screen.queryByText(/hankealue 1/i)).not.toBeInTheDocument();
   });
 
+  test('Should not allow deletion of hanke area if there are application areas inside it', async () => {
+    const hanke = cloneDeep(hankkeet[1] as HankeDataFormState);
+    const { user } = await setupAlueetPage(hanke);
+
+    await user.click(screen.getByRole('button', { name: 'Poista alue' }));
+
+    const { getByRole, getByText } = within(screen.getByRole('dialog'));
+    expect(getByText('Aluetta ei voi poistaa')).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Sulje' })).toBeInTheDocument();
+
+    await user.click(getByRole('button', { name: 'Sulje' }));
+
+    expect(screen.queryByText(/hankealue 1/i)).toBeInTheDocument();
+  });
+
   async function setupHaittaIndexUpdateTest(
     nuisanceResponse = {
       autoliikenne: {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -620,6 +620,8 @@
       "rights": "Käyttöoikeutesi hankkeelle",
       "removeAreaTitle": "Poista alue",
       "removeAreaDescription": "Haluatko varmasti poistaa hankealueen {{areaName}}?",
+      "cannotRemoveAreaTitle": "Aluetta ei voi poistaa",
+      "cannotRemoveAreaDescription": "Hankealueen sisällä on hakemusten työalueita, joten aluetta ei voi poistaa. Tarkastele meneillään olevia hakemuksia hankesivun Hakemukset-välilehdellä.",
       "hankeAlue": "Hankealue",
       "haittojenhallintasuunnitelma": {
         "YLEINEN": "Toimet hankealueen haittojen hallintaan",
@@ -656,23 +658,27 @@
       "omistajat": {
         "nimi": "$t(form:yhteystiedot:titles:omistaja): $t(form:yhteystiedot:labels:nimi)",
         "email": "$t(form:yhteystiedot:titles:omistaja): $t(form:yhteystiedot:labels:email)",
-        "ytunnus": "$t(form:yhteystiedot:titles:omistaja): $t(form:yhteystiedot:labels:ytunnus)"
+        "ytunnus": "$t(form:yhteystiedot:titles:omistaja): $t(form:yhteystiedot:labels:ytunnus)",
+        "puhelinnumero": "$t(form:yhteystiedot:titles:omistaja): $t(form:yhteystiedot:labels:puhelinnumero)"
       },
       "toteuttajat": {
         "nimi": "$t(form:yhteystiedot:titles:toteuttajat): $t(form:yhteystiedot:labels:nimi)",
         "email": "$t(form:yhteystiedot:titles:toteuttajat): $t(form:yhteystiedot:labels:email)",
-        "ytunnus": "$t(form:yhteystiedot:titles:toteuttajat): $t(form:yhteystiedot:labels:ytunnus)"
+        "ytunnus": "$t(form:yhteystiedot:titles:toteuttajat): $t(form:yhteystiedot:labels:ytunnus)",
+        "puhelinnumero": "$t(form:yhteystiedot:titles:toteuttajat): $t(form:yhteystiedot:labels:puhelinnumero)"
       },
       "rakennuttajat": {
         "nimi": "$t(form:yhteystiedot:titles:rakennuttajat): $t(form:yhteystiedot:labels:nimi)",
         "email": "$t(form:yhteystiedot:titles:rakennuttajat): $t(form:yhteystiedot:labels:email)",
-        "ytunnus": "$t(form:yhteystiedot:titles:rakennuttajat): $t(form:yhteystiedot:labels:ytunnus)"
+        "ytunnus": "$t(form:yhteystiedot:titles:rakennuttajat): $t(form:yhteystiedot:labels:ytunnus)",
+        "puhelinnumero": "$t(form:yhteystiedot:titles:rakennuttajat): $t(form:yhteystiedot:labels:puhelinnumero)"
       },
       "muut": {
         "rooli": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:rooli)",
         "nimi": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:nimi)",
         "email": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:email)",
-        "ytunnus": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:ytunnus)"
+        "ytunnus": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:ytunnus)",
+        "puhelinnumero": "$t(form:yhteystiedot:titles:muut): $t(form:yhteystiedot:labels:puhelinnumero)"
       }
     },
     "toolTips": {


### PR DESCRIPTION
# Description

In Hanke form Alueet page when user tries to delete an area, check whether there are any application areas inside the hanke area and if so, show a dialog and prevent the user from deleting the area.

Implemented for both johtoselvityshakemus and kaivuilmoitus at the same time.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2088 and https://helsinkisolutionoffice.atlassian.net/browse/HAI-2090

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create a hanke or use an existing one
2. Create some applications for the hanke or use existing ones
3. Try to delete hanke areas that contain application areas - do the same for hanke areas that do not include any application areas
4. Check also that if application does not yet have any areas (only the first page has been filled) the system works okay

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
