### PR TITLE
HAI-1242 Validate hanke area dates against application work areas

### DIFF
--- a/src/common/utils/yup.ts
+++ b/src/common/utils/yup.ts
@@ -241,8 +241,7 @@ yup.addMethod(yup.date, 'validHankealueDate', function isValidHankealueDate(type
     if (!hakemukset) {
       return true;
     }
-    const path = this.path;
-    const indexMatch = path.match(/alueet\[(\d+)]/);
+    const indexMatch = /alueet\[(\d+)]/.exec(this.path);
     const hankealueIndex = indexMatch ? parseInt(indexMatch[1], 10) : undefined;
     if (hankealueIndex === undefined) {
       return true;

--- a/src/common/utils/yup.ts
+++ b/src/common/utils/yup.ts
@@ -5,6 +5,7 @@ import { HankeUser } from '../../domain/hanke/hankeUsers/hankeUser';
 import { HankeDataFormState } from '../../domain/hanke/edit/types';
 import {
   Application,
+  HankkeenHakemus,
   KaivuilmoitusAlue,
   KaivuilmoitusData,
 } from '../../domain/application/types/application';
@@ -14,6 +15,10 @@ import isValidPersonalId from './isValidPersonalId';
 import { HAITTOJENHALLINTATYYPPI } from '../../domain/common/haittojenhallinta/types';
 import { HaittaIndexData } from '../../domain/common/haittaIndexes/types';
 import { calculateLiikennehaittaindeksienYhteenveto } from '../../domain/kaivuilmoitus/utils';
+import {
+  getApplicationsInsideHankealue,
+  getHankealueDateLimits,
+} from '../../domain/hanke/edit/utils';
 
 // https://github.com/jquense/yup/blob/master/src/locale.ts
 yup.setLocale({
@@ -213,6 +218,76 @@ yup.addMethod(yup.date, 'validCompletionDate', function isValidCompletionDate() 
         message: { key: dateInFutureErrorMessageKey, values: {} },
       })
     );
+  });
+});
+
+/**
+ * Validates that hankealue date is within the limits of hakemukset with work areas inside the hankealue.
+ */
+yup.addMethod(yup.date, 'validHankealueDate', function isValidHankealueDate(type: 'start' | 'end') {
+  return this.test('validHankealueDate', 'Invalid date', function (value) {
+    if (!value) {
+      return true;
+    }
+    const context = this.options.context;
+    if (!context) {
+      return true;
+    }
+    const { hanke, hakemukset, dateConflictWithWorkAreasErrorKey } = context as {
+      hanke: HankeDataFormState;
+      hakemukset?: HankkeenHakemus[];
+      dateConflictWithWorkAreasErrorKey: string;
+    };
+    if (!hakemukset) {
+      return true;
+    }
+    const path = this.path;
+    const indexMatch = path.match(/alueet\[(\d+)]/);
+    const hankealueIndex = indexMatch ? parseInt(indexMatch[1], 10) : undefined;
+    if (hankealueIndex === undefined) {
+      return true;
+    }
+    const hankealue = hanke.alueet ? hanke.alueet[hankealueIndex] : undefined;
+    if (!hankealue) {
+      return true;
+    }
+    const hakemuksetHankealueella = getApplicationsInsideHankealue(hankealue, hakemukset);
+    const [maxStartDate, minEndDate] = getHankealueDateLimits(
+      hankealue.haittaAlkuPvm,
+      hakemuksetHankealueella,
+    );
+    if (!maxStartDate || !minEndDate) {
+      return true;
+    }
+    const date = new Date(value);
+    date.setHours(0, 0, 0, 0);
+    if (type === 'start') {
+      maxStartDate.setHours(0, 0, 0, 0);
+      if (date > maxStartDate) {
+        return this.createError({
+          path: this.path,
+          message: {
+            key: dateConflictWithWorkAreasErrorKey,
+            values: {},
+          },
+        });
+      }
+      return true;
+    }
+    if (type === 'end') {
+      minEndDate.setHours(0, 0, 0, 0);
+      if (date < minEndDate) {
+        return this.createError({
+          path: this.path,
+          message: {
+            key: dateConflictWithWorkAreasErrorKey,
+            values: {},
+          },
+        });
+      }
+      return true;
+    }
+    return true;
   });
 });
 

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -251,9 +251,9 @@ describe('HankeForm', () => {
     // Area name
     expect(screen.getByTestId('alueet.0.nimi')).toHaveValue('Hankealue 1');
     // Start date of the nuisance
-    expect(screen.getByDisplayValue('2.1.2023')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('14.6.2023')).toBeInTheDocument();
     // End date of the nuisance
-    expect(screen.getByDisplayValue('24.2.2023')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('16.10.2023')).toBeInTheDocument();
     // Noise nuisance
     expect(screen.getByText('Satunnainen meluhaitta')).toBeInTheDocument();
     // Dust nuisance
@@ -794,6 +794,25 @@ describe('HankeForm', () => {
     await user.click(getByRole('button', { name: 'Sulje' }));
 
     expect(screen.queryByText(/hankealue 1/i)).toBeInTheDocument();
+  });
+
+  test('Should show validation error message if area start date is after application start date', async () => {
+    const hanke = cloneDeep(hankkeet[1] as HankeDataFormState);
+    hanke.vaihe = 'OHJELMOINTI';
+
+    const { user } = await setupAlueetPage(hanke);
+
+    fireEvent.change(screen.getByLabelText(/haittojen alkupäivä/i), {
+      target: { value: '1.9.2024' },
+    });
+    await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+    expect(screen.queryByText('Vaihe 2/6: Alueet')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Tällä hankealueella on jo hakemusten kautta lisättyjä työalueita. Et voi lyhentää hankealueen ajankohtaa lyhyemmäksi kuin työalueiden ajankohdat.',
+      ),
+    ).toBeInTheDocument();
   });
 
   async function setupHaittaIndexUpdateTest(

--- a/src/domain/hanke/edit/HankeForm.tsx
+++ b/src/domain/hanke/edit/HankeForm.tsx
@@ -242,7 +242,7 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
     tyomaaKatuosoite,
     vaihe,
   });
