### PR TITLE
HAI-3298 Fix areas page name not showing in pages with errors list in form summary page

### DIFF
--- a/src/domain/kaivuilmoitus/validationSchema.ts
+++ b/src/domain/kaivuilmoitus/validationSchema.ts
@@ -138,7 +138,11 @@ export const applicationDataSchema = yup.object().shape(
       .nullable()
       .required()
       .meta({ pageName: FORM_PAGES.ALUEET }),
-    areas: yup.array(kaivuilmoitusAlueSchema).min(1).required(),
+    areas: yup
+      .array(kaivuilmoitusAlueSchema)
+      .min(1)
+      .required()
+      .meta({ pageName: FORM_PAGES.ALUEET }),
     additionalInfo: yup.string().max(2000).nullable(),
   },
   [['startTime', 'endTime']],


### PR DESCRIPTION
# Description

Fix issue in kaivuilmoitus and kaivuilmoitus täydennys forms summary page where list of pages with validation errors would not show areas page if work areas were missing entirely.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3298

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Remove all work areas in kaivuilmoitus or kaivuilmoitus täydennys form and check that areas page is listed in summary page in error notification.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
