### PR TITLE
HAI-3399 Add muutosilmoitus notification and a button to continue editing muutosilmoitus

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -93,6 +93,7 @@ import FormPagesErrorSummary from '../../forms/components/FormPagesErrorSummary'
 import TaydennysCancel from '../taydennys/components/TaydennysCancel';
 import TaydennysAttachmentsList from '../taydennys/components/TaydennysAttachmentsList';
 import { HaittojenhallintasuunnitelmaInfo } from '../../kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo';
+import MuutosilmoitusNotification from '../muutosilmoitus/components/MuutosilmoitusNotification';
 
 function TyoalueetList({ tyoalueet }: { tyoalueet: ApplicationArea[] }) {
   const { t } = useTranslation();
@@ -520,6 +521,7 @@ function ApplicationView({
     valmistumisilmoitukset,
     taydennyspyynto,
     taydennys,
+    muutosilmoitus,
   } = application;
   const {
     name,
@@ -581,7 +583,8 @@ function ApplicationView({
 
   const showMuutosilmoitusButton =
     applicationType === 'EXCAVATION_NOTIFICATION' &&
-    (alluStatus === AlluStatus.DECISION || alluStatus === AlluStatus.OPERATIONAL_CONDITION);
+    (alluStatus === AlluStatus.DECISION || alluStatus === AlluStatus.OPERATIONAL_CONDITION) &&
+    !muutosilmoitus?.sent;
 
   async function onSendApplication(pdr: PaperDecisionReceiver | undefined | null) {
     applicationSendMutation.mutate({
@@ -635,6 +638,7 @@ function ApplicationView({
                 applicationType={applicationType}
               />
             )}
+          {muutosilmoitus && <MuutosilmoitusNotification sent={muutosilmoitus.sent} />}
           <Box mt="var(--spacing-s)">
             <FormPagesErrorSummary
               data={taydennys ?? application}
@@ -755,7 +759,9 @@ function ApplicationView({
                 onClick={onEditMuutosilmoitus}
                 isLoading={creatingMuutosilmoitus}
               >
-                {t('muutosilmoitus:buttons:createMuutosilmoitus')}
+                {!muutosilmoitus
+                  ? t('muutosilmoitus:buttons:createMuutosilmoitus')
+                  : t('muutosilmoitus:buttons:editMuutosilmoitus')}
               </Button>
             </CheckRightsByHanke>
           )}

--- a/src/domain/application/muutosilmoitus/components/MuutosilmoitusNotification.tsx
+++ b/src/domain/application/muutosilmoitus/components/MuutosilmoitusNotification.tsx
@@ -1,0 +1,26 @@
+import { Notification } from 'hds-react';
+import { MuutosilmoitusSent } from '../types';
+import { format } from 'date-fns/format';
+import { fi } from 'date-fns/locale';
+import { useTranslation } from 'react-i18next';
+
+type Props = {
+  sent: MuutosilmoitusSent;
+};
+
+export default function MuutosilmoitusNotification({ sent }: Readonly<Props>) {
+  const { t } = useTranslation();
+  const formattedSentDate =
+    sent &&
+    format(sent, 'd.M.yyyy HH:mm', {
+      locale: fi,
+    });
+
+  return (
+    <Notification type="alert" label={t('muutosilmoitus:notification:label')} size="small">
+      {formattedSentDate === null
+        ? t('muutosilmoitus:notification:createdText')
+        : t('muutosilmoitus:notification:sentText', { date: formattedSentDate })}
+    </Notification>
+  );
+}

--- a/src/domain/application/muutosilmoitus/types.ts
+++ b/src/domain/application/muutosilmoitus/types.ts
@@ -1,5 +1,7 @@
+export type MuutosilmoitusSent = string | null;
+
 export type Muutosilmoitus<T> = {
   id: string;
   applicationData: T;
-  sent: Date | null;
+  sent: MuutosilmoitusSent;
 };

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -865,6 +865,14 @@ const hakemukset: Application[] = [
           kaistahaitta: 'YKSI_KAISTA_VAHENEE',
           kaistahaittojenPituus: 'PITUUS_10_99_METRIA',
           lisatiedot: '',
+          haittojenhallintasuunnitelma: {
+            YLEINEN: 'Työalueen yleisten haittojen hallintasuunnitelma',
+            PYORALIIKENNE: 'Pyöräliikenteelle koituvien työalueen haittojen hallintasuunnitelma',
+            AUTOLIIKENNE: 'Autoliikenteelle koituvien työalueen haittojen hallintasuunnitelma',
+            LINJAAUTOLIIKENNE: '',
+            RAITIOLIIKENNE: 'Raitioliikenteelle koituvien työalueen haittojen hallintasuunnitelma',
+            MUUT: 'Muiden työalueen haittojen hallintasuunnitelma',
+          },
         },
       ],
       customerWithContacts: {
@@ -898,7 +906,7 @@ const hakemukset: Application[] = [
           country: 'FI',
           email: 'yritys2@test.com',
           phone: '040123456',
-          registryKey: null,
+          registryKey: '1234567-1',
           registryKeyHidden: false,
           ovt: null,
           invoicingOperator: null,

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1546,7 +1546,13 @@
   },
   "muutosilmoitus": {
     "buttons": {
-      "createMuutosilmoitus": "Tee muutosilmoitus"
+      "createMuutosilmoitus": "Tee muutosilmoitus",
+      "editMuutosilmoitus": "Jatka muutosilmoitusta"
+    },
+    "notification": {
+      "label": "Muutosilmoitus",
+      "createdText": "Hakemukselle on luotu muutosilmoitus",
+      "sentText": "Hakemukselle on tehty muutosilmoitus, joka on lähetetty käsittelyyn {{date}}"
     }
   },
   "hankeSidebar": {


### PR DESCRIPTION
# Description

Added muutosilmoitus notification to application view that is shown if hakemus has muutosilmoitus. Notification has text "Hakemukselle on luotu muutosilmoitus" if muutosilmoitus sent field is null and text "Hakemukselle on tehty muutosilmoitus, joka on lähetetty käsittelyyn [date]" if muutosilmoitus has been sent. Date comes from sent field.

Muutosilmoitus edit button has text "Jatka muutosilmoitusta" if hakemus has muutosilmoitus but has not been sent. The button is not shown if muutosilmoitus has been sent. The button does nothing at this point.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3399

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check that kaivuilmoitus that has muutosilmoitus, has a notification "Hakemukselle on luotu muutosilmoitus" shown in application view and a button "Jatka muutosilmoitusta". State of the sent muutosilmoitus can not be tested yet as sending to Allu is implemented later.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