-  const alueetErrors = useValidationErrors(hankeAlueetPublicSchema, { alueet });
+  const alueetErrors = useValidationErrors(hankeAlueetPublicSchema, { alueet }, validationContext);
   const haittojenHallintaErrors = useValidationErrors(
     haittojenhallintaPublicSchema,
     {

--- a/src/domain/hanke/edit/HankeForm.tsx
+++ b/src/domain/hanke/edit/HankeForm.tsx
@@ -35,6 +35,7 @@ import { useValidationErrors } from '../../forms/hooks/useValidationErrors';
 import DrawProvider from '../../../common/components/map/modules/draw/DrawProvider';
 import FormPagesErrorSummary from '../../forms/components/FormPagesErrorSummary';
 import FormFieldsErrorSummary from '../../forms/components/FormFieldsErrorSummary';
+import { useApplicationsForHanke } from '../../application/hooks/useApplications';
 
 type Props = {
   formData: HankeDataFormState;
@@ -57,7 +58,12 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
   const [showNotification, setShowNotification] = useState<FormNotification | null>(null);
   const [showAddApplicationDialog, setShowAddApplicationDialog] = useState(false);
   const [attachmentsUploading, setAttachmentsUploading] = useState(false);
-  const validationContext = { hanke: formData };
+  const hakemukset = useApplicationsForHanke(formData.hankeTunnus, true);
+  const validationContext = {
+    hanke: formData,
+    hakemukset: hakemukset.data?.applications,
+    dateConflictWithWorkAreasErrorKey: 'dateConflictWithWorkAreas',
+  };
   const formContext = useForm<HankeDataFormState>({
     mode: 'onTouched',
     reValidateMode: 'onChange',

--- a/src/domain/hanke/edit/hankeSchema.ts
+++ b/src/domain/hanke/edit/hankeSchema.ts
@@ -58,7 +58,11 @@ const muuYhteystietoSchema = yhteystietoSchema
 
 export const hankeAlueetSchema = yup.object({
   [FORMFIELD.NIMI]: yup.string().nullable(),
-  [FORMFIELD.HAITTA_ALKU_PVM]: yup.date().required().meta({ pageName: FORM_PAGES.ALUEET }),
+  [FORMFIELD.HAITTA_ALKU_PVM]: yup
+    .date()
+    .validHankealueDate('start')
+    .required()
+    .meta({ pageName: FORM_PAGES.ALUEET }),
   [FORMFIELD.HAITTA_LOPPU_PVM]: yup
     .date()
     .when(FORMFIELD.HAITTA_ALKU_PVM, (alkuPvm: Date[], schema: yup.DateSchema) => {
@@ -68,6 +72,7 @@ export const hankeAlueetSchema = yup.object({
         return schema;
       }
     })
+    .validHankealueDate('end')
     .required()
     .meta({ pageName: FORM_PAGES.ALUEET }),
   [FORMFIELD.MELUHAITTA]: yup

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -107,8 +107,8 @@ test('Correct information about hanke should be displayed', async () => {
     ),
   ).toBeInTheDocument();
   expect(screen.queryByText('Mannerheimintie 6')).toBeInTheDocument();
-  expect(screen.queryByText('2.1.2023')).toBeInTheDocument();
-  expect(screen.queryByText('24.2.2023')).toBeInTheDocument();
+  expect(screen.queryByText('14.6.2023')).toBeInTheDocument();
+  expect(screen.queryByText('16.10.2023')).toBeInTheDocument();
   expect(screen.queryByText('Ohjelmointi')).toBeInTheDocument();
   expect(screen.queryByText('Kaukolämpö')).toBeInTheDocument();
   expect(screen.queryByText('Ei')).toBeInTheDocument();
@@ -116,14 +116,14 @@ test('Correct information about hanke should be displayed', async () => {
 
   // Data in sidebar
   expect(screen.queryByText('Hankealue 1 (12041 m²)')).toBeInTheDocument();
-  expect(screen.queryByText('2.1.2023–24.2.2023')).toBeInTheDocument();
+  expect(screen.queryByText('14.6.2023–16.10.2023')).toBeInTheDocument();
 
   // Change to areas tab
   await user.click(screen.getByRole('tab', { name: /alueet/i }));
 
   // Data in areas tab
   expect(screen.queryByText('Hankealue 1')).toBeInTheDocument();
-  expect(screen.getAllByText('2.1.2023–24.2.2023').length).toBe(2);
+  expect(screen.getAllByText('14.6.2023–16.10.2023').length).toBe(2);
   expect(screen.getByTestId('test-pyoraliikenneindeksi')).toHaveTextContent('3.5');
   expect(screen.getByTestId('test-raitioliikenneindeksi')).toHaveTextContent('2');
   expect(screen.getByTestId('test-linjaautoliikenneindeksi')).toHaveTextContent('0');

--- a/src/domain/map/HankeMap.test.tsx
+++ b/src/domain/map/HankeMap.test.tsx
@@ -30,7 +30,7 @@ describe('HankeMap', () => {
     changeFilterDate(endDateLabel, renderedComponent, '12.12.2023');
     expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('3');
     changeFilterDate(startDateLabel, renderedComponent, '28.2.2023');
-    expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('2');
+    expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('3');
     changeFilterDate(startDateLabel, renderedComponent, '1');
     expect(renderedComponent.getByTestId(countOfFilteredHankeAlueet)).toHaveTextContent('3');
     changeFilterDate(startDateLabel, renderedComponent, '1.1');

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -64,8 +64,8 @@ const hakemukset: Application[] = [
           },
         },
       ],
-      startTime: new Date('2023-07-13T21:59:59.999Z'),
-      endTime: new Date('2023-07-15T21:59:59.999Z'),
+      startTime: new Date('2023-07-14T00:00:00.000Z'),
+      endTime: new Date('2023-07-16T00:00:00.000Z'),
       workDescription: 'Kuvaus',
       contractorWithContacts: {
         customer: {
@@ -224,8 +224,8 @@ const hakemukset: Application[] = [
           },
         },
       ],
-      startTime: new Date('2023-07-13T21:59:59.999Z'),
-      endTime: new Date('2023-09-31T21:59:59.999Z'),
+      startTime: new Date('2023-07-14T00:00:00.000Z'),
+      endTime: new Date('2023-10-01T00:00:00.000Z'),
       workDescription: 'Kaivetaan kuoppia Mannerheimintiellä',
       contractorWithContacts: {
         customer: {
@@ -298,8 +298,8 @@ const hakemukset: Application[] = [
         ],
       },
       areas: [],
-      startTime: new Date('2023-07-13T21:59:59.999Z'),
-      endTime: new Date('2023-09-31T21:59:59.999Z'),
+      startTime: new Date('2023-07-14T00:00:00.000Z'),
+      endTime: new Date('2023-10-01T00:00:00.000Z'),
       workDescription: 'Kaivetaan kuoppia Mannerheimintiellä',
       contractorWithContacts: {
         customer: {
@@ -395,8 +395,8 @@ const hakemukset: Application[] = [
           },
         },
       ],
-      startTime: new Date('2023-06-13T21:59:59.999Z'),
-      endTime: new Date('2023-10-15T21:59:59.999Z'),
+      startTime: new Date('2023-06-14T00:00:00.000Z'),
+      endTime: new Date('2023-10-16T00:00:00.000Z'),
       workDescription: 'Kairataan Mannerheimintiellä',
       contractorWithContacts: {
         customer: {
@@ -597,8 +597,8 @@ const hakemukset: Application[] = [
         ],
       },
       areas: [],
-      startTime: new Date('2023-07-13T21:59:59.999Z'),
-      endTime: new Date('2023-09-31T21:59:59.999Z'),
+      startTime: new Date('2023-07-14T00:00:00.000Z'),
+      endTime: new Date('2023-10-01T00:00:00.000Z'),
       workDescription: 'Kaivetaan kuoppia Mannerheimintiellä',
       contractorWithContacts: {
         customer: {
@@ -1036,8 +1036,8 @@ const hakemukset: Application[] = [
           },
         },
       ],
-      startTime: new Date('2023-07-13T21:59:59.999Z'),
-      endTime: new Date('2023-09-31T21:59:59.999Z'),
+      startTime: new Date('2023-07-14T00:00:00.000Z'),
+      endTime: new Date('2023-10-01T00:00:00.000Z'),
       workDescription: 'Kaivetaan kuoppia Mannerheimintiellä',
       contractorWithContacts: {
         customer: {
@@ -1351,8 +1351,8 @@ const hakemukset: Application[] = [
           },
         },
       ],
-      startTime: new Date('2024-08-13T21:59:59.999Z'),
-      endTime: new Date('2024-10-29T21:59:59.999Z'),
+      startTime: new Date('2024-08-14T00:00:00.000Z'),
+      endTime: new Date('2024-10-30T00:00:00.000Z'),
       customerWithContacts: {
         customer: {
           type: 'COMPANY',

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -65,7 +65,7 @@ const hakemukset: Application[] = [
         },
       ],
       startTime: new Date('2023-07-13T21:59:59.999Z'),
-      endTime: new Date('2023-07-13T21:59:59.999Z'),
+      endTime: new Date('2023-07-15T21:59:59.999Z'),
       workDescription: 'Kuvaus',
       contractorWithContacts: {
         customer: {

--- a/src/domain/mocks/data/hankkeet-data.ts
+++ b/src/domain/mocks/data/hankkeet-data.ts
@@ -294,8 +294,8 @@ const hankkeet: HankeDataDraft[] = [
     kuvaus:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
     tyomaaKatuosoite: 'Mannerheimintie 6',
-    alkuPvm: '2023-01-02T00:00:00Z',
-    loppuPvm: '2023-02-24T00:00:00Z',
+    alkuPvm: '2023-06-14T00:00:00Z',
+    loppuPvm: '2023-10-16T00:00:00Z',
     vaihe: 'OHJELMOINTI',
     tyomaaTyyppi: ['KAUKOLAMPO'],
     version: 0,
@@ -347,8 +347,8 @@ const hankkeet: HankeDataDraft[] = [
     alueet: [
       {
         id: 1,
-        haittaAlkuPvm: new Date('2023-01-02T21:59:59.999Z'),
-        haittaLoppuPvm: new Date('2023-02-24T21:59:59.999Z'),
+        haittaAlkuPvm: new Date('2023-06-13T21:59:59.999Z'),
+        haittaLoppuPvm: new Date('2023-10-15T21:59:59.999Z'),
         meluHaitta: HANKE_MELUHAITTA.SATUNNAINEN_MELUHAITTA,
         polyHaitta: HANKE_POLYHAITTA.TOISTUVA_POLYHAITTA,
         tarinaHaitta: HANKE_TARINAHAITTA.JATKUVA_TARINAHAITTA,

--- a/src/domain/mocks/data/hankkeet-data.ts
+++ b/src/domain/mocks/data/hankkeet-data.ts
@@ -347,8 +347,8 @@ const hankkeet: HankeDataDraft[] = [
     alueet: [
       {
         id: 1,
-        haittaAlkuPvm: new Date('2023-06-13T21:59:59.999Z'),
-        haittaLoppuPvm: new Date('2023-10-15T21:59:59.999Z'),
+        haittaAlkuPvm: new Date('2023-06-14T00:00:00.000Z'),
+        haittaLoppuPvm: new Date('2023-10-16T00:00:00.000Z'),
         meluHaitta: HANKE_MELUHAITTA.SATUNNAINEN_MELUHAITTA,
         polyHaitta: HANKE_POLYHAITTA.TOISTUVA_POLYHAITTA,
         tarinaHaitta: HANKE_TARINAHAITTA.JATKUVA_TARINAHAITTA,

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -114,7 +114,8 @@
       "emailAlreadyUsedInContacts": "Valitsemasi sähköpostiosoite löytyy jo hankkeen käyttäjähallinnasta. Lisää yhteyshenkilö pudotusvalikosta.",
       "emailAlreadyUsedInUserManagement": "Valitsemasi sähköpostiosoite löytyy jo toiselta käyttäjältä.",
       "dateBeforeStart": "Päivämäärä ei voi olla ennen hakemuksen töiden alkamispäivää ({{startDate}})",
-      "dateInFuture": "Päivämäärä ei voi olla tulevaisuudessa"
+      "dateInFuture": "Päivämäärä ei voi olla tulevaisuudessa",
+      "dateConflictWithWorkAreas": "Tällä hankealueella on jo hakemusten kautta lisättyjä työalueita. Et voi lyhentää hankealueen ajankohtaa lyhyemmäksi kuin työalueiden ajankohdat."
     },
     "errors": {
       "areaRequired": "Vähintään yksi alue vaaditaan",

--- a/src/types/yup-extensions.d.ts
+++ b/src/types/yup-extensions.d.ts
@@ -11,6 +11,7 @@ declare module 'yup' {
   }
   interface DateSchema {
     validCompletionDate(): this;
+    validHankealueDate(type: 'start' | 'end'): this;
   }
   interface CustomSchemaMetadata {
     pageName?: string | string[];


### PR DESCRIPTION
# Description

Prevent changing hanke area dates to be outside of the dates of the applications that have work areas in that hanke area.
This implementation also changes the implementation of https://github.com/City-of-Helsinki/haitaton-ui/pull/1064.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1242

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Have a hanke with applications (of both types) with areas inside different hanke areas and with variable dates
2. Try to change hanke area dates to be outside of the date limits of the applications that have work areas in that hanke area
3. Check that the date picker does not allow to choose invalid dates
4. Check that when typing an invalid date by hand there is a validation error message shown
5. With invalid date user cannot change form page
6. (Saving the form is still possible with invalid dates but that will be fixed when the backend prevents this?)

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
