### PR TITLE
HAI-3396 Add create muutosilmoitus button to kaivuilmoitus application view

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -486,6 +486,8 @@ type Props = {
   onEditApplication: () => void;
   onEditTaydennys: () => void;
   creatingTaydennys?: boolean;
+  onEditMuutosilmoitus: () => void;
+  creatingMuutosilmoitus?: boolean;
 };
 
 function ApplicationView({
@@ -495,6 +497,8 @@ function ApplicationView({
   onEditApplication,
   onEditTaydennys,
   creatingTaydennys,
+  onEditMuutosilmoitus,
+  creatingMuutosilmoitus,
 }: Readonly<Props>) {
   const { t } = useTranslation();
   const locale = useLocale();
@@ -573,6 +577,10 @@ function ApplicationView({
   const informationRequestFeatureEnabled = useIsInformationRequestFeatureEnabled();
 
   const { sendTaydennysButton, sendTaydennysDialog } = useSendTaydennys(application, signedInUser);
+
+  const showMuutosilmoitusButton =
+    applicationType === 'EXCAVATION_NOTIFICATION' &&
+    (alluStatus === AlluStatus.DECISION || alluStatus === AlluStatus.OPERATIONAL_CONDITION);
 
   async function onSendApplication(pdr: PaperDecisionReceiver | undefined | null) {
     applicationSendMutation.mutate({
@@ -736,6 +744,18 @@ function ApplicationView({
               >
                 {t('hakemus:notifications:sendApplicationDisabled')}
               </Notification>
+            </CheckRightsByHanke>
+          )}
+          {showMuutosilmoitusButton && (
+            <CheckRightsByHanke requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>
+              <Button
+                theme="coat"
+                iconLeft={<IconPen />}
+                onClick={onEditMuutosilmoitus}
+                isLoading={creatingMuutosilmoitus}
+              >
+                {t('muutosilmoitus:buttons:createMuutosilmoitus')}
+              </Button>
             </CheckRightsByHanke>
           )}
           {showReportOperationalConditionButton && (

--- a/src/domain/application/muutosilmoitus/hooks/useCreateMuutosilmoitus.ts
+++ b/src/domain/application/muutosilmoitus/hooks/useCreateMuutosilmoitus.ts
@@ -1,0 +1,14 @@
+import { useQueryClient } from 'react-query';
+import { KaivuilmoitusData } from '../../types/application';
+import useDebouncedMutation from '../../../../common/hooks/useDebouncedMutation';
+import { createMuutosilmoitus } from '../muutosilmoitusApi';
+
+export default function useCreateMuutosilmoitus<ApplicationData extends KaivuilmoitusData>() {
+  const queryClient = useQueryClient();
+
+  return useDebouncedMutation(createMuutosilmoitus<ApplicationData>, {
+    async onSuccess(_, id) {
+      await queryClient.invalidateQueries(['application', id], { refetchInactive: true });
+    },
+  });
+}

--- a/src/domain/application/muutosilmoitus/muutosilmoitusApi.ts
+++ b/src/domain/application/muutosilmoitus/muutosilmoitusApi.ts
@@ -1,0 +1,13 @@
+import api from '../../api/api';
+import { Muutosilmoitus } from './types';
+
+/**
+ * Create muutosilmoitus
+ * @param id application id
+ */
+export async function createMuutosilmoitus<ApplicationData>(id: number) {
+  const response = await api.post<Muutosilmoitus<ApplicationData>>(
+    `/hakemukset/${id}/muutosilmoitus`,
+  );
+  return response.data;
+}

--- a/src/domain/application/muutosilmoitus/types.ts
+++ b/src/domain/application/muutosilmoitus/types.ts
@@ -1,0 +1,5 @@
+export type Muutosilmoitus<T> = {
+  id: string;
+  applicationData: T;
+  sent: Date | null;
+};

--- a/src/domain/application/taydennys/taydennysApi.ts
+++ b/src/domain/application/taydennys/taydennysApi.ts
@@ -6,7 +6,7 @@ import { Taydennys } from './types';
  * Create new taydennys
  * @param id application id
  */
-export async function createTaydennys<ApplicationData>(id: string) {
+export async function createTaydennys<ApplicationData>(id: number) {
   const response = await api.post<Taydennys<ApplicationData>>(`/hakemukset/${id}/taydennys`);
   return response.data;
 }

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -20,6 +20,7 @@ import { reportCompletionDateSchema } from '../../kaivuilmoitus/validationSchema
 import { sendSchema } from '../yupSchemas';
 import { Taydennys, Taydennyspyynto } from '../taydennys/types';
 import { Haittojenhallintasuunnitelma } from '../../common/haittojenhallinta/types';
+import { Muutosilmoitus } from '../muutosilmoitus/types';
 
 export type ApplicationType = 'CABLE_REPORT' | 'EXCAVATION_NOTIFICATION';
 
@@ -269,6 +270,7 @@ export interface Application<T = JohtoselvitysData | KaivuilmoitusData> {
   valmistumisilmoitukset?: Valmistumisilmoitukset | null;
   taydennyspyynto?: Taydennyspyynto | null;
   taydennys?: Taydennys<T> | null;
+  muutosilmoitus?: Muutosilmoitus<T>;
 }
 
 export interface HankkeenHakemus {

--- a/src/domain/johtoselvitys/types.ts
+++ b/src/domain/johtoselvitys/types.ts
@@ -10,7 +10,8 @@ export interface JohtoselvitysFormData extends JohtoselvitysData {
   areas: JohtoselvitysArea[];
 }
 
-export interface JohtoselvitysFormValues extends Omit<Application<JohtoselvitysData>, 'paatokset'> {
+export interface JohtoselvitysFormValues
+  extends Omit<Application<JohtoselvitysData>, 'paatokset' | 'muutosilmoitus'> {
   applicationData: JohtoselvitysFormData;
   geometriesChanged?: boolean; // virtualField
   selfIntersectingPolygon?: boolean; // virtualField

--- a/src/domain/kaivuilmoitus/types.ts
+++ b/src/domain/kaivuilmoitus/types.ts
@@ -1,6 +1,7 @@
 import { Application, KaivuilmoitusData } from '../application/types/application';
 
-export interface KaivuilmoitusFormValues extends Omit<Application<KaivuilmoitusData>, 'paatokset'> {
+export interface KaivuilmoitusFormValues
+  extends Omit<Application<KaivuilmoitusData>, 'paatokset' | 'muutosilmoitus'> {
   geometriesChanged?: boolean; // virtualField
   selfIntersectingPolygon?: boolean; // virtualField
 }

--- a/src/domain/kaivuilmoitusTaydennys/types.ts
+++ b/src/domain/kaivuilmoitusTaydennys/types.ts
@@ -13,6 +13,7 @@ export interface KaivuilmoitusTaydennysFormValues
     | 'valmistumisilmoitukset'
     | 'taydennyspyynto'
     | 'taydennys'
+    | 'muutosilmoitus'
   > {
   id: string;
   muutokset: string[];

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -14,6 +14,7 @@ import ApiError from '../apiError';
 import { cloneDeep } from 'lodash';
 import { faker } from '@faker-js/faker';
 import { Taydennys } from '../../application/taydennys/types';
+import { Muutosilmoitus } from '../../application/muutosilmoitus/types';
 
 let hakemukset: Application[] = [...hakemuksetData];
 
@@ -189,4 +190,18 @@ export async function cancelTaydennys(id: string) {
     throw new ApiError(`No application with id ${id}`, 404);
   }
   hakemus.taydennys = null;
+}
+
+export async function createMuutosilmoitus(id: number) {
+  const hakemus = await read(id);
+  if (!hakemus) {
+    throw new ApiError(`No application with id ${id}`, 404);
+  }
+  const muutosilmoitus: Muutosilmoitus<JohtoselvitysData | KaivuilmoitusData> = {
+    id: faker.string.uuid(),
+    applicationData: cloneDeep(hakemus.applicationData),
+    sent: null,
+  };
+  hakemus.muutosilmoitus = muutosilmoitus;
+  return muutosilmoitus;
 }

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -395,4 +395,14 @@ export const handlers = [
   http.delete(`${apiUrl}/taydennykset/:id/liitteet/:attachmentId`, async () => {
     return new HttpResponse();
   }),
+
+  http.post(`${apiUrl}/hakemukset/:id/muutosilmoitus`, async ({ params }) => {
+    const { id } = params;
+    try {
+      const muutosilmoitus = await hakemuksetDB.createTaydennys(Number(id));
+      return HttpResponse.json(muutosilmoitus, { status: 200 });
+    } catch (error) {
+      return HttpResponse.json((<ApiError>error).message, { status: (<ApiError>error).status });
+    }
+  }),
 ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1540,6 +1540,11 @@
       "description": "Lähettämällä tiedot käsittelyssä oleva hakemuksesi päivitetään täydennetyillä tiedoilla."
     }
   },
+  "muutosilmoitus": {
+    "buttons": {
+      "createMuutosilmoitus": "Tee muutosilmoitus"
+    }
+  },
   "hankeSidebar": {
     "ariaSidebarContent": "Hankkeen tiedot",
     "closeButtonAriaLabel": "Sulje hankevalikko",


### PR DESCRIPTION
# Description

Button is shown if kaivuilmoitus has Allu status DECISION or OPERATIONAL_CONDITION and user has EDIT_APPLICATIONS permission.

Clicking the button calls POST /hakemukset/:id/muutosilmoitus, but nothing else happens at this point. The actual muutosilmoitus form and navigating to it will be implemented later.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3396

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Check that create muutosilmoitus button is shown for kaivuilmoitus when Allu status is DECISION or OPERATIONAL_CONDITION (and that it is not shown for johtoselvitys even in DECISION status)
2. Click the button and check in browser dev tools network tab that POST /hakemukset/:id/muutosilmoitus is called

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
