### PR TITLE
HAI-430 Show muutosilmoitus work areas in application view sidebar

### DIFF
--- a/src/domain/application/applicationView/Sidebar.test.tsx
+++ b/src/domain/application/applicationView/Sidebar.test.tsx
@@ -2,7 +2,12 @@ import { cloneDeep } from 'lodash';
 import { render, screen } from '../../../testUtils/render';
 import hankkeet from '../../mocks/data/hankkeet-data';
 import hakemukset from '../../mocks/data/hakemukset-data';
-import { Application, JohtoselvitysData, KaivuilmoitusData } from '../types/application';
+import {
+  Application,
+  JohtoselvitysData,
+  KaivuilmoitusAlue,
+  KaivuilmoitusData,
+} from '../types/application';
 import Sidebar from './Sidebar';
 import { HankeData } from '../../types/hanke';
 
@@ -56,7 +61,7 @@ describe('Sidebar', () => {
         expect(screen.queryByText('Työalue 2 (31 m²)')).not.toBeInTheDocument();
       });
 
-      test('If there is no taydennys, should not show taydennys tabs', async () => {
+      test('If there is no taydennys, should not show tabs', async () => {
         const hanke = cloneDeep(hankkeet[1]) as HankeData;
         const application = cloneDeep(hakemukset[10]) as Application<JohtoselvitysData>;
         render(<Sidebar hanke={hanke} application={application} />);
@@ -68,69 +73,105 @@ describe('Sidebar', () => {
   });
 
   describe('Kaivuilmoitus', () => {
+    function getAreas(application: Application<KaivuilmoitusData>) {
+      return [
+        {
+          ...application.applicationData.areas[0],
+          tyoalueet: [
+            ...application.applicationData.areas[0].tyoalueet,
+            {
+              area: 10,
+              geometry: {
+                type: 'Polygon',
+                crs: {
+                  type: 'name',
+                  properties: {
+                    name: 'urn:ogc:def:crs:EPSG::3879',
+                  },
+                },
+                coordinates: [
+                  [
+                    [25498581.440262634, 6679345.526261961],
+                    [25498592.233686976, 6679350.99321815],
+                    [25498576.766730886, 6679351.786642391],
+                    [25498575.973306544, 6679346.319686302],
+                    [25498581.440262634, 6679345.526261961],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+      ] as KaivuilmoitusAlue[];
+    }
+
+    function setup(application: Application<KaivuilmoitusData>) {
+      const hanke = cloneDeep(hankkeet[1]) as HankeData;
+      return render(<Sidebar hanke={hanke} application={application} />);
+    }
+
     describe('Taydennys', () => {
       test('Should show correct taydennys content', async () => {
-        const hanke = cloneDeep(hankkeet[1]) as HankeData;
         const application = cloneDeep(hakemukset[12]) as Application<KaivuilmoitusData>;
         application.taydennys = {
           id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
           applicationData: {
             ...application.applicationData,
-            areas: [
-              {
-                ...application.applicationData.areas[0],
-                tyoalueet: [
-                  ...application.applicationData.areas[0].tyoalueet,
-                  {
-                    area: 10,
-                    geometry: {
-                      type: 'Polygon',
-                      crs: {
-                        type: 'name',
-                        properties: {
-                          name: 'urn:ogc:def:crs:EPSG::3879',
-                        },
-                      },
-                      coordinates: [
-                        [
-                          [25498581.440262634, 6679345.526261961],
-                          [25498582.233686976, 6679350.99321805],
-                          [25498576.766730886, 6679351.786642391],
-                          [25498575.973306544, 6679346.319686302],
-                          [25498581.440262634, 6679345.526261961],
-                        ],
-                      ],
-                    },
-                  },
-                ],
-              },
-            ],
+            areas: getAreas(application),
           },
           muutokset: ['areas[0].tyoalueet[2]'],
           liitteet: [],
         };
-        const { user } = render(<Sidebar hanke={hanke} application={application} />);
+        const { user } = setup(application);
 
         expect(screen.getByText('Täydennykset')).toBeInTheDocument();
         await user.click(screen.getByText('Hankealue 2'));
         expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
         expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
-        expect(screen.getByText('Työalue 3 (31 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 3 (62 m²)')).toBeInTheDocument();
 
         await user.click(screen.getByText('Alkuperäiset'));
 
         expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
         expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
-        expect(screen.queryByText('Työalue 3 (31 m²)')).not.toBeInTheDocument();
+        expect(screen.queryByText('Työalue 3 (62 m²)')).not.toBeInTheDocument();
       });
 
-      test('If there is no taydennys, should not show taydennys tabs', async () => {
-        const hanke = cloneDeep(hankkeet[1]) as HankeData;
+      test('If there is no taydennys (or muutosilmoitus), should not show tabs', async () => {
         const application = cloneDeep(hakemukset[12]) as Application<KaivuilmoitusData>;
-        render(<Sidebar hanke={hanke} application={application} />);
+        setup(application);
 
         expect(screen.queryByText('Täydennykset')).not.toBeInTheDocument();
         expect(screen.queryByText('Alkuperäiset')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('Muutosilmoitus', () => {
+      test('Should show correct muutosilmoitus content', async () => {
+        const application = cloneDeep(hakemukset[12]) as Application<KaivuilmoitusData>;
+        application.muutosilmoitus = {
+          id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+          applicationData: {
+            ...application.applicationData,
+            areas: getAreas(application),
+          },
+          sent: null,
+        };
+        const { user } = setup(application);
+
+        expect(screen.getByText('Muutokset')).toBeInTheDocument();
+
+        await user.click(screen.getByText('Hankealue 2'));
+
+        expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 3 (62 m²)')).toBeInTheDocument();
+
+        await user.click(screen.getByText('Alkuperäiset'));
+
+        expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
+        expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
+        expect(screen.queryByText('Työalue 3 (62 m²)')).not.toBeInTheDocument();
       });
     });
   });

--- a/src/domain/application/applicationView/Sidebar.tsx
+++ b/src/domain/application/applicationView/Sidebar.tsx
@@ -4,6 +4,8 @@ import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
 import {
   Application,
   ApplicationArea,
+  ApplicationType,
+  JohtoselvitysData,
   KaivuilmoitusAlue,
   KaivuilmoitusData,
 } from '../types/application';
@@ -15,16 +17,27 @@ import ApplicationDates from '../components/ApplicationDates';
 import OwnHankeMapHeader from '../../map/components/OwnHankeMap/OwnHankeMapHeader';
 import OwnHankeMap from '../../map/components/OwnHankeMap/OwnHankeMap';
 import useFilterHankeAlueetByApplicationDates from '../hooks/useFilterHankeAlueetByApplicationDates';
-import { HankeData } from '../../types/hanke';
+import { HankeAlue, HankeData } from '../../types/hanke';
 import CustomAccordion from '../../../common/components/customAccordion/CustomAccordion';
+import { Taydennys } from '../taydennys/types';
+import { Muutosilmoitus } from '../muutosilmoitus/types';
 
-type SidebarTyoalueetProps = {
+function getTyoalueet(
+  applicationType: ApplicationType,
+  areas: ApplicationArea[] | KaivuilmoitusAlue[],
+) {
+  return applicationType === 'CABLE_REPORT'
+    ? (areas as ApplicationArea[])
+    : (areas as KaivuilmoitusAlue[]).flatMap((area) => area.tyoalueet);
+}
+
+type TyoalueetListProps = {
   tyoalueet: ApplicationArea[];
   startTime: Date | null;
   endTime: Date | null;
 };
 
-function SidebarTyoalueet({ tyoalueet, startTime, endTime }: Readonly<SidebarTyoalueetProps>) {
+function TyoalueetList({ tyoalueet, startTime, endTime }: Readonly<TyoalueetListProps>) {
   const { t } = useTranslation();
 
   return tyoalueet.map((tyoalue, index) => {
@@ -78,7 +91,7 @@ function KaivuilmoitusAlueet({
             }
           >
             <Box marginLeft="var(--spacing-s)">
-              <SidebarTyoalueet
+              <TyoalueetList
                 tyoalueet={kaivuilmoitusAlue.tyoalueet}
                 startTime={applicationData.startTime}
                 endTime={applicationData.endTime}
@@ -91,31 +104,98 @@ function KaivuilmoitusAlueet({
   );
 }
 
+type AreaTabsProps = {
+  hanke: HankeData;
+  applicationType: ApplicationType;
+  taydennys?: Taydennys<JohtoselvitysData | KaivuilmoitusData> | null;
+  muutosilmoitus?: Muutosilmoitus<JohtoselvitysData | KaivuilmoitusData>;
+  originalHakemusContent: React.ReactNode;
+};
+
+/**
+ * Renders a tabbed interface for displaying täydennys/muutosilmoitus areas and original hakemus areas.
+ */
+function AreaTabs({
+  hanke,
+  applicationType,
+  taydennys,
+  muutosilmoitus,
+  originalHakemusContent,
+}: Readonly<AreaTabsProps>) {
+  const { t } = useTranslation();
+
+  const taydennysTyoalueet = taydennys
+    ? getTyoalueet(applicationType, taydennys.applicationData.areas)
+    : undefined;
+  const muutosilmoitusTyoalueet = muutosilmoitus
+    ? getTyoalueet(applicationType, muutosilmoitus.applicationData.areas)
+    : undefined;
+  const tyoalueet = taydennysTyoalueet ?? muutosilmoitusTyoalueet;
+
+  const taydennysKaivuilmoitusAlueet =
+    applicationType === 'EXCAVATION_NOTIFICATION'
+      ? (taydennys?.applicationData.areas as KaivuilmoitusAlue[] | undefined)
+      : null;
+  const muutosilmoitusKaivuilmoitusAlueet =
+    applicationType === 'EXCAVATION_NOTIFICATION'
+      ? (muutosilmoitus?.applicationData.areas as KaivuilmoitusAlue[] | undefined)
+      : null;
+  const kaivuilmoitusAlueet = taydennysKaivuilmoitusAlueet ?? muutosilmoitusKaivuilmoitusAlueet;
+
+  const applicationData = taydennys?.applicationData ?? muutosilmoitus?.applicationData;
+  const startTime = applicationData?.startTime;
+  const endTime = applicationData?.endTime;
+
+  return (
+    <Tabs>
+      <TabList>
+        <Tab>
+          {taydennys ? t('taydennys:labels:taydennykset') : t('muutosilmoitus:labels:muutokset')}
+        </Tab>
+        <Tab>{t('taydennys:labels:originalInformation')}</Tab>
+      </TabList>
+      <TabPanel>
+        <Box mt="var(--spacing-s)">
+          <Box mb="var(--spacing-s)">
+            <OwnHankeMapHeader hankeTunnus={hanke.hankeTunnus} showLink={false} />
+            <OwnHankeMap hanke={hanke} tyoalueet={tyoalueet} />
+          </Box>
+          {applicationType === 'CABLE_REPORT' && (
+            <TyoalueetList
+              tyoalueet={tyoalueet ?? []}
+              startTime={startTime ?? null}
+              endTime={endTime ?? null}
+            />
+          )}
+          {applicationType === 'EXCAVATION_NOTIFICATION' && (
+            <KaivuilmoitusAlueet
+              kaivuilmoitusAlueet={kaivuilmoitusAlueet}
+              hanke={hanke}
+              applicationData={applicationData as KaivuilmoitusData}
+            />
+          )}
+        </Box>
+      </TabPanel>
+      <TabPanel>
+        <Box mt="var(--spacing-s)">{originalHakemusContent}</Box>
+      </TabPanel>
+    </Tabs>
+  );
+}
+
 type SidebarProps = {
   hanke: HankeData;
   application: Application;
 };
 
 export default function Sidebar({ hanke, application }: Readonly<SidebarProps>) {
-  const { t } = useTranslation();
-  const { applicationType, applicationData, taydennys } = application;
-  const tyoalueet =
-    applicationType === 'CABLE_REPORT'
-      ? (applicationData.areas as ApplicationArea[])
-      : (applicationData.areas as KaivuilmoitusAlue[]).flatMap((area) => area.tyoalueet);
-  const taydennysTyoalueet =
-    applicationType === 'CABLE_REPORT'
-      ? (application.taydennys?.applicationData.areas as ApplicationArea[] | undefined)
-      : (application.taydennys?.applicationData.areas as KaivuilmoitusAlue[] | undefined)?.flatMap(
-          (area) => area.tyoalueet,
-        );
+  const { applicationType, applicationData, taydennys, muutosilmoitus } = application;
+
+  const tyoalueet = getTyoalueet(applicationType, applicationData.areas);
+
   const kaivuilmoitusAlueet =
     applicationType === 'EXCAVATION_NOTIFICATION'
       ? (applicationData.areas as KaivuilmoitusAlue[])
-      : null;
-  const taydennysKaivuilmoitusAlueet =
-    applicationType === 'EXCAVATION_NOTIFICATION'
-      ? (taydennys?.applicationData.areas as KaivuilmoitusAlue[] | undefined)
       : null;
 
   const filterHankeAlueet = useFilterHankeAlueetByApplicationDates({
@@ -128,19 +208,30 @@ export default function Sidebar({ hanke, application }: Readonly<SidebarProps>) 
     applicationEndDate: taydennys?.applicationData.endTime ?? null,
   });
 
-  function getHankeWithAlueetFilteredByDates(hankeData: HankeData): HankeData {
-    return {
-      ...hankeData,
-      // Do not show hanke alueet for generated hanke
-      alueet: !hankeData.generated ? filterHankeAlueet(hankeData.alueet) : [],
-    };
-  }
+  const filterHankeAlueetForMuutosilmoitus = useFilterHankeAlueetByApplicationDates({
+    applicationStartDate: muutosilmoitus?.applicationData.startTime ?? null,
+    applicationEndDate: muutosilmoitus?.applicationData.endTime ?? null,
+  });
 
-  function getHankeWithAlueetFilteredByDatesForTaydennys(hankeData: HankeData): HankeData {
+  function getHankeWithAlueetFilteredByDates(
+    hankeData: HankeData,
+    forTaydennys: boolean = false,
+    forMuutosilmoitus: boolean = false,
+  ): HankeData {
+    let alueet: HankeAlue[] = [];
+    // Only return alueet if the hanke is not generated
+    if (!hankeData.generated) {
+      if (forTaydennys) {
+        alueet = filterHankeAlueetForTaydennys(hankeData.alueet);
+      } else if (forMuutosilmoitus) {
+        alueet = filterHankeAlueetForMuutosilmoitus(hankeData.alueet);
+      } else {
+        alueet = filterHankeAlueet(hankeData.alueet);
+      }
+    }
     return {
       ...hankeData,
-      // Do not show hanke alueet for generated hanke
-      alueet: !hankeData.generated ? filterHankeAlueetForTaydennys(hankeData.alueet) : [],
+      alueet,
     };
   }
 
@@ -151,7 +242,7 @@ export default function Sidebar({ hanke, application }: Readonly<SidebarProps>) 
         <OwnHankeMap hanke={getHankeWithAlueetFilteredByDates(hanke)} tyoalueet={tyoalueet} />
       </Box>
       {applicationType === 'CABLE_REPORT' && (
-        <SidebarTyoalueet
+        <TyoalueetList
           tyoalueet={tyoalueet}
           startTime={applicationData.startTime}
           endTime={applicationData.endTime}
@@ -167,42 +258,19 @@ export default function Sidebar({ hanke, application }: Readonly<SidebarProps>) 
     </>
   );
 
-  if (taydennys) {
+  if (taydennys || muutosilmoitus) {
     return (
-      <Tabs>
-        <TabList>
-          <Tab>{t('taydennys:labels:taydennykset')}</Tab>
-          <Tab>{t('taydennys:labels:originalInformation')}</Tab>
-        </TabList>
-        <TabPanel>
-          <Box mt="var(--spacing-s)">
-            <Box mb="var(--spacing-s)">
-              <OwnHankeMapHeader hankeTunnus={hanke.hankeTunnus} showLink={false} />
-              <OwnHankeMap
-                hanke={getHankeWithAlueetFilteredByDatesForTaydennys(hanke)}
-                tyoalueet={taydennysTyoalueet}
-              />
-            </Box>
-            {applicationType === 'CABLE_REPORT' && (
-              <SidebarTyoalueet
-                tyoalueet={taydennysTyoalueet ?? []}
-                startTime={taydennys.applicationData.startTime}
-                endTime={taydennys.applicationData.endTime}
-              />
-            )}
-            {applicationType === 'EXCAVATION_NOTIFICATION' && (
-              <KaivuilmoitusAlueet
-                kaivuilmoitusAlueet={taydennysKaivuilmoitusAlueet}
-                hanke={hanke}
-                applicationData={applicationData as KaivuilmoitusData}
-              />
-            )}
-          </Box>
-        </TabPanel>
-        <TabPanel>
-          <Box mt="var(--spacing-s)">{hakemusContent}</Box>
-        </TabPanel>
-      </Tabs>
+      <AreaTabs
+        hanke={getHankeWithAlueetFilteredByDates(
+          hanke,
+          Boolean(taydennys),
+          Boolean(muutosilmoitus),
+        )}
+        applicationType={applicationType}
+        taydennys={taydennys}
+        muutosilmoitus={muutosilmoitus}
+        originalHakemusContent={hakemusContent}
+      />
     );
   }
 

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1556,7 +1556,8 @@
   "muutosilmoitus": {
     "heading": "$t(muutosilmoitus:notification:label)",
     "labels": {
-      "originalInformation": "$t(taydennys:labels:originalInformation)"
+      "originalInformation": "$t(taydennys:labels:originalInformation)",
+      "muutokset": "Muutokset"
     },
     "buttons": {
       "createMuutosilmoitus": "Tee muutosilmoitus",


### PR DESCRIPTION
# Description

In similar way to täydennys, muutosilmoitus area information is displayed in tabs along with original application area information in application view sidebar.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-430

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Have a kaivuilmoitus for which muutosilmoitus can be made (in decision or operational condition state)
2. Start making muutosilmoitus and make changes to work areas
3. Save and quit the form and check in application view that there are "Muutokset" and "Alkuperäiset" tabs in sidebar that show the correct information

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
