### PR TITLE
HAI-3341 Notify if kaivuilmoitus täydennys changes nuisance indexes

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -14,6 +14,7 @@ import * as taydennysApi from '../taydennys/taydennysApi';
 import { USER_VIEW } from '../../mocks/signedInUser';
 import { createTaydennysAttachments } from '../../mocks/attachments';
 import * as muutosilmoitusApi from '../muutosilmoitus/muutosilmoitusApi';
+import { HAITTA_INDEX_TYPE } from '../../common/haittaIndexes/types';
 
 describe('Cable report application view', () => {
   test('Correct information about application should be displayed', async () => {
@@ -1525,6 +1526,23 @@ describe('Excavation notification application view', () => {
                       ],
                     ],
                   },
+                  tormaystarkasteluTulos: {
+                    liikennehaittaindeksi: {
+                      indeksi: 5,
+                      tyyppi: HAITTA_INDEX_TYPE.AUTOLIIKENNEINDEKSI,
+                    },
+                    pyoraliikenneindeksi: 3,
+                    autoliikenne: {
+                      indeksi: 5,
+                      haitanKesto: 5,
+                      katuluokka: 5,
+                      liikennemaara: 5,
+                      kaistahaitta: 5,
+                      kaistapituushaitta: 5,
+                    },
+                    linjaautoliikenneindeksi: 0,
+                    raitioliikenneindeksi: 1,
+                  },
                 },
               ],
               tyonTarkoitukset: ['VESI', 'TIETOLIIKENNE'],
@@ -1554,6 +1572,11 @@ describe('Excavation notification application view', () => {
 
       expect(screen.getAllByText('Täydennys:').length).toBe(8);
       expect(screen.getByText('394 m²')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Työalueille lasketut liikennehaittaindeksit ovat muuttuneet. Tarkista haittojenhallintasuunnitelma.',
+        ),
+      ).toBeInTheDocument();
     });
 
     test('Shows changed information in haittojen hallinta tab', async () => {

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -77,7 +77,10 @@ import { validationSchema as kaivuilmoitusValidationSchema } from '../../kaivuil
 import ApplicationReportCompletionDateDialog from '../../kaivuilmoitus/components/ApplicationReportCompletionDateDialog';
 import { formatToFinnishDate, formatToFinnishDateTime } from '../../../common/utils/date';
 import HaittaIndexes from '../../common/haittaIndexes/HaittaIndexes';
-import { calculateLiikennehaittaindeksienYhteenveto } from '../../kaivuilmoitus/utils';
+import {
+  calculateLiikennehaittaindeksienYhteenveto,
+  hasHaittaIndexesChanged,
+} from '../../kaivuilmoitus/utils';
 import styles from './ApplicationView.module.scss';
 import ApplicationSendDialog from '../components/ApplicationSendDialog';
 import TaydennyspyyntoNotification from '../taydennys/TaydennyspyyntoNotification';
@@ -155,11 +158,13 @@ function JohtoselvitysAreasInfo({
   const areasChanged =
     changedAreas &&
     muutokset &&
-    changedAreas.filter((_, index) => muutokset.includes(`areas[${index}]`)).length > 0;
+    changedAreas.filter((_area, index) => muutokset.includes(`areas[${index}]`)).length > 0;
   const areasRemoved =
     changedAreas &&
     muutokset &&
-    tyoalueet.filter((_, index) => muutokset.includes(`areas[${index}]`) && !changedAreas[index]);
+    tyoalueet.filter(
+      (_area, index) => muutokset.includes(`areas[${index}]`) && !changedAreas[index],
+    );
 
   return (
     <FormSummarySection>
@@ -231,17 +236,14 @@ function KaivuilmoitusAreasInfo({
   const areasChanged =
     changedAreas &&
     muutokset &&
-    changedAreas.filter((_, index) => muutokset.includes(`areas[${index}]`)).length > 0;
+    changedAreas.filter((_alue, index) => muutokset.includes(`areas[${index}]`)).length > 0;
 
   return areas.map((alue, index) => {
     const changedAlue = changedAreas?.at(index);
     const changedPropertyPrefix = `areas[${index}]`;
     const { tyoalueet: originalTyoalueet } = alue;
     const { tyoalueet: changedTyoalueet } = changedAlue ?? {};
-    const haittaIndexes = calculateLiikennehaittaindeksienYhteenveto(alue);
-    const changedHaittaIndexes =
-      changedAlue && calculateLiikennehaittaindeksienYhteenveto(changedAlue);
-    const haittaIndexesChanged = changedHaittaIndexes && haittaIndexes !== changedHaittaIndexes;
+    const haittaIndexesChanged = hasHaittaIndexesChanged(alue, changedAlue);
     const tyonTarkoituksetChanged =
       changedAlue && muutokset?.includes(`${changedPropertyPrefix}.tyonTarkoitukset`);
     const tyonTarkoituksetAdded = changedAlue?.tyonTarkoitukset?.filter(

--- a/src/domain/hanke/hooks/useHaittaIndexes.ts
+++ b/src/domain/hanke/hooks/useHaittaIndexes.ts
@@ -18,7 +18,7 @@ type HankeAlueData = {
 /**
  * Request haittaindeksit for hanke area
  */
-export async function calculateHaittaIndexes(data: HankeAlueData) {
+async function calculateHaittaIndexes(data: HankeAlueData) {
   const { data: response } = await api.post<HaittaIndexData>('/haittaindeksit', data);
   return response;
 }

--- a/src/domain/kaivuilmoitus/utils.test.ts
+++ b/src/domain/kaivuilmoitus/utils.test.ts
@@ -1,5 +1,5 @@
-import { calculateLiikennehaittaindeksienYhteenveto } from './utils';
-import { HAITTA_INDEX_TYPE } from '../common/haittaIndexes/types';
+import { calculateLiikennehaittaindeksienYhteenveto, hasHaittaIndexesChanged } from './utils';
+import { HAITTA_INDEX_TYPE, HaittaIndexData } from '../common/haittaIndexes/types';
 import { ApplicationGeometry, KaivuilmoitusAlue } from '../application/types/application';
 
 const geometry: ApplicationGeometry = {
@@ -20,84 +20,85 @@ const geometry: ApplicationGeometry = {
   },
 };
 
+const kaivuilmoitusalue: KaivuilmoitusAlue = {
+  name: 'testialue',
+  hankealueId: 1,
+  katuosoite: 'Kotikatu 1',
+  tyonTarkoitukset: ['VESI'],
+  meluhaitta: 'EI_MELUHAITTAA',
+  polyhaitta: 'EI_POLYHAITTAA',
+  tarinahaitta: 'EI_TARINAHAITTAA',
+  kaistahaitta: 'EI_VAIKUTA',
+  kaistahaittojenPituus: 'EI_VAIKUTA_KAISTAJARJESTELYIHIN',
+  tyoalueet: [
+    {
+      geometry: geometry,
+      area: 1,
+      tormaystarkasteluTulos: {
+        liikennehaittaindeksi: {
+          indeksi: 5,
+          tyyppi: HAITTA_INDEX_TYPE.RAITIOLIIKENNEINDEKSI,
+        },
+        pyoraliikenneindeksi: 3,
+        autoliikenne: {
+          indeksi: 2,
+          haitanKesto: 3,
+          katuluokka: 1,
+          liikennemaara: 3,
+          kaistahaitta: 2,
+          kaistapituushaitta: 1,
+        },
+        linjaautoliikenneindeksi: 1,
+        raitioliikenneindeksi: 5,
+      },
+    },
+    {
+      geometry: geometry,
+      area: 1,
+      tormaystarkasteluTulos: {
+        liikennehaittaindeksi: {
+          indeksi: 3,
+          tyyppi: HAITTA_INDEX_TYPE.PYORALIIKENNEINDEKSI,
+        },
+        pyoraliikenneindeksi: 3,
+        autoliikenne: {
+          indeksi: 1,
+          haitanKesto: 2,
+          katuluokka: 2,
+          liikennemaara: 2,
+          kaistahaitta: 1,
+          kaistapituushaitta: 2,
+        },
+        linjaautoliikenneindeksi: 1,
+        raitioliikenneindeksi: 1,
+      },
+    },
+    {
+      geometry: geometry,
+      area: 1,
+      tormaystarkasteluTulos: {
+        liikennehaittaindeksi: {
+          indeksi: 4,
+          tyyppi: HAITTA_INDEX_TYPE.AUTOLIIKENNEINDEKSI,
+        },
+        pyoraliikenneindeksi: 3,
+        autoliikenne: {
+          indeksi: 4,
+          haitanKesto: 5,
+          katuluokka: 3,
+          liikennemaara: 5,
+          kaistahaitta: 3,
+          kaistapituushaitta: 3,
+        },
+        linjaautoliikenneindeksi: 3,
+        raitioliikenneindeksi: 1,
+      },
+    },
+  ],
+};
+
 describe('calculateLiikennehaittaindeksienYhteenveto', () => {
   test('returns correct summary', async () => {
-    const kaivuilmoitusalue: KaivuilmoitusAlue = {
-      name: 'testialue',
-      hankealueId: 1,
-      katuosoite: 'Kotikatu 1',
-      tyonTarkoitukset: ['VESI'],
-      meluhaitta: 'EI_MELUHAITTAA',
-      polyhaitta: 'EI_POLYHAITTAA',
-      tarinahaitta: 'EI_TARINAHAITTAA',
-      kaistahaitta: 'EI_VAIKUTA',
-      kaistahaittojenPituus: 'EI_VAIKUTA_KAISTAJARJESTELYIHIN',
-      tyoalueet: [
-        {
-          geometry: geometry,
-          area: 1,
-          tormaystarkasteluTulos: {
-            liikennehaittaindeksi: {
-              indeksi: 5,
-              tyyppi: HAITTA_INDEX_TYPE.RAITIOLIIKENNEINDEKSI,
-            },
-            pyoraliikenneindeksi: 3,
-            autoliikenne: {
-              indeksi: 2,
-              haitanKesto: 3,
-              katuluokka: 1,
-              liikennemaara: 3,
-              kaistahaitta: 2,
-              kaistapituushaitta: 1,
-            },
-            linjaautoliikenneindeksi: 1,
-            raitioliikenneindeksi: 5,
-          },
-        },
-        {
-          geometry: geometry,
-          area: 1,
-          tormaystarkasteluTulos: {
-            liikennehaittaindeksi: {
-              indeksi: 3,
-              tyyppi: HAITTA_INDEX_TYPE.PYORALIIKENNEINDEKSI,
-            },
-            pyoraliikenneindeksi: 3,
-            autoliikenne: {
-              indeksi: 1,
-              haitanKesto: 2,
-              katuluokka: 2,
-              liikennemaara: 2,
-              kaistahaitta: 1,
-              kaistapituushaitta: 2,
-            },
-            linjaautoliikenneindeksi: 1,
-            raitioliikenneindeksi: 1,
-          },
-        },
-        {
-          geometry: geometry,
-          area: 1,
-          tormaystarkasteluTulos: {
-            liikennehaittaindeksi: {
-              indeksi: 4,
-              tyyppi: HAITTA_INDEX_TYPE.AUTOLIIKENNEINDEKSI,
-            },
-            pyoraliikenneindeksi: 3,
-            autoliikenne: {
-              indeksi: 4,
-              haitanKesto: 5,
-              katuluokka: 3,
-              liikennemaara: 5,
-              kaistahaitta: 3,
-              kaistapituushaitta: 3,
-            },
-            linjaautoliikenneindeksi: 3,
-            raitioliikenneindeksi: 1,
-          },
-        },
-      ],
-    };
     const summary = calculateLiikennehaittaindeksienYhteenveto(kaivuilmoitusalue);
 
     expect(summary).toEqual({
@@ -117,5 +118,91 @@ describe('calculateLiikennehaittaindeksienYhteenveto', () => {
       linjaautoliikenneindeksi: 3,
       raitioliikenneindeksi: 5,
     });
+  });
+});
+
+describe('hasHaittaIndexesChanged', () => {
+  test('returns true if haittaIndexes have increased', async () => {
+    const changedArea: KaivuilmoitusAlue = {
+      ...kaivuilmoitusalue,
+      tyoalueet: [
+        kaivuilmoitusalue.tyoalueet[0],
+        kaivuilmoitusalue.tyoalueet[1],
+        {
+          ...kaivuilmoitusalue.tyoalueet[2],
+          tormaystarkasteluTulos: {
+            ...(kaivuilmoitusalue.tyoalueet[2].tormaystarkasteluTulos as HaittaIndexData),
+            autoliikenne: {
+              indeksi: 5,
+              haitanKesto: 5,
+              katuluokka: 5,
+              liikennemaara: 5,
+              kaistahaitta: 5,
+              kaistapituushaitta: 5,
+            },
+          },
+        },
+      ],
+    };
+
+    const hasChanged = hasHaittaIndexesChanged(kaivuilmoitusalue, changedArea);
+
+    expect(hasChanged).toBe(true);
+  });
+
+  test('returns true if haittaIndexes have decreased', async () => {
+    const changedArea: KaivuilmoitusAlue = {
+      ...kaivuilmoitusalue,
+      tyoalueet: [
+        kaivuilmoitusalue.tyoalueet[0],
+        kaivuilmoitusalue.tyoalueet[1],
+        {
+          ...kaivuilmoitusalue.tyoalueet[2],
+          tormaystarkasteluTulos: {
+            ...(kaivuilmoitusalue.tyoalueet[2].tormaystarkasteluTulos as HaittaIndexData),
+            autoliikenne: {
+              indeksi: 3,
+              haitanKesto: 3,
+              katuluokka: 3,
+              liikennemaara: 3,
+              kaistahaitta: 3,
+              kaistapituushaitta: 3,
+            },
+          },
+        },
+      ],
+    };
+
+    const hasChanged = hasHaittaIndexesChanged(kaivuilmoitusalue, changedArea);
+
+    expect(hasChanged).toBe(true);
+  });
+
+  test('returns false if haittaIndexes are the same', async () => {
+    const changedArea: KaivuilmoitusAlue = {
+      ...kaivuilmoitusalue,
+      tyoalueet: [
+        kaivuilmoitusalue.tyoalueet[0],
+        kaivuilmoitusalue.tyoalueet[1],
+        {
+          ...kaivuilmoitusalue.tyoalueet[2],
+          tormaystarkasteluTulos: {
+            ...(kaivuilmoitusalue.tyoalueet[2].tormaystarkasteluTulos as HaittaIndexData),
+            autoliikenne: {
+              indeksi: 4,
+              haitanKesto: 5,
+              katuluokka: 3,
+              liikennemaara: 5,
+              kaistahaitta: 3,
+              kaistapituushaitta: 3,
+            },
+          },
+        },
+      ],
+    };
+
+    const hasChanged = hasHaittaIndexesChanged(kaivuilmoitusalue, changedArea);
+
+    expect(hasChanged).toBe(false);
   });
 });

--- a/src/domain/kaivuilmoitus/utils.ts
+++ b/src/domain/kaivuilmoitus/utils.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, omitBy } from 'lodash';
+import _, { cloneDeep, omitBy } from 'lodash';
 import { Feature } from 'ol';
 import { Polygon } from 'ol/geom';
 import {
@@ -150,4 +150,16 @@ export function calculateLiikennehaittaindeksienYhteenveto(
       };
     }, emptyHaittaIndexData);
   return summary;
+}
+
+/**
+ * Check if traffic nuisance indexes have changed between two kaivuilmoitusalues.
+ */
+export function hasHaittaIndexesChanged(alue1: KaivuilmoitusAlue, alue2?: KaivuilmoitusAlue) {
+  if (!alue2) {
+    return false;
+  }
+  const haittaIndexes = calculateLiikennehaittaindeksienYhteenveto(alue1);
+  const changedHaittaIndexes = calculateLiikennehaittaindeksienYhteenveto(alue2);
+  return !_.isEqual(haittaIndexes, changedHaittaIndexes);
 }

--- a/src/domain/kaivuilmoitus/utils.ts
+++ b/src/domain/kaivuilmoitus/utils.ts
@@ -1,4 +1,4 @@
-import _, { cloneDeep, omitBy } from 'lodash';
+import { cloneDeep, isEqual, omitBy } from 'lodash';
 import { Feature } from 'ol';
 import { Polygon } from 'ol/geom';
 import {
@@ -161,5 +161,5 @@ export function hasHaittaIndexesChanged(alue1: KaivuilmoitusAlue, alue2?: Kaivui
   }
   const haittaIndexes = calculateLiikennehaittaindeksienYhteenveto(alue1);
   const changedHaittaIndexes = calculateLiikennehaittaindeksienYhteenveto(alue2);
-  return !_.isEqual(haittaIndexes, changedHaittaIndexes);
+  return !isEqual(haittaIndexes, changedHaittaIndexes);
 }

--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
@@ -162,7 +162,11 @@ export default function KaivuilmoitusTaydennysContainer({
     },
     {
       element: (
-        <Areas hankeData={hankeData} hankkeenHakemukset={hankkeenHakemukset?.applications ?? []} />
+        <Areas
+          hankeData={hankeData}
+          hankkeenHakemukset={hankkeenHakemukset?.applications ?? []}
+          originalHakemus={originalApplication}
+        />
       ),
       label: t('form:headers:alueet'),
       state: StepState.available,


### PR DESCRIPTION
# Description

Notification in kaivuilmoitus täydennys form areas page when nuisance indexes change. Also, fixed equality check of index changes in täydennys application view.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3341

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create a kaivuilmoitus and täydennys for it
2. Change areas in kaivuilmoitus täydennys
3. If the changes also change the nuisance indexes, a notification is shown
4. Also, a notification is shown in täydennys application view areas tab (was already before but the equality check was incorrect)

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
