### PR TITLE
Automatic closing for modal and text changes.

### DIFF
--- a/src/domain/auth/components/UserIdentify.tsx
+++ b/src/domain/auth/components/UserIdentify.tsx
@@ -40,6 +40,8 @@ function UserIdentify() {
             type: 'success',
             dismissible: true,
             closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+            autoClose: true,
+            autoCloseDuration: 30000,
           });
         },
         onSettled() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1115,7 +1115,7 @@
       "userUpdatedErrorLabel": "Error in the updating process",
       "userUpdatedErrorText": "<0>An error occurred when updating user information. Please try again later or contact the Haitaton technical support by email <1>haitatontuki@hel.fi</1>.</0>",
       "userIdentifiedLabel": "Login successful",
-      "userIdentifiedText": "Login successful. You have now been added to the project ({{hankeNimi}} {{hankeTunnus}}).",
+      "userIdentifiedText": "You have now been added to the project ({{hankeNimi}} {{hankeTunnus}}).",
       "userIdentifiedError": "Login failed",
       "invitationSentSuccessLabel": "Invitation link sent",
       "invitationSentSuccessText": "Invitation link sent to the address {{email}}.",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1556,7 +1556,7 @@
       "userUpdatedErrorLabel": "Virhe päivityksessä",
       "userUpdatedErrorText": "<0>Käyttäjätietojen päivityksessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>",
       "userIdentifiedLabel": "Tunnistautuminen onnistui",
-      "userIdentifiedText": "Tunnistautuminen onnistui. Sinut on nyt lisätty hankkeelle ({{hankeNimi}} {{hankeTunnus}}).",
+      "userIdentifiedText": "Sinut on nyt lisätty hankkeelle ({{hankeNimi}} {{hankeTunnus}}).",
       "userIdentifiedError": "Tunnistautuminen epäonnistui",
       "invitationSentSuccessLabel": "Kutsulinkki lähetetty",
       "invitationSentSuccessText": "Kutsulinkki lähetetty osoitteeseen {{email}}.",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -1102,7 +1102,7 @@
       "userUpdatedErrorLabel": "Ett fel uppstod vid uppdateringen",
       "userUpdatedErrorText": "<0>Ett fel uppstod när användarinformation skulle uppdateras. Försök igen senare eller kontakta Haitatons tekniska support med e-post till <1>haitatontuki@hel.fi</1>.</0>",
       "userIdentifiedLabel": "Identifieringen lyckades",
-      "userIdentifiedText": "Identifieringen lyckades. Du har nu lagts till i projektet ({{hankeNimi}} {{hankeTunnus}}).",
+      "userIdentifiedText": "Du har nu lagts till i projektet ({{hankeNimi}} {{hankeTunnus}}).",
       "userIdentifiedError": "Identifieringen misslyckades",
       "invitationSentSuccessLabel": "Inbjudningslänken skickades",
       "invitationSentSuccessText": "Inbjudningslänken skickades till {{email}}.",


### PR DESCRIPTION
# Description

Added auto-close after 30 seconds on successful authentication notification.
Text changes: Removed from all language versions userIdentifiedText "Login successful", which is already once in the label.

# Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2500

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
