### PR TITLE
HAI-3437 Show error to user if they don't have name when logging in with Helsinki AD

### DIFF
--- a/src/domain/auth/components/ADError.tsx
+++ b/src/domain/auth/components/ADError.tsx
@@ -1,10 +1,14 @@
 import { Box, Flex } from '@chakra-ui/react';
 import { Link, useOidcClient } from 'hds-react';
+import { Trans } from 'react-i18next';
 import MainHeading from '../../../common/components/mainHeading/MainHeading';
-import { Trans, useTranslation } from 'react-i18next';
 
-export default function ADGroupsError() {
-  const { t } = useTranslation();
+type Props = {
+  errorHeading: string;
+  errorTextKey: string;
+};
+
+export default function ADError({ errorHeading, errorTextKey }: Readonly<Props>) {
   const oidcClient = useOidcClient();
 
   function logout() {
@@ -22,14 +26,14 @@ export default function ADGroupsError() {
       gap={{ base: 'var(--spacing-m)', md: 'var(--spacing-4-xl)' }}
       px="var(--spacing-s)"
     >
-      <MainHeading>{t('authentication:noADPermissionHeading')}</MainHeading>
+      <MainHeading>{errorHeading}</MainHeading>
       <Box
         as="p"
         maxWidth="612px"
         fontSize={{ base: 'var(--fontsize-body-m)', md: 'var(--fontsize-body-l)' }}
       >
         <Trans
-          i18nKey="authentication:noADPermissionText"
+          i18nKey={errorTextKey}
           components={{
             a: (
               <Box

--- a/src/domain/auth/components/OidcCallback.test.tsx
+++ b/src/domain/auth/components/OidcCallback.test.tsx
@@ -9,12 +9,12 @@ import {
   renderWithLoginProvider,
 } from '../testUtils/renderWithLoginProvider';
 
-function getWrapper({ state, returnUser, errorType, userADGroups }: RenderWithLoginProviderProps) {
+function getWrapper({ state, returnUser, errorType, userProfile }: RenderWithLoginProviderProps) {
   return renderWithLoginProvider({
     state,
     returnUser,
     errorType,
-    userADGroups,
+    userProfile,
     children: (
       <I18nextProvider i18n={i18n}>
         <MemoryRouter initialEntries={[LOGIN_CALLBACK_PATH]}>
@@ -83,7 +83,7 @@ describe('<OidcCallback />', () => {
         state: 'NO_SESSION',
         returnUser: true,
         errorType: undefined,
-        userADGroups: ['test_group'],
+        userProfile: { ad_groups: ['test_group'] },
       });
 
       expect(await findByText('Ei käyttöoikeutta Haitaton-asiointiin')).toBeInTheDocument();
@@ -101,7 +101,7 @@ describe('<OidcCallback />', () => {
         state: 'NO_SESSION',
         returnUser: true,
         errorType: undefined,
-        userADGroups: ['test_group'],
+        userProfile: { ad_groups: ['test_group'] },
       });
 
       expect(await findByText('Home page')).toBeInTheDocument();
@@ -119,11 +119,28 @@ describe('<OidcCallback />', () => {
         state: 'NO_SESSION',
         returnUser: true,
         errorType: undefined,
-        userADGroups: ['test_group'],
+        userProfile: { ad_groups: ['test_group'] },
       });
 
       expect(await findByText('Home page')).toBeInTheDocument();
       window._env_ = OLD_ENV;
+    });
+
+    it('should show error message when user does not have given_name or family_name', async () => {
+      const { findByText, getByText } = getWrapper({
+        state: 'NO_SESSION',
+        returnUser: true,
+        errorType: undefined,
+        userProfile: { given_name: '', family_name: '', ad_groups: ['test_group'] },
+      });
+
+      expect(await findByText('Kirjautuminen epäonnistui')).toBeInTheDocument();
+      expect(
+        getByText(
+          'Kirjautuminen AD:n kautta epäonnistui, sillä Haitaton ei saanut kirjautumisen yhteydessä nimeäsi.',
+          { exact: false },
+        ),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/domain/auth/testUtils/renderWithLoginProvider.tsx
+++ b/src/domain/auth/testUtils/renderWithLoginProvider.tsx
@@ -7,6 +7,7 @@ import {
   OidcClientError,
   OidcClientProps,
   OidcClientState,
+  Profile,
   triggerForAllOidcClientSignals,
 } from 'hds-react';
 import { createUser } from './userTestUtil';
@@ -27,7 +28,7 @@ export type RenderWithLoginProviderProps = {
   state: OidcClientState;
   returnUser: boolean;
   placeUserToStorage?: boolean;
-  userADGroups?: string[];
+  userProfile?: Partial<Profile>;
   errorType?: 'SIGNIN_ERROR' | 'INVALID_OR_EXPIRED_USER' | 'RENEWAL_FAILED';
   children?: React.ReactNode;
 };
@@ -36,7 +37,7 @@ export function renderWithLoginProvider({
   state,
   returnUser,
   placeUserToStorage = true,
-  userADGroups,
+  userProfile,
   errorType,
   children,
 }: RenderWithLoginProviderProps) {
@@ -47,13 +48,13 @@ export function renderWithLoginProvider({
     connect: (targetBeacon) => {
       beacon = targetBeacon;
       beacon.addListener(triggerForAllOidcClientSignals, (signal) => {
-        const user = createUser(placeUserToStorage, userADGroups);
+        const user = createUser(placeUserToStorage, userProfile);
         const oidcClient = signal.context as OidcClient;
         jest.spyOn(oidcClient, 'getState').mockReturnValue(state);
         jest.spyOn(oidcClient, 'getUser').mockReturnValue(user);
         jest
           .spyOn(oidcClient, 'getAmr')
-          .mockReturnValue(userADGroups === undefined ? ['suomi_fi'] : ['helsinkiad']);
+          .mockReturnValue(userProfile?.ad_groups === undefined ? ['suomi_fi'] : ['helsinkiad']);
         if (!returnUser) {
           jest.spyOn(oidcClient, 'handleCallback').mockRejectedValue(handleError);
         } else {

--- a/src/domain/auth/testUtils/userTestUtil.ts
+++ b/src/domain/auth/testUtils/userTestUtil.ts
@@ -1,11 +1,11 @@
-import { User } from 'hds-react';
+import { Profile, User } from 'hds-react';
 
 const authority = 'https://api.hel.fi/sso/openid';
 const client_id = 'test-client';
 
 const tokenExpirationTimeInSeconds = 3600;
 
-export function createUser(placeUserToStorage = true, ad_groups?: string[]): User {
+export function createUser(placeUserToStorage = true, userProfile?: Partial<Profile>): User {
   const nowAsSeconds = Math.round(Date.now() / 1000);
   const expires_in = tokenExpirationTimeInSeconds;
   const expires_at = nowAsSeconds + expires_in;
@@ -20,10 +20,12 @@ export function createUser(placeUserToStorage = true, ad_groups?: string[]): Use
       aud: 'aud',
       exp: expires_at,
       iat: nowAsSeconds,
+      given_name: 'Test',
+      family_name: 'User',
       name: 'Test User',
       email: 'test.user@mail.com',
       amr: ['validAmr'],
-      ad_groups,
+      ...userProfile,
     },
     refresh_token: 'refresh_token',
     scope: 'openid profile',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -10,7 +10,11 @@
     "loggingIn": "Logging in...",
     "loggingOut": "Logging out...",
     "loggingInErrorLabel": "Error during log-in",
-    "logoutError": "Error during log-out"
+    "logoutError": "Error during log-out",
+    "noADPermissionHeading": "No access rights to Haitaton service",
+    "noADPermissionText": "You are not entitled to AD identification. <a>Log out</a> of Haitaton and try again through the suomi.fi authentication.",
+    "noADUserNameHeading": "Login failed",
+    "noADUserNameText": "Login via AD failed, as Haitaton did not receive your name upon login. Contact your organization's IT support or <a>log out</a> of Haitaton and try again through the suomi.fi-authentication."
   },
   "common": {
     "increment": "Increment",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -12,7 +12,9 @@
     "loggingInErrorLabel": "Kirjautumisessa tapahtui virhe",
     "logoutError": "Uloskirjautumisessa tapahtui virhe",
     "noADPermissionHeading": "Ei käyttöoikeutta Haitaton-asiointiin",
-    "noADPermissionText": "Sinulla ei ole oikeutta AD-tunnistautumiseen. <a>Kirjaudu ulos</a> Haitattomasta ja yritä uudelleen suomi.fi-tunnistautumisen kautta."
+    "noADPermissionText": "Sinulla ei ole oikeutta AD-tunnistautumiseen. <a>Kirjaudu ulos</a> Haitattomasta ja yritä uudelleen suomi.fi-tunnistautumisen kautta.",
+    "noADUserNameHeading": "Kirjautuminen epäonnistui",
+    "noADUserNameText": "Kirjautuminen AD:n kautta epäonnistui, sillä Haitaton ei saanut kirjautumisen yhteydessä nimeäsi. Ota yhteyttä organisaatiosi IT-tukeen tai <a>kirjaudu ulos</a> Haitattomasta ja yritä uudelleen suomi.fi-tunnistautumisen kautta."
   },
   "common": {
     "increment": "Lisää",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -10,7 +10,11 @@
     "loggingIn": "Loggar in...",
     "loggingOut": "Loggar ut...",
     "loggingInErrorLabel": "Ett fel uppstod vid inloggningen",
-    "logoutError": "Ett fel uppstod vid utloggningen"
+    "logoutError": "Ett fel uppstod vid utloggningen",
+    "noADPermissionHeading": "Ingen användarrätt till Haitaton ärenden",
+    "noADPermissionText": "Du har inte rätt till AD-autentisering. <a>Logga ut</a> från Haitaton och försök på nytt via suomi.fi-identifikationen.",
+    "noADUserNameHeading": "Inloggningen misslyckades",
+    "noADUserNameText": "Inloggning via AD misslyckades eftersom Haiton inte fick ditt namn vid inloggningen. Kontakta IT-supporten i din organisation eller <a>logga ut</a> från Haitaton och försök igen via suomi.fi-identifikation."
   },
   "common": {
     "increment": "Lägg till",


### PR DESCRIPTION
# Description

If user's given or family name is missing or blank when logging in with Helsinki AD, show error message to user with a link to log out.

Also added translations for AD permission error message.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3437

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
