### PR TITLE
HAI-3434 Use feature flag for using either internal or external work instructions links

### DIFF
--- a/src/common/components/header/Header.test.tsx
+++ b/src/common/components/header/Header.test.tsx
@@ -115,4 +115,39 @@ describe('Header', () => {
     await changeLanguage(user, 'English', 'Svenska');
     expect(window.location.pathname).toBe('/sv/ansokan/1');
   });
+
+  test('Should render external work instructions link when hanke feature is disabled', async () => {
+    const OLD_ENV = { ...window._env_ };
+    window._env_ = { ...OLD_ENV, REACT_APP_FEATURE_HANKE: '0' };
+    await i18next.changeLanguage('fi');
+    getWrapper(true);
+
+    const linkElement = screen.getByRole('link', {
+      name: 'Työohjeet. Avautuu uudessa välilehdessä. Siirtyy toiseen sivustoon.',
+    });
+    expect(linkElement).toHaveAttribute('target', '_blank');
+    expect(linkElement).toHaveAttribute('rel', 'noopener');
+    expect(linkElement).toHaveAttribute(
+      'href',
+      'https://www.hel.fi/fi/kaupunkiymparisto-ja-liikenne/tontit-ja-rakentamisen-luvat/tyomaan-luvat-ja-ohjeet',
+    );
+
+    window._env_ = OLD_ENV;
+  });
+
+  test('Should render internal work instructions link when hanke feature is enabled', async () => {
+    const OLD_ENV = { ...window._env_ };
+    window._env_ = { ...OLD_ENV, REACT_APP_FEATURE_HANKE: '1' };
+    await i18next.changeLanguage('fi');
+    getWrapper(true);
+
+    const linkElement = await screen.findByRole('link', {
+      name: 'Työohjeet',
+    });
+    expect(linkElement).not.toHaveAttribute('target', '_blank');
+    expect(linkElement).not.toHaveAttribute('rel', 'noopener');
+    expect(linkElement).toHaveAttribute('href', '/fi/tyoohjeet');
+
+    window._env_ = OLD_ENV;
+  });
 });

--- a/src/common/components/header/Header.tsx
+++ b/src/common/components/header/Header.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Header, IconUser, Logo, logoFi, logoSv } from 'hds-react';
+import { Header, IconUser, Link, Logo, logoFi, logoSv } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { NavLink, useMatch, useLocation, useNavigate } from 'react-router-dom';
 import { $enum } from 'ts-enum-util';
@@ -197,15 +197,26 @@ function HaitatonHeader() {
             active={Boolean(isHankePortfolioPath)}
             data-testid="hankeListLink"
           />
-          <Header.Link
-            label={t('routes:WORKINSTRUCTIONS:headerLabel')}
-            as={NavLink}
-            to={WORKINSTRUCTIONS.path}
-            aria-label={t('routes:workInstructionsAriaLabel')}
-            active={Boolean(isWorkInstructionsPath)}
-          >
-            {t('routes:WORKINSTRUCTIONS:headerLabel')}
-          </Header.Link>
+          {features.hanke ? (
+            <Header.Link
+              label={t('routes:WORKINSTRUCTIONS:headerLabel')}
+              as={NavLink}
+              to={WORKINSTRUCTIONS.path}
+              active={Boolean(isWorkInstructionsPath)}
+            >
+              {t('routes:WORKINSTRUCTIONS:headerLabel')}
+            </Header.Link>
+          ) : (
+            <Header.Link
+              label={t('routes:WORKINSTRUCTIONS:headerLabel')}
+              as={Link}
+              href={t('workInstructions:sideNav:externalLinks:permitsAndInstructions:url')}
+              external
+              openInNewTab
+            >
+              {t('routes:WORKINSTRUCTIONS:headerLabel')}
+            </Header.Link>
+          )}
         </Header.NavigationMenu>
       )}
       <HankeCreateDialog isOpen={showHankeCreateDialog} onClose={closeHankeCreateDialog} />

--- a/src/domain/homepage/Homepage.test.tsx
+++ b/src/domain/homepage/Homepage.test.tsx
@@ -174,3 +174,57 @@ describe('Create johtoselvitys from dialog', () => {
     expect(screen.getByText('Puhelinnumero on virheellinen')).toBeInTheDocument();
   });
 });
+
+describe('Work instructions link', () => {
+  function setup() {
+    return renderWithLoginProvider({
+      state: 'VALID_SESSION',
+      returnUser: true,
+      placeUserToStorage: true,
+      children: (
+        <I18nextProvider i18n={i18n}>
+          <QueryClientProvider client={queryClient}>
+            <BrowserRouter>
+              <FeatureFlagsProvider>
+                <Homepage />
+              </FeatureFlagsProvider>
+            </BrowserRouter>
+          </QueryClientProvider>
+        </I18nextProvider>
+      ),
+    });
+  }
+
+  test('Should render external work instructions link when hanke feature is disabled', () => {
+    const OLD_ENV = { ...window._env_ };
+    window._env_ = { ...OLD_ENV, REACT_APP_FEATURE_HANKE: '0' };
+    setup();
+
+    const linkElement = screen.getByRole('link', {
+      name: 'Tutustu ohjeisiin. Avautuu uudessa välilehdessä. Siirtyy toiseen sivustoon.',
+    });
+    expect(linkElement).toHaveAttribute('target', '_blank');
+    expect(linkElement).toHaveAttribute('rel', 'noopener');
+    expect(linkElement).toHaveAttribute(
+      'href',
+      'https://www.hel.fi/fi/kaupunkiymparisto-ja-liikenne/tontit-ja-rakentamisen-luvat/tyomaan-luvat-ja-ohjeet',
+    );
+
+    window._env_ = OLD_ENV;
+  });
+
+  test('Should render internal work instructions link when hanke feature is enabled', () => {
+    const OLD_ENV = { ...window._env_ };
+    window._env_ = { ...OLD_ENV, REACT_APP_FEATURE_HANKE: '1' };
+    setup();
+
+    const linkElement = screen.getByRole('link', {
+      name: 'Tutustu ohjeisiin.',
+    });
+    expect(linkElement).not.toHaveAttribute('target', '_blank');
+    expect(linkElement).not.toHaveAttribute('rel', 'noopener');
+    expect(linkElement).toHaveAttribute('href', '/fi/tyoohjeet');
+
+    window._env_ = OLD_ENV;
+  });
+});

--- a/src/domain/homepage/HomepageComponent.tsx
+++ b/src/domain/homepage/HomepageComponent.tsx
@@ -71,9 +71,11 @@ const Homepage: React.FC<React.PropsWithChildren<unknown>> = () => {
     },
     {
       key: 'ohjeet',
-      actionLink: WORKINSTRUCTIONS.path,
+      actionLink: features.hanke
+        ? WORKINSTRUCTIONS.path
+        : t('workInstructions:sideNav:externalLinks:permitsAndInstructions:url'),
       imgProps: undefined,
-      external: false,
+      external: !features.hanke,
       featureFlags: [],
     },
   ];
@@ -98,7 +100,7 @@ const Homepage: React.FC<React.PropsWithChildren<unknown>> = () => {
       actionLink: WORKINSTRUCTIONS.path,
       imgProps: undefined,
       external: false,
-      featureFlags: [],
+      featureFlags: ['hanke'],
     },
   ];
 


### PR DESCRIPTION
# Description

If hanke feature flag is enabled, work instruction links link to Haitaton internal work instructions page. If hanke feature is disabled they link to hel.fi site, same as they previously were.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3434

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
