### PR TITLE
HAI-221 Don't show validation errors for undetected liikennemuodot

### DIFF
--- a/src/common/utils/yup.ts
+++ b/src/common/utils/yup.ts
@@ -111,7 +111,9 @@ yup.addMethod(
         // Retrieve the correct area
         const alueet = hanke?.alueet ?? application?.applicationData.areas;
         const pathSegments: string[] = this.path.split('.');
-        const aluePathSegment = pathSegments.length > 0 ? pathSegments[0] : '';
+        const aluePathSegment =
+          pathSegments.find((segment) => segment.includes('alueet') || segment.includes('areas')) ??
+          '';
         const match = aluePathSegment.match(/\[(\d+)]/);
         let alueIndex = 0;
         if (match) {

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -2051,4 +2051,94 @@ describe('Error notification', () => {
     expect(screen.getByRole('listitem', { name: /alueiden/i })).toBeInTheDocument();
     expect(screen.getByRole('listitem', { name: /yhteystiedot/i })).toBeInTheDocument();
   });
+
+  test('Should not show validation errors in haittojenhallinta page for liikennemuodot that have no detected nuisances', async () => {
+    const application = cloneDeep(applications[4]) as Application<KaivuilmoitusData>;
+    application.applicationData.areas = [
+      ...application.applicationData.areas,
+      {
+        name: 'Hankealue 1',
+        hankealueId: 1,
+        tyoalueet: [
+          {
+            geometry: {
+              type: 'Polygon',
+              crs: {
+                type: 'name',
+                properties: {
+                  name: 'urn:ogc:def:crs:EPSG::3879',
+                },
+              },
+              coordinates: [
+                [
+                  [25498583.867247857, 6679281.28058593],
+                  [25498584.13087749, 6679314.065289769],
+                  [25498573.17171292, 6679313.3807182815],
+                  [25498571.913494226, 6679281.456795131],
+                  [25498583.867247857, 6679281.28058593],
+                ],
+              ],
+            },
+            area: 159.32433261766946,
+            tormaystarkasteluTulos: {
+              liikennehaittaindeksi: {
+                indeksi: 0,
+                tyyppi: HAITTA_INDEX_TYPE.PYORALIIKENNEINDEKSI,
+              },
+              pyoraliikenneindeksi: 0,
+              autoliikenne: {
+                indeksi: 0,
+                haitanKesto: 0,
+                katuluokka: 0,
+                liikennemaara: 0,
+                kaistahaitta: 0,
+                kaistapituushaitta: 0,
+              },
+              linjaautoliikenneindeksi: 0,
+              raitioliikenneindeksi: 0,
+            },
+          },
+        ],
+        katuosoite: 'Aidasmäentie 5',
+        tyonTarkoitukset: ['VESI', 'VIEMARI'],
+        meluhaitta: 'TOISTUVA_MELUHAITTA',
+        polyhaitta: 'JATKUVA_POLYHAITTA',
+        tarinahaitta: 'SATUNNAINEN_TARINAHAITTA',
+        kaistahaitta: 'EI_VAIKUTA',
+        kaistahaittojenPituus: 'EI_VAIKUTA_KAISTAJARJESTELYIHIN',
+        lisatiedot: '',
+        haittojenhallintasuunnitelma: {
+          YLEINEN: 'Työalueen yleisten haittojen hallintasuunnitelma',
+          PYORALIIKENNE: '',
+          AUTOLIIKENNE: '',
+          LINJAAUTOLIIKENNE: '',
+          RAITIOLIIKENNE: '',
+          MUUT: 'Muiden työalueen haittojen hallintasuunnitelma',
+        },
+      },
+    ];
+    const { user } = setup(application);
+    await user.click(screen.getByRole('button', { name: /haittojen hallinta/i }));
+
+    expect(
+      screen.queryByRole('link', {
+        name: 'Työalueet (Hankealue 1) Pyöräliikenteen merkittävyys: Toimet työalueiden haittojen hallintaan',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
+        name: 'Työalueet (Hankealue 1) Autoliikenteen ruuhkautuminen: Toimet työalueiden haittojen hallintaan',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
+        name: 'Työalueet (Hankealue 1) Raitioliikenne: Toimet työalueiden haittojen hallintaan',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
+        name: 'Työalueet (Hankealue 1) Linja-autojen paikallisliikenne: Toimet työalueiden haittojen hallintaan',
+      }),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
# Description

There was a problem in kaivuilmoitus form haittojenhallinta page that validation errors might be shown for liikennemuodot that have nuisance index 0 (which are optional and no error should be shown). This was happening if there were work areas in multiple hanke areas as nuisance indexes were checked always only on the first area. Fixed this by finding the area path segment based on if it includes 'alueet' or 'areas' instead of taking the first path segment as the first segment for hakemus is 'applicationData'.

### Jira Issue:

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Have a kaivuilmoitus that have work areas in multiple hanke areas so that the first area has for example raitioliikenne or linja-autoliikenne nuisance index above 0 but for other area(s) that same index is 0 and check that unnecessary validation errors are not shown.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
