### PR TITLE
HAI-424 Fix tab names in kaivuilmoitus form haittojenhallinta page

### DIFF
--- a/src/domain/kaivuilmoitus/HaittojenHallinta.tsx
+++ b/src/domain/kaivuilmoitus/HaittojenHallinta.tsx
@@ -43,7 +43,11 @@ export default function HaittojenHallinta({ hankeData }: Readonly<Props>) {
       <Tabs>
         <TabList>
           {hakemusAlueet.map((alue) => {
-            return <Tab key={alue.id}>{alue.name}</Tab>;
+            return (
+              <Tab key={alue.id}>
+                {t('hakemus:labels:workAreaPlural')} ({alue.name})
+              </Tab>
+            );
           })}
         </TabList>
         {hakemusAlueet.map((alue, index) => {

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1986,7 +1986,7 @@ describe('Error notification', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', {
-        name: 'Työalueet (Hankealue 2): Toimet työalueiden haittojen hallintaan',
+        name: 'Työalueet (Hankealue 2): Yleiset toimet työalueiden haittojen hallintaan',
       }),
     ).toBeInTheDocument();
   });

--- a/src/domain/kaivuilmoitus/mapValidationErrorToErrorListItem.test.ts
+++ b/src/domain/kaivuilmoitus/mapValidationErrorToErrorListItem.test.ts
@@ -40,7 +40,7 @@ test('Should show error for haittojenhallintasuunnitelma', () => {
   render(mapValidationErrorToErrorListItem(error, t, application));
 
   expect(
-    screen.getByText('Työalueet (Hankealue 2): Toimet työalueiden haittojen hallintaan'),
+    screen.getByText('Työalueet (Hankealue 2): Yleiset toimet työalueiden haittojen hallintaan'),
   ).toBeInTheDocument();
   expect(screen.getByRole('link')).toHaveAttribute(
     'href',

--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennys.test.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennys.test.tsx
@@ -523,7 +523,7 @@ describe('Error notification', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', {
-        name: 'Työalueet (Hankealue 2): Toimet työalueiden haittojen hallintaan',
+        name: 'Työalueet (Hankealue 2): Yleiset toimet työalueiden haittojen hallintaan',
       }),
     ).toBeInTheDocument();
     expect(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1104,7 +1104,7 @@
       "helperText": "Actions to be taken or agreed measures in work areas to control or prevent nuisances",
       "haittaindeksi": "Nuisance index for work areas",
       "labels": {
-        "YLEINEN": "Measures to control nuisances in work areas",
+        "YLEINEN": "[TRANSLATION_PENDING]Measures to control nuisances in work areas",
         "PYORALIIKENNE": "Measures to control nuisances in work areas",
         "AUTOLIIKENNE": "Measures to control nuisances in work areas",
         "LINJAAUTOLIIKENNE": "Measures to control nuisances in work areas",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1183,7 +1183,7 @@
       "hankeHaittaindeksi": "Hankealueen haittaindeksi",
       "haittaindeksi": "Työalueiden haittaindeksi",
       "labels": {
-        "YLEINEN": "Toimet työalueiden haittojen hallintaan",
+        "YLEINEN": "Yleiset toimet työalueiden haittojen hallintaan",
         "PYORALIIKENNE": "Toimet työalueiden haittojen hallintaan",
         "AUTOLIIKENNE": "Toimet työalueiden haittojen hallintaan",
         "LINJAAUTOLIIKENNE": "Toimet työalueiden haittojen hallintaan",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -1104,7 +1104,7 @@
       "helperText": "De åtgärder som ska utföras på eller som avtalats för arbetsområdena för att hantera eller förhindra olägenheter",
       "haittaindeksi": "Arbetsområdenas olägenhetsindex",
       "labels": {
-        "YLEINEN": "Åtgärderna för att hantera olägenheter på arbetsområdena",
+        "YLEINEN": "[TRANSLATION_PENDING]Åtgärderna för att hantera olägenheter på arbetsområdena",
         "PYORALIIKENNE": "Åtgärderna för att hantera olägenheter på arbetsområdena",
         "AUTOLIIKENNE": "Åtgärderna för att hantera olägenheter på arbetsområdena",
         "LINJAAUTOLIIKENNE": "Åtgärderna för att hantera olägenheter på arbetsområdena",


### PR DESCRIPTION
# Description

Also changed Toimet työalueiden haittojen hallintaan label to Yleiset toimet työalueiden haittojen hallintaan for yleiset toimet text area.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-424

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
