### PR TITLE
Change testid in application list item link to application view

### DIFF
--- a/src/domain/application/components/ApplicationListItem.tsx
+++ b/src/domain/application/components/ApplicationListItem.tsx
@@ -49,7 +49,7 @@ function ApplicationListItem({ application }: Readonly<Props>) {
                 aria-label={
                   t(`routes:${ROUTES.HAKEMUS}.meta.title`) + ` ${name}` + ` ${applicationId}`
                 }
-                data-testid={`applicationViewLinkIdentifier-${id}`}
+                data-testid={`applicationViewLinkIdentifier-${applicationIdentifier ?? id}`}
                 className={styles.applicationLink}
               >
                 {applicationId}

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -271,7 +271,7 @@ test('Should navigate to application view when clicking application identifier l
 
   await waitForLoadingToFinish();
   await user.click(screen.getByRole('tab', { name: /hakemukset/i }));
-  await user.click(screen.getByTestId('applicationViewLinkIdentifier-2'));
+  await user.click(screen.getByTestId('applicationViewLinkIdentifier-JS2300001'));
 
   expect(window.location.pathname).toBe('/fi/hakemus/2');
   expect(screen.queryByText('Mannerheimintien kuopat')).toBeInTheDocument();


### PR DESCRIPTION
# Description

Changed testid to use application identifier if available or application id otherwise as was before.
