### PR TITLE
HAI-551: Add hanke nuisance control info to kaivuilmoitus

### DIFF
--- a/src/domain/common/haittojenhallinta/CommonProcedureTips.tsx
+++ b/src/domain/common/haittojenhallinta/CommonProcedureTips.tsx
@@ -103,8 +103,7 @@ const CommonProcedureTips: React.FC = () => {
           '--header-font-size': 'var(--fontsize-heading-s)',
         }}
       >
-        {' '}
-        {renderProcedureTips()}
+        <Box mb="var(--spacing-s)"> {renderProcedureTips()}</Box>
       </Accordion>
     </Box>
   );

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1735,6 +1735,31 @@ describe('Haittojenhallintasuunnitelma', () => {
     return renderResult;
   }
 
+  test.only('Hanke nuisance control plans are shown', async () => {
+    await setupHaittojenHallintaPage();
+    expect(screen.queryByTestId('test-hanke-YLEINEN')).not.toBeInTheDocument();
+    expect(screen.getByTestId('test-hanke-PYORALIIKENNE')).toHaveTextContent('2');
+    expect(screen.getByTestId('test-hanke-nuisance-control-PYORALIIKENNE')).toHaveTextContent(
+      'Pyöräliikenteelle koituvien haittojen hallintasuunnitelma',
+    );
+    expect(screen.getByTestId('test-hanke-AUTOLIIKENNE')).toHaveTextContent('1.1');
+    expect(screen.getByTestId('test-hanke-nuisance-control-AUTOLIIKENNE')).toHaveTextContent(
+      'Autoliikenteelle koituvien haittojen hallintasuunnitelma',
+    );
+    expect(screen.getByTestId('test-hanke-LINJAAUTOLIIKENNE')).toHaveTextContent('3');
+    expect(screen.getByTestId('test-hanke-nuisance-control-LINJAAUTOLIIKENNE')).toHaveTextContent(
+      'Linja-autoliikenteelle koituvien haittojen hallintasuunnitelma',
+    );
+    expect(screen.getByTestId('test-hanke-RAITIOLIIKENNE')).toHaveTextContent('2');
+    expect(screen.getByTestId('test-hanke-nuisance-control-RAITIOLIIKENNE')).toHaveTextContent(
+      'Raitioliikenteelle koituvien haittojen hallintasuunnitelma',
+    );
+    expect(screen.queryByTestId('test-hanke-MUUT')).not.toBeInTheDocument();
+    expect(screen.getByTestId('test-hanke-nuisance-control-MUUT')).toHaveTextContent(
+      'Muiden haittojen hallintasuunnitelma',
+    );
+  });
+
   test('Nuisance control plan is shown correctly', async () => {
     await setupHaittojenHallintaPage();
 

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1735,7 +1735,7 @@ describe('Haittojenhallintasuunnitelma', () => {
     return renderResult;
   }
 
-  test.only('Hanke nuisance control plans are shown', async () => {
+  test('Hanke nuisance control plans are shown', async () => {
     await setupHaittojenHallintaPage();
     expect(screen.queryByTestId('test-hanke-YLEINEN')).not.toBeInTheDocument();
     expect(screen.getByTestId('test-hanke-PYORALIIKENNE')).toHaveTextContent('2');

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
@@ -69,7 +69,12 @@ function HankeNuisanceControl({
             />
           </Box>
         )}
-        <Box as="p" className="text-sm" data-testid={`test-hanke-nuisance-control-${haitta}`}>
+        <Box
+          as="p"
+          className="text-sm"
+          style={{ whiteSpace: 'pre-wrap' }}
+          data-testid={`test-hanke-nuisance-control-${haitta}`}
+        >
           {indeksi === 0 && !hankeText
             ? t('hankeForm:haittojenHallintaForm:noHankeNuisanceDetected')
             : hankeText}

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
@@ -49,6 +49,8 @@ function HankeNuisanceControl({
 }: Readonly<HankeNuisanceControlProps>) {
   const { t } = useTranslation();
 
+  if (!haitta) return null;
+
   const hankeText = haittojenhallintasuunnitelma && haittojenhallintasuunnitelma[haitta];
 
   return (
@@ -58,17 +60,18 @@ function HankeNuisanceControl({
           label={t('hakemus:labels:hankeAreaNuisanceControl')}
           style={{ overflow: 'visible' }}
         >
-          {haitta !== HAITTOJENHALLINTATYYPPI.YLEINEN && (
-            <Box mb="var(--spacing-s)">
-              <HaittaIndexHeading
-                index={indeksi}
-                haittojenhallintaTyyppi={haitta}
-                heading={t('kaivuilmoitusForm:haittojenHallinta:hankeHaittaindeksi')}
-                testId={`test-${haitta}`}
-              />
-            </Box>
-          )}
-          <Box as="p" className="text-sm">
+          {haitta !== HAITTOJENHALLINTATYYPPI.YLEINEN &&
+            haitta !== HAITTOJENHALLINTATYYPPI.MUUT && (
+              <Box mb="var(--spacing-s)">
+                <HaittaIndexHeading
+                  index={indeksi}
+                  haittojenhallintaTyyppi={haitta}
+                  heading={t('kaivuilmoitusForm:haittojenHallinta:hankeHaittaindeksi')}
+                  testId={`test-hanke-${haitta}`}
+                />
+              </Box>
+            )}
+          <Box as="p" className="text-sm" data-testid={`test-hanke-nuisance-control-${haitta}`}>
             {indeksi === 0 && !hankeText
               ? t('hankeForm:haittojenHallintaForm:noHankeNuisanceDetected')
               : hankeText}
@@ -86,7 +89,7 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
 }: Readonly<Props>) {
   const { t } = useTranslation();
 
-  const hankeTormaystarkasteluTulos = hankeAlue.tormaystarkasteluTulos as HaittaIndexData;
+  const hankeTormaystarkasteluTulos = hankeAlue?.tormaystarkasteluTulos as HaittaIndexData;
   const hankeHaittojenhallintatyypit = sortedLiikenneHaittojenhallintatyyppi(
     hankeTormaystarkasteluTulos,
   );
@@ -231,7 +234,7 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
             </Box>
             {isVisible[haitta] ? (
               <>
-                <Box mt="var(--spacing-s)">
+                <Box mt="var(--spacing-s)" mb="var(--spacing-s)">
                   <ProcedureTips haittojenhallintaTyyppi={haitta} haittaIndex={indeksi} />
                 </Box>
                 <TextArea
@@ -265,6 +268,7 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
           as="h4"
           backgroundColor="var(--color-black-10)"
           padding="var(--spacing-m)"
+          mb="var(--spacing-m)"
           className="heading-s"
         >
           {t(`hankeForm:haittojenHallintaForm:nuisanceType:${HAITTOJENHALLINTATYYPPI.MUUT}`)}
@@ -304,7 +308,12 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
           showIndex={false}
           className={styles.muutHaittojenHallintaToimetSubSection}
         />
+
         <Box mt="var(--spacing-s)">
+          <HankeNuisanceControl
+            haitta={HAITTOJENHALLINTATYYPPI.MUUT}
+            haittojenhallintasuunnitelma={hankeAlue?.haittojenhallintasuunnitelma}
+          />
           <ProcedureTips haittojenhallintaTyyppi="MUUT" haittaIndex={0} />
         </Box>
         <Box mt="var(--spacing-m)">

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
@@ -4,7 +4,10 @@ import { Box, Flex } from '@chakra-ui/layout';
 import { Button, IconPlusCircle, Notification } from 'hds-react';
 import TextArea from '../../../common/components/textArea/TextArea';
 import { KaivuilmoitusAlue } from '../../application/types/application';
-import { HAITTOJENHALLINTATYYPPI } from '../../common/haittojenhallinta/types';
+import {
+  Haittojenhallintasuunnitelma,
+  HAITTOJENHALLINTATYYPPI,
+} from '../../common/haittojenhallinta/types';
 import {
   mapNuisanceEnumIndexToNuisanceIndex,
   sortedLiikenneHaittojenhallintatyyppi,
@@ -34,32 +37,41 @@ type Props = {
 };
 
 type HankeNuisanceControlProps = {
-  indeksi: number | undefined;
+  indeksi?: number;
   haitta: HAITTOJENHALLINTATYYPPI;
-  hankeAlue: HankeAlue;
+  haittojenhallintasuunnitelma?: Haittojenhallintasuunnitelma;
 };
 
-function HankeNuisanceControl({ indeksi, haitta, hankeAlue }: Readonly<HankeNuisanceControlProps>) {
+function HankeNuisanceControl({
+  indeksi = 0,
+  haitta,
+  haittojenhallintasuunnitelma,
+}: Readonly<HankeNuisanceControlProps>) {
   const { t } = useTranslation();
-  if (!indeksi) {
-    return null;
-  }
+
+  const hankeText = haittojenhallintasuunnitelma && haittojenhallintasuunnitelma[haitta];
 
   return (
     <>
       <Box mb="var(--spacing-m)">
-        <Notification label={t('hakemus:labels:hankeAreaNuisanceControl')}>
-          <Box mb="var(--spacing-s)">
-            <HaittaIndexHeading
-              index={indeksi}
-              haittojenhallintaTyyppi={haitta}
-              heading={t('kaivuilmoitusForm:haittojenHallinta:haittaindeksi')}
-              testId={`test-${haitta}`}
-            />
-          </Box>
+        <Notification
+          label={t('hakemus:labels:hankeAreaNuisanceControl')}
+          style={{ overflow: 'visible' }}
+        >
+          {haitta !== HAITTOJENHALLINTATYYPPI.YLEINEN && (
+            <Box mb="var(--spacing-s)">
+              <HaittaIndexHeading
+                index={indeksi}
+                haittojenhallintaTyyppi={haitta}
+                heading={t('kaivuilmoitusForm:haittojenHallinta:hankeHaittaindeksi')}
+                testId={`test-${haitta}`}
+              />
+            </Box>
+          )}
           <Box as="p" className="text-sm">
-            {hankeAlue.haittojenhallintasuunnitelma &&
-              hankeAlue.haittojenhallintasuunnitelma[haitta]}
+            {indeksi === 0 && !hankeText
+              ? t('hankeForm:haittojenHallintaForm:noHankeNuisanceDetected')
+              : hankeText}
           </Box>
         </Notification>
       </Box>
@@ -95,12 +107,17 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
     kaivuilmoitusAlue.haittojenhallintasuunnitelma,
   );
 
-  const mapHankeIndex = (tyyppi: string, hTyypit: [HAITTOJENHALLINTATYYPPI, number][]) =>
-    hTyypit.find((val) => val[0] === tyyppi)?.[1];
+  const mapHankeIndex = (tyyppi: string, hhTyypit: [HAITTOJENHALLINTATYYPPI, number][]) =>
+    hhTyypit.find((val) => val[0] === tyyppi)?.[1];
 
   return (
     <Box mt="var(--spacing-m)">
       <Box mb="var(--spacing-m)">
+        <HankeNuisanceControl
+          haitta={HAITTOJENHALLINTATYYPPI.YLEINEN}
+          indeksi={mapHankeIndex(HAITTOJENHALLINTATYYPPI.YLEINEN, hankeHaittojenhallintatyypit)}
+          haittojenhallintasuunnitelma={hankeAlue?.haittojenhallintasuunnitelma}
+        />
         <TextArea
           name={`applicationData.areas.${index}.haittojenhallintasuunnitelma.${HAITTOJENHALLINTATYYPPI.YLEINEN}`}
           label={t(`kaivuilmoitusForm:haittojenHallinta:labels:${HAITTOJENHALLINTATYYPPI.YLEINEN}`)}
@@ -130,6 +147,11 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
                 kaivuilmoitusAlue={kaivuilmoitusAlue}
                 haittojenHallintaTyyppi={haitta}
                 mb="var(--spacing-m)"
+              />
+              <HankeNuisanceControl
+                haitta={haitta}
+                indeksi={mapHankeIndex(haitta, hankeHaittojenhallintatyypit)}
+                haittojenhallintasuunnitelma={hankeAlue?.haittojenhallintasuunnitelma}
               />
               {haitta === HAITTOJENHALLINTATYYPPI.AUTOLIIKENNE ? (
                 <CustomAccordion
@@ -198,11 +220,6 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
                 </CustomAccordion>
               ) : (
                 <>
-                  <HankeNuisanceControl
-                    haitta={haitta}
-                    indeksi={mapHankeIndex(haitta, hankeHaittojenhallintatyypit)}
-                    hankeAlue={hankeAlue}
-                  />
                   <HaittaIndexHeading
                     index={indeksi}
                     haittojenhallintaTyyppi={haitta}

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintaSuunnitelma.tsx
@@ -51,34 +51,31 @@ function HankeNuisanceControl({
 
   if (!haitta) return null;
 
-  const hankeText = haittojenhallintasuunnitelma && haittojenhallintasuunnitelma[haitta];
+  const hankeText = haittojenhallintasuunnitelma?.[haitta];
 
   return (
-    <>
-      <Box mb="var(--spacing-m)">
-        <Notification
-          label={t('hakemus:labels:hankeAreaNuisanceControl')}
-          style={{ overflow: 'visible' }}
-        >
-          {haitta !== HAITTOJENHALLINTATYYPPI.YLEINEN &&
-            haitta !== HAITTOJENHALLINTATYYPPI.MUUT && (
-              <Box mb="var(--spacing-s)">
-                <HaittaIndexHeading
-                  index={indeksi}
-                  haittojenhallintaTyyppi={haitta}
-                  heading={t('kaivuilmoitusForm:haittojenHallinta:hankeHaittaindeksi')}
-                  testId={`test-hanke-${haitta}`}
-                />
-              </Box>
-            )}
-          <Box as="p" className="text-sm" data-testid={`test-hanke-nuisance-control-${haitta}`}>
-            {indeksi === 0 && !hankeText
-              ? t('hankeForm:haittojenHallintaForm:noHankeNuisanceDetected')
-              : hankeText}
+    <Box mb="var(--spacing-m)">
+      <Notification
+        label={t('hakemus:labels:hankeAreaNuisanceControl')}
+        style={{ overflow: 'visible' }}
+      >
+        {haitta !== HAITTOJENHALLINTATYYPPI.YLEINEN && haitta !== HAITTOJENHALLINTATYYPPI.MUUT && (
+          <Box mb="var(--spacing-s)">
+            <HaittaIndexHeading
+              index={indeksi}
+              haittojenhallintaTyyppi={haitta}
+              heading={t('kaivuilmoitusForm:haittojenHallinta:hankeHaittaindeksi')}
+              testId={`test-hanke-${haitta}`}
+            />
           </Box>
-        </Notification>
-      </Box>
-    </>
+        )}
+        <Box as="p" className="text-sm" data-testid={`test-hanke-nuisance-control-${haitta}`}>
+          {indeksi === 0 && !hankeText
+            ? t('hankeForm:haittojenHallintaForm:noHankeNuisanceDetected')
+            : hankeText}
+        </Box>
+      </Notification>
+    </Box>
   );
 }
 
@@ -222,14 +219,12 @@ export default function KaivuilmoitusHaittojenhallintaSuunnitelma({
                   />
                 </CustomAccordion>
               ) : (
-                <>
-                  <HaittaIndexHeading
-                    index={indeksi}
-                    haittojenhallintaTyyppi={haitta}
-                    heading={t('kaivuilmoitusForm:haittojenHallinta:haittaindeksi')}
-                    testId={`test-${haitta}`}
-                  />
-                </>
+                <HaittaIndexHeading
+                  index={indeksi}
+                  haittojenhallintaTyyppi={haitta}
+                  heading={t('kaivuilmoitusForm:haittojenHallinta:haittaindeksi')}
+                  testId={`test-${haitta}`}
+                />
               )}
             </Box>
             {isVisible[haitta] ? (

--- a/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.tsx
+++ b/src/domain/kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo.tsx
@@ -50,7 +50,10 @@ const LiikennehaitanHallintasuunnitelmaInfo: React.FC<LiikennehaitanHallintasuun
         <Grid templateColumns="9fr 1fr" gap="var(--spacing-xs)">
           <GridItem>
             <HankkeenHaittojenhallintasuunnitelma
-              text={hankealue?.haittojenhallintasuunnitelma?.[tyyppi] ?? ''}
+              text={
+                hankealue?.haittojenhallintasuunnitelma?.[tyyppi] ||
+                t('hankeForm:haittojenHallintaForm:noHankeNuisanceDetected')
+              }
             />
             <Text spacingTop="xs" weight="bold" styleAs="h6" tag="h6">
               {t('kaivuilmoitusForm:haittojenHallinta:labels:YLEINEN')}
@@ -121,7 +124,7 @@ export const HaittojenhallintasuunnitelmaInfo: React.FC<HaittojenHallintaProps> 
             <Grid templateColumns="9fr 1fr" gap="var(--spacing-xs)">
               <GridItem>
                 <HankkeenHaittojenhallintasuunnitelma
-                  text={hankealue?.haittojenhallintasuunnitelma?.YLEINEN ?? ''}
+                  text={hankealue?.haittojenhallintasuunnitelma?.YLEINEN || ''}
                 />
                 <Box whiteSpace="pre-wrap" wordBreak="break-word" paddingTop="var(--spacing-s)">
                   {alue.haittojenhallintasuunnitelma?.YLEINEN ?? ''}

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -723,6 +723,7 @@
       "instructions2": "Kartan vasemmassa reunassa olevilla kulkumuotovalitsimilla voit tarkastella hanke- ja työalueiden haittaindeksejä tietylle kulkumuodolle. Kaikki kulkumuodot ovat oletuksena aktiivisina, voit vaihtaa näkyvien kulkumuotojen määrää klikkaamalla ikoneja. Kartalla näkyy valittujen kulkumuotojen kriittisin indeksiväri.",
       "noAlueet": "Lisää hankealueita täyttääksesi tietoja",
       "nuisanceControlPlanSubHeader": "Haittojenhallintasuunnitelma",
+      "noHankeNuisanceDetected": "Haitaton ei ole tunnistanut hankealueelta tätä kohderyhmää",
       "instructionsPlan": "Kerro haittojenhallintasuunnitelmassa, millä toimenpiteillä hallitset hankealueita koskevat haitat. Muistathan käydä läpi kaikki hankealueet.",
       "subHeaderPlan": "Tarkista aina nämä toimenpiteet",
       "helperText": "Hankealueella tehtävät tai sovitut toimet haittojen hallitsemiseksi tai estämiseksi.",
@@ -1166,6 +1167,7 @@
       "instructions4": "Tarkenna haittojenhallintasuunnitelmassa, millä toimenpiteillä hallitset työalueitasi koskevat haitat. Hankealueille määritellyt haittojenhallintatoimet näkyvät työalueiden suunnitelman pohjana. Muistathan käydä läpi kaikki työalueet.",
       "nuisanceControlPlanSubHeader": "$t(hankeForm:haittojenHallintaForm:nuisanceControlPlanSubHeader)",
       "helperText": "Työalueilla tehtävät tai sovitut toimet haittojen hallitsemiseksi tai estämiseksi",
+      "hankeHaittaindeksi": "Hankealueen haittaindeksi",
       "haittaindeksi": "Työalueiden haittaindeksi",
       "labels": {
         "YLEINEN": "Toimet työalueiden haittojen hallintaan",


### PR DESCRIPTION
# Description

Adds showing hanke nuisance control index and procedures within kaivuilmoitus form.

### Jira Issue: HAI-551

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Open Kaivuilmoitus form. Hanke nuisance control procedures are indexes should be visible.

# Checklist:

- [x] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: