### PR TITLE
HAI-3405 Show muutosilmoitus changes in application view

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -1827,6 +1827,7 @@ describe('Excavation notification application view', () => {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
         applicationData: application.applicationData,
         sent: null,
+        muutokset: [],
       };
       const { user } = await setup(application);
       await user.click(screen.getByRole('button', { name: 'Jatka muutosilmoitusta' }));
@@ -1858,6 +1859,7 @@ describe('Excavation notification application view', () => {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
         applicationData: application.applicationData,
         sent: null,
+        muutokset: [],
       };
       await setup(application);
 
@@ -1870,6 +1872,7 @@ describe('Excavation notification application view', () => {
       const sentDate = new Date();
       application.muutosilmoitus = {
         id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        muutokset: [],
         applicationData: application.applicationData,
         sent: sentDate,
       };
@@ -1889,6 +1892,246 @@ describe('Excavation notification application view', () => {
       expect(
         screen.queryByRole('button', { name: 'Jatka muutosilmoitusta' }),
       ).not.toBeInTheDocument();
+    });
+
+    test('Shows changed information in basic information tab', async () => {
+      const application = cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>);
+      const name = 'New name';
+      const workDescription = 'New work description';
+      application.muutosilmoitus = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+        sent: null,
+        applicationData: {
+          ...application.applicationData,
+          name,
+          workDescription,
+          constructionWork: false,
+          maintenanceWork: true,
+          emergencyWork: true,
+          cableReports: [...(application.applicationData.cableReports || []), 'JS2300003'],
+          placementContracts: [
+            ...(application.applicationData.placementContracts || []),
+            'SL1234568',
+          ],
+          areas: [
+            {
+              ...application.applicationData.areas[0],
+              tyoalueet: [
+                ...application.applicationData.areas[0].tyoalueet,
+                {
+                  area: 10,
+                  geometry: {
+                    type: 'Polygon',
+                    crs: {
+                      type: 'name',
+                      properties: {
+                        name: 'urn:ogc:def:crs:EPSG::3879',
+                      },
+                    },
+                    coordinates: [
+                      [
+                        [25498581.440262634, 6679345.526261961],
+                        [25498582.233686976, 6679350.99321805],
+                        [25498576.766730886, 6679351.786642391],
+                        [25498575.973306544, 6679346.319686302],
+                        [25498581.440262634, 6679345.526261961],
+                      ],
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        muutokset: [
+          'name',
+          'workDescription',
+          'constructionWork',
+          'maintenanceWork',
+          'emergencyWork',
+          'cableReports',
+          'placementContracts',
+        ],
+      };
+      await setup(application);
+
+      expect(screen.getAllByText('Muutos:').length).toBe(6);
+      expect(screen.getAllByText('Poistettu:').length).toBe(1);
+      expect(screen.getByText(name)).toBeInTheDocument();
+      expect(screen.getByText(workDescription)).toBeInTheDocument();
+      expect(screen.getByText('Olemassaolevan rakenteen kunnossapitotyöstä')).toBeInTheDocument();
+      expect(screen.getAllByText('Uuden rakenteen tai johdon rakentamisesta').length).toBe(2);
+      expect(
+        screen.getByText(
+          'Kaivutyö on aloitettu ennen johtoselvityksen tilaamista merkittävien vahinkojen välttämiseksi',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText('JS2300003')).toBeInTheDocument();
+      expect(screen.getByText('SL1234568')).toBeInTheDocument();
+      expect(screen.getByText('221 m²')).toBeInTheDocument();
+    });
+
+    test('Shows changed information in areas tab', async () => {
+      const application = cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>);
+      application.muutosilmoitus = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+        sent: null,
+        applicationData: {
+          ...application.applicationData,
+          areas: [
+            {
+              ...application.applicationData.areas[0],
+              tyoalueet: [
+                ...application.applicationData.areas[0].tyoalueet.slice(0, 1),
+                {
+                  area: 10,
+                  geometry: {
+                    type: 'Polygon',
+                    crs: {
+                      type: 'name',
+                      properties: {
+                        name: 'urn:ogc:def:crs:EPSG::3879',
+                      },
+                    },
+                    coordinates: [
+                      [
+                        [25498574.56194478, 6679282.528783048],
+                        [25498582.990384366, 6679282.528783048],
+                        [25498582.990384366, 6679310.418567079],
+                        [25498574.56194478, 6679310.418567079],
+                        [25498574.56194478, 6679282.528783048],
+                      ],
+                    ],
+                  },
+                  tormaystarkasteluTulos: {
+                    liikennehaittaindeksi: {
+                      indeksi: 5,
+                      tyyppi: HAITTA_INDEX_TYPE.AUTOLIIKENNEINDEKSI,
+                    },
+                    pyoraliikenneindeksi: 3,
+                    autoliikenne: {
+                      indeksi: 5,
+                      haitanKesto: 5,
+                      katuluokka: 5,
+                      liikennemaara: 5,
+                      kaistahaitta: 5,
+                      kaistapituushaitta: 5,
+                    },
+                    linjaautoliikenneindeksi: 0,
+                    raitioliikenneindeksi: 1,
+                  },
+                },
+              ],
+              tyonTarkoitukset: ['VESI', 'TIETOLIIKENNE'],
+              meluhaitta: 'SATUNNAINEN_MELUHAITTA',
+              polyhaitta: 'SATUNNAINEN_POLYHAITTA',
+              tarinahaitta: 'TOISTUVA_TARINAHAITTA',
+              kaistahaitta: 'YKSI_KAISTA_VAHENEE_KAHDELLA_AJOSUUNNALLA',
+              kaistahaittojenPituus: 'PITUUS_ALLE_10_METRIA',
+              lisatiedot: 'Lisätiedot',
+            },
+          ],
+        },
+        muutokset: [
+          'areas[0].tyoalueet[1]',
+          'areas[0].tyonTarkoitukset',
+          'areas[0].meluhaitta',
+          'areas[0].polyhaitta',
+          'areas[0].tarinahaitta',
+          'areas[0].kaistahaitta',
+          'areas[0].kaistahaittojenPituus',
+          'areas[0].lisatiedot',
+        ],
+      };
+      const { user } = await setup(application);
+      await user.click(screen.getByRole('tab', { name: /alueet/i }));
+
+      expect(screen.getAllByText('Muutos:').length).toBe(8);
+      expect(screen.getByText('394 m²')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Työalueille lasketut liikennehaittaindeksit ovat muuttuneet. Tarkista haittojenhallintasuunnitelma.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    test('Shows changed information in haittojen hallinta tab', async () => {
+      const application = cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>);
+      application.applicationData.propertyDeveloperWithContacts = cloneDeep(
+        application.applicationData.customerWithContacts,
+      );
+      application.muutosilmoitus = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+        sent: null,
+        applicationData: {
+          ...application.applicationData,
+          areas: [
+            {
+              ...application.applicationData.areas[0],
+              haittojenhallintasuunnitelma: {
+                YLEINEN: 'Täydennetty työalueen yleisten haittojen hallintasuunnitelma',
+                PYORALIIKENNE:
+                  'Täydennetty pyöräliikenteelle koituvien työalueen haittojen hallintasuunnitelma',
+                AUTOLIIKENNE:
+                  'Täydennetty autoliikenteelle koituvien työalueen haittojen hallintasuunnitelma',
+                LINJAAUTOLIIKENNE:
+                  'Linja-autoliikenteelle koituvien työalueen haittojen hallintasuunnitelma',
+                RAITIOLIIKENNE:
+                  'Täydennetty raitioliikenteelle koituvien työalueen haittojen hallintasuunnitelma',
+                MUUT: '',
+              },
+            },
+          ],
+        },
+        muutokset: [
+          'areas[0].haittojenhallintasuunnitelma[YLEINEN]',
+          'areas[0].haittojenhallintasuunnitelma[PYORALIIKENNE]',
+          'areas[0].haittojenhallintasuunnitelma[AUTOLIIKENNE]',
+          'areas[0].haittojenhallintasuunnitelma[LINJAAUTOLIIKENNE]',
+          'areas[0].haittojenhallintasuunnitelma[RAITOLIIKENNE]',
+          'areas[0].haittojenhallintasuunnitelma[MUUT]',
+        ],
+      };
+      const { user } = await setup(application);
+      await user.click(screen.getByRole('tab', { name: /haittojen hallinta/i }));
+
+      expect(screen.getAllByText('Muutos:').length).toBe(6);
+    });
+
+    test('Shows changed information in contacts tab', async () => {
+      const application = cloneDeep(hakemukset[12] as Application<KaivuilmoitusData>);
+      application.applicationData.propertyDeveloperWithContacts = cloneDeep(
+        application.applicationData.customerWithContacts,
+      );
+      application.muutosilmoitus = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01c',
+        sent: null,
+        applicationData: {
+          ...application.applicationData,
+          customerWithContacts: {
+            customer: {
+              ...application.applicationData.customerWithContacts!.customer,
+              name: 'New name',
+              email: 'newMail@test.com',
+            },
+            contacts: application.applicationData.customerWithContacts!.contacts,
+          },
+          propertyDeveloperWithContacts: null,
+          invoicingCustomer: {
+            ...application.applicationData.invoicingCustomer!,
+            name: 'Uusi Laskutus Oy',
+          },
+        },
+        muutokset: ['customerWithContacts', 'propertyDeveloperWithContacts', 'invoicingCustomer'],
+      };
+      const { user } = await setup(application);
+      await user.click(screen.getByRole('tab', { name: /yhteystiedot/i }));
+
+      expect(screen.getAllByText('Muutos:').length).toBe(2);
+      expect(screen.getAllByText('Poistettu:').length).toBe(1);
+      expect(screen.getByText('New name')).toBeInTheDocument();
+      expect(screen.getByText('newMail@test.com')).toBeInTheDocument();
+      expect(screen.getByText('Uusi Laskutus Oy')).toBeInTheDocument();
     });
   });
 });

--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -1863,7 +1863,7 @@ describe('Excavation notification application view', () => {
       };
       await setup(application);
 
-      expect(screen.getByText('Hakemukselle on luotu muutosilmoitus')).toBeInTheDocument();
+      expect(screen.getByText('Hakemuksella on keskeneräinen muutosilmoitus.')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Jatka muutosilmoitusta' })).toBeInTheDocument();
     });
 

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -94,6 +94,7 @@ import TaydennysCancel from '../taydennys/components/TaydennysCancel';
 import TaydennysAttachmentsList from '../taydennys/components/TaydennysAttachmentsList';
 import { HaittojenhallintasuunnitelmaInfo } from '../../kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo';
 import MuutosilmoitusNotification from '../muutosilmoitus/components/MuutosilmoitusNotification';
+import { MuutosLabelProvider } from '../taydennysAndMuutosilmoitusCommon/MuutosLabelContext';
 
 function TyoalueetList({ tyoalueet }: { tyoalueet: ApplicationArea[] }) {
   const { t } = useTranslation();
@@ -717,17 +718,21 @@ function ApplicationView({
     representativeWithContacts,
     paperDecisionReceiver,
   } = applicationData;
+
+  const muutokset = taydennys?.muutokset ?? muutosilmoitus?.muutokset;
+  const changedData = taydennys?.applicationData ?? muutosilmoitus?.applicationData;
+
   const tyoalueet =
     applicationType === 'CABLE_REPORT'
       ? (areas as ApplicationArea[])
       : (areas as KaivuilmoitusAlue[]).flatMap((area) => area.tyoalueet);
   const kaivuilmoitusTaydennysAlueet =
     applicationType === 'EXCAVATION_NOTIFICATION'
-      ? (application.taydennys?.applicationData.areas as KaivuilmoitusAlue[] | undefined)
+      ? (changedData?.areas as KaivuilmoitusAlue[] | undefined)
       : null;
   const taydennysTyoalueet =
     applicationType === 'CABLE_REPORT'
-      ? (application.taydennys?.applicationData.areas as ApplicationArea[] | undefined)
+      ? (changedData?.areas as ApplicationArea[] | undefined)
       : kaivuilmoitusTaydennysAlueet?.flatMap((area) => area.tyoalueet);
   const kaivuilmoitusAlueet =
     applicationType === 'EXCAVATION_NOTIFICATION' ? (areas as KaivuilmoitusAlue[]) : null;
@@ -996,240 +1001,232 @@ function ApplicationView({
 
       <InformationViewContentContainer>
         <InformationViewMainContent>
-          <Tabs>
-            <TabList style={{ marginBottom: 'var(--spacing-m)' }}>
-              <Tab>{t('hankePortfolio:tabit:perustiedot')}</Tab>
-              <Tab>{t('hankePortfolio:tabit:alueet')}</Tab>
-              {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                <Tab>{t('hankePortfolio:tabit:haittojenHallinta')}</Tab>
-              )}
-              <Tab>{t('hankePortfolio:tabit:yhteystiedot')}</Tab>
-              <Tab>{t('hankePortfolio:tabit:liitteet')}</Tab>
-            </TabList>
-            <TabPanel>
-              {/* Basic information panel */}
-              {applicationType === 'CABLE_REPORT' && (
-                <JohtoselvitysBasicInformationSummary
-                  formData={application as Application<JohtoselvitysData>}
-                  changedData={taydennys?.applicationData as JohtoselvitysData}
-                  muutokset={taydennys?.muutokset}
-                >
-                  <SectionItemTitle>{t('hakemus:labels:totalSurfaceArea')}</SectionItemTitle>
-                  <SectionItemContent>
-                    <TotalSurfaceArea tyoalueet={tyoalueet} changedAreas={taydennysTyoalueet} />
-                  </SectionItemContent>
-                </JohtoselvitysBasicInformationSummary>
-              )}
-              {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                <KaivuilmoitusBasicInformationSummary
-                  formData={application as Application<KaivuilmoitusData>}
-                  changedData={taydennys?.applicationData as KaivuilmoitusData}
-                  muutokset={taydennys?.muutokset}
-                >
-                  <SectionItemTitle>{t('hakemus:labels:totalSurfaceArea')}</SectionItemTitle>
-                  <SectionItemContent>
-                    <TotalSurfaceArea tyoalueet={tyoalueet} changedAreas={taydennysTyoalueet} />
-                  </SectionItemContent>
-                </KaivuilmoitusBasicInformationSummary>
-              )}
-            </TabPanel>
-            <TabPanel>
-              {/* Areas information panel */}
-              <FormSummarySection style={{ marginBottom: 'var(--spacing-m)' }}>
-                <SectionItemTitle>{t('kaivuilmoitusForm:alueet:startDate')}</SectionItemTitle>
-                <SectionItemContent>
-                  {startTime && <p>{formatToFinnishDate(startTime)}</p>}
-                  {application.taydennys?.muutokset.includes('startTime') && (
-                    <Box marginTop="var(--spacing-s)">
-                      {!application.taydennys?.applicationData.startTime ? (
-                        <SectionItemContentRemoved>
-                          {startTime && <p>{formatToFinnishDate(startTime)}</p>}
-                        </SectionItemContentRemoved>
-                      ) : (
-                        <SectionItemContentAdded>
-                          <p>
-                            {formatToFinnishDate(application.taydennys.applicationData.startTime)}
-                          </p>
-                        </SectionItemContentAdded>
-                      )}
-                    </Box>
-                  )}
-                </SectionItemContent>
-                <SectionItemTitle>{t('kaivuilmoitusForm:alueet:endDate')}</SectionItemTitle>
-                <SectionItemContent>
-                  {endTime && <p>{formatToFinnishDate(endTime)}</p>}
-                  {application.taydennys?.muutokset.includes('endTime') && (
-                    <Box marginTop="var(--spacing-s)">
-                      {!application.taydennys?.applicationData.endTime ? (
-                        <SectionItemContentRemoved>
-                          {endTime && <p>{formatToFinnishDate(endTime)}</p>}
-                        </SectionItemContentRemoved>
-                      ) : (
-                        <SectionItemContentAdded>
-                          <p>
-                            {formatToFinnishDate(application.taydennys.applicationData.endTime)}
-                          </p>
-                        </SectionItemContentAdded>
-                      )}
-                    </Box>
-                  )}
-                </SectionItemContent>
-              </FormSummarySection>
-              {applicationType === 'CABLE_REPORT' && (
-                <JohtoselvitysAreasInfo
-                  tyoalueet={tyoalueet}
-                  changedAreas={taydennysTyoalueet}
-                  muutokset={taydennys?.muutokset}
-                />
-              )}
-              {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                <KaivuilmoitusAreasInfo
-                  originalAreas={kaivuilmoitusAlueet}
-                  changedAreas={taydennys?.applicationData?.areas as KaivuilmoitusAlue[]}
-                  muutokset={taydennys?.muutokset}
-                />
-              )}
-            </TabPanel>
-            <TabPanel>
-              {/* Nuisance management panel */}
-              {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                <KaivuilmoitusAreasNuisanceInfo
-                  hankeAreas={hankealueet}
-                  originalAreas={kaivuilmoitusAlueet}
-                  changedAreas={taydennys?.applicationData?.areas as KaivuilmoitusAlue[]}
-                  muutokset={taydennys?.muutokset}
-                />
-              )}
-            </TabPanel>
-            <TabPanel>
-              {/* Contacts information panel */}
-              <FormSummarySection>
-                <ContactsSummary
-                  customerWithContacts={customerWithContacts}
-                  title={t('form:yhteystiedot:titles:customerWithContacts')}
-                />
-                {application.taydennys?.muutokset.includes('customerWithContacts') &&
-                  application.taydennys.applicationData.customerWithContacts && (
-                    <ContactsSummary
-                      customerWithContacts={
-                        application.taydennys.applicationData.customerWithContacts
-                      }
-                      ContentContainer={SectionItemContentAdded}
-                    />
-                  )}
-                <ContactsSummary
-                  customerWithContacts={contractorWithContacts}
-                  title={t('form:yhteystiedot:titles:contractorWithContacts')}
-                />
-                {application.taydennys?.muutokset.includes('contractorWithContacts') &&
-                  application.taydennys.applicationData.contractorWithContacts && (
-                    <ContactsSummary
-                      customerWithContacts={
-                        application.taydennys.applicationData.contractorWithContacts
-                      }
-                      ContentContainer={SectionItemContentAdded}
-                    />
-                  )}
-                <ContactsSummary
-                  customerWithContacts={propertyDeveloperWithContacts}
-                  title={t('form:yhteystiedot:titles:rakennuttajat')}
-                />
-                {application.taydennys?.muutokset.includes('propertyDeveloperWithContacts') && (
-                  <ContactsSummary
-                    customerWithContacts={
-                      application.taydennys.applicationData.propertyDeveloperWithContacts ??
-                      propertyDeveloperWithContacts
-                    }
-                    title={
-                      !propertyDeveloperWithContacts
-                        ? t('form:yhteystiedot:titles:rakennuttajat')
-                        : undefined
-                    }
-                    ContentContainer={
-                      application.taydennys.applicationData.propertyDeveloperWithContacts
-                        ? SectionItemContentAdded
-                        : SectionItemContentRemoved
-                    }
-                  />
+          <MuutosLabelProvider
+            value={taydennys ? t('taydennys:labels:taydennys') : t('muutosilmoitus:labels:muutos')}
+          >
+            <Tabs>
+              <TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+                <Tab>{t('hankePortfolio:tabit:perustiedot')}</Tab>
+                <Tab>{t('hankePortfolio:tabit:alueet')}</Tab>
+                {applicationType === 'EXCAVATION_NOTIFICATION' && (
+                  <Tab>{t('hankePortfolio:tabit:haittojenHallinta')}</Tab>
                 )}
-                <ContactsSummary
-                  customerWithContacts={representativeWithContacts}
-                  title={t('form:yhteystiedot:titles:representativeWithContacts')}
-                />
-                {application.taydennys?.muutokset.includes('representativeWithContacts') && (
-                  <ContactsSummary
-                    customerWithContacts={
-                      application.taydennys.applicationData.representativeWithContacts ??
-                      representativeWithContacts
-                    }
-                    title={
-                      !representativeWithContacts
-                        ? t('form:yhteystiedot:titles:representativeWithContacts')
-                        : undefined
-                    }
-                    ContentContainer={
-                      application.taydennys.applicationData.representativeWithContacts
-                        ? SectionItemContentAdded
-                        : SectionItemContentRemoved
-                    }
+                <Tab>{t('hankePortfolio:tabit:yhteystiedot')}</Tab>
+                <Tab>{t('hankePortfolio:tabit:liitteet')}</Tab>
+              </TabList>
+              <TabPanel>
+                {/* Basic information panel */}
+                {applicationType === 'CABLE_REPORT' && (
+                  <JohtoselvitysBasicInformationSummary
+                    formData={application as Application<JohtoselvitysData>}
+                    changedData={changedData as JohtoselvitysData}
+                    muutokset={muutokset}
+                  >
+                    <SectionItemTitle>{t('hakemus:labels:totalSurfaceArea')}</SectionItemTitle>
+                    <SectionItemContent>
+                      <TotalSurfaceArea tyoalueet={tyoalueet} changedAreas={taydennysTyoalueet} />
+                    </SectionItemContent>
+                  </JohtoselvitysBasicInformationSummary>
+                )}
+                {applicationType === 'EXCAVATION_NOTIFICATION' && (
+                  <KaivuilmoitusBasicInformationSummary
+                    formData={application as Application<KaivuilmoitusData>}
+                    changedData={changedData as KaivuilmoitusData}
+                    muutokset={muutokset}
+                  >
+                    <SectionItemTitle>{t('hakemus:labels:totalSurfaceArea')}</SectionItemTitle>
+                    <SectionItemContent>
+                      <TotalSurfaceArea tyoalueet={tyoalueet} changedAreas={taydennysTyoalueet} />
+                    </SectionItemContent>
+                  </KaivuilmoitusBasicInformationSummary>
+                )}
+              </TabPanel>
+              <TabPanel>
+                {/* Areas information panel */}
+                <FormSummarySection style={{ marginBottom: 'var(--spacing-m)' }}>
+                  <SectionItemTitle>{t('kaivuilmoitusForm:alueet:startDate')}</SectionItemTitle>
+                  <SectionItemContent>
+                    {startTime && <p>{formatToFinnishDate(startTime)}</p>}
+                    {muutokset?.includes('startTime') && (
+                      <Box marginTop="var(--spacing-s)">
+                        {!changedData?.startTime ? (
+                          <SectionItemContentRemoved>
+                            {startTime && <p>{formatToFinnishDate(startTime)}</p>}
+                          </SectionItemContentRemoved>
+                        ) : (
+                          <SectionItemContentAdded>
+                            <p>{formatToFinnishDate(changedData.startTime)}</p>
+                          </SectionItemContentAdded>
+                        )}
+                      </Box>
+                    )}
+                  </SectionItemContent>
+                  <SectionItemTitle>{t('kaivuilmoitusForm:alueet:endDate')}</SectionItemTitle>
+                  <SectionItemContent>
+                    {endTime && <p>{formatToFinnishDate(endTime)}</p>}
+                    {muutokset?.includes('endTime') && (
+                      <Box marginTop="var(--spacing-s)">
+                        {!changedData?.endTime ? (
+                          <SectionItemContentRemoved>
+                            {endTime && <p>{formatToFinnishDate(endTime)}</p>}
+                          </SectionItemContentRemoved>
+                        ) : (
+                          <SectionItemContentAdded>
+                            <p>{formatToFinnishDate(changedData.endTime)}</p>
+                          </SectionItemContentAdded>
+                        )}
+                      </Box>
+                    )}
+                  </SectionItemContent>
+                </FormSummarySection>
+                {applicationType === 'CABLE_REPORT' && (
+                  <JohtoselvitysAreasInfo
+                    tyoalueet={tyoalueet}
+                    changedAreas={taydennysTyoalueet}
+                    muutokset={muutokset}
                   />
                 )}
                 {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                  <>
-                    <InvoicingCustomerSummary
-                      invoicingCustomer={(applicationData as KaivuilmoitusData).invoicingCustomer}
-                      title={t('form:yhteystiedot:titles:invoicingCustomerInfo')}
+                  <KaivuilmoitusAreasInfo
+                    originalAreas={kaivuilmoitusAlueet}
+                    changedAreas={changedData?.areas as KaivuilmoitusAlue[]}
+                    muutokset={muutokset}
+                  />
+                )}
+              </TabPanel>
+              <TabPanel>
+                {/* Nuisance management panel */}
+                {applicationType === 'EXCAVATION_NOTIFICATION' && (
+                  <KaivuilmoitusAreasNuisanceInfo
+                    hankeAreas={hankealueet}
+                    originalAreas={kaivuilmoitusAlueet}
+                    changedAreas={changedData?.areas as KaivuilmoitusAlue[]}
+                    muutokset={muutokset}
+                  />
+                )}
+              </TabPanel>
+              <TabPanel>
+                {/* Contacts information panel */}
+                <FormSummarySection>
+                  <ContactsSummary
+                    customerWithContacts={customerWithContacts}
+                    title={t('form:yhteystiedot:titles:customerWithContacts')}
+                  />
+                  {muutokset?.includes('customerWithContacts') &&
+                    changedData?.customerWithContacts && (
+                      <ContactsSummary
+                        customerWithContacts={changedData?.customerWithContacts}
+                        ContentContainer={SectionItemContentAdded}
+                      />
+                    )}
+                  <ContactsSummary
+                    customerWithContacts={contractorWithContacts}
+                    title={t('form:yhteystiedot:titles:contractorWithContacts')}
+                  />
+                  {muutokset?.includes('contractorWithContacts') &&
+                    changedData?.contractorWithContacts && (
+                      <ContactsSummary
+                        customerWithContacts={changedData?.contractorWithContacts}
+                        ContentContainer={SectionItemContentAdded}
+                      />
+                    )}
+                  <ContactsSummary
+                    customerWithContacts={propertyDeveloperWithContacts}
+                    title={t('form:yhteystiedot:titles:rakennuttajat')}
+                  />
+                  {muutokset?.includes('propertyDeveloperWithContacts') && (
+                    <ContactsSummary
+                      customerWithContacts={
+                        changedData?.propertyDeveloperWithContacts ?? propertyDeveloperWithContacts
+                      }
+                      title={
+                        !propertyDeveloperWithContacts
+                          ? t('form:yhteystiedot:titles:rakennuttajat')
+                          : undefined
+                      }
+                      ContentContainer={
+                        changedData?.propertyDeveloperWithContacts
+                          ? SectionItemContentAdded
+                          : SectionItemContentRemoved
+                      }
                     />
-                    {application.taydennys?.muutokset.includes('invoicingCustomer') &&
-                      (application.taydennys?.applicationData as KaivuilmoitusData)
-                        .invoicingCustomer && (
-                        <InvoicingCustomerSummary
-                          invoicingCustomer={
-                            (application.taydennys?.applicationData as KaivuilmoitusData)
-                              .invoicingCustomer ??
-                            (applicationData as KaivuilmoitusData).invoicingCustomer
-                          }
-                          title={
-                            !(applicationData as KaivuilmoitusData).invoicingCustomer
-                              ? t('form:yhteystiedot:titles:invoicingCustomerInfo')
-                              : undefined
-                          }
-                          ContentContainer={SectionItemContentAdded}
-                        />
-                      )}
-                  </>
-                )}
-                {paperDecisionReceiver && (
-                  <PaperDecisionReceiverSummary paperDecisionReceiver={paperDecisionReceiver} />
-                )}
-              </FormSummarySection>
-            </TabPanel>
-            <TabPanel>
-              {/* Attachments panel */}
-              {applicationType === 'EXCAVATION_NOTIFICATION' ? (
-                <KaivuilmoitusAttachmentSummary
-                  formData={application as Application<KaivuilmoitusData>}
-                  attachments={attachments}
-                  taydennysAttachments={taydennys?.liitteet}
-                  taydennysAdditionalInfo={
-                    (taydennys?.applicationData as KaivuilmoitusData)?.additionalInfo
-                  }
-                />
-              ) : attachments ? (
-                <AttachmentSummary
-                  attachments={attachments}
-                  children={
-                    taydennys?.liitteet &&
-                    taydennys.liitteet.length > 0 && (
-                      <SectionItemContentAdded mt="var(--spacing-xs)">
-                        <TaydennysAttachmentsList attachments={taydennys.liitteet} />
-                      </SectionItemContentAdded>
-                    )
-                  }
-                />
-              ) : null}
-            </TabPanel>
-          </Tabs>
+                  )}
+                  <ContactsSummary
+                    customerWithContacts={representativeWithContacts}
+                    title={t('form:yhteystiedot:titles:representativeWithContacts')}
+                  />
+                  {muutokset?.includes('representativeWithContacts') && (
+                    <ContactsSummary
+                      customerWithContacts={
+                        changedData?.representativeWithContacts ?? representativeWithContacts
+                      }
+                      title={
+                        !representativeWithContacts
+                          ? t('form:yhteystiedot:titles:representativeWithContacts')
+                          : undefined
+                      }
+                      ContentContainer={
+                        changedData?.representativeWithContacts
+                          ? SectionItemContentAdded
+                          : SectionItemContentRemoved
+                      }
+                    />
+                  )}
+                  {applicationType === 'EXCAVATION_NOTIFICATION' && (
+                    <>
+                      <InvoicingCustomerSummary
+                        invoicingCustomer={(applicationData as KaivuilmoitusData).invoicingCustomer}
+                        title={t('form:yhteystiedot:titles:invoicingCustomerInfo')}
+                      />
+                      {muutokset?.includes('invoicingCustomer') &&
+                        (changedData as KaivuilmoitusData).invoicingCustomer && (
+                          <InvoicingCustomerSummary
+                            invoicingCustomer={
+                              (changedData as KaivuilmoitusData).invoicingCustomer ??
+                              (applicationData as KaivuilmoitusData).invoicingCustomer
+                            }
+                            title={
+                              !(applicationData as KaivuilmoitusData).invoicingCustomer
+                                ? t('form:yhteystiedot:titles:invoicingCustomerInfo')
+                                : undefined
+                            }
+                            ContentContainer={SectionItemContentAdded}
+                          />
+                        )}
+                    </>
+                  )}
+                  {paperDecisionReceiver && (
+                    <PaperDecisionReceiverSummary paperDecisionReceiver={paperDecisionReceiver} />
+                  )}
+                </FormSummarySection>
+              </TabPanel>
+              <TabPanel>
+                {/* Attachments panel */}
+                {applicationType === 'EXCAVATION_NOTIFICATION' ? (
+                  <KaivuilmoitusAttachmentSummary
+                    formData={application as Application<KaivuilmoitusData>}
+                    attachments={attachments}
+                    taydennysAttachments={taydennys?.liitteet}
+                    taydennysAdditionalInfo={
+                      (taydennys?.applicationData as KaivuilmoitusData)?.additionalInfo
+                    }
+                  />
+                ) : attachments ? (
+                  <AttachmentSummary
+                    attachments={attachments}
+                    children={
+                      taydennys?.liitteet &&
+                      taydennys.liitteet.length > 0 && (
+                        <SectionItemContentAdded mt="var(--spacing-xs)">
+                          <TaydennysAttachmentsList attachments={taydennys.liitteet} />
+                        </SectionItemContentAdded>
+                      )
+                    }
+                  />
+                ) : null}
+              </TabPanel>
+            </Tabs>
+          </MuutosLabelProvider>
         </InformationViewMainContent>
         <InformationViewSidebar testId="application-view-sidebar">
           {hanke && <Sidebar hanke={hanke} application={application} />}

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -94,7 +94,6 @@ import TaydennysCancel from '../taydennys/components/TaydennysCancel';
 import TaydennysAttachmentsList from '../taydennys/components/TaydennysAttachmentsList';
 import { HaittojenhallintasuunnitelmaInfo } from '../../kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo';
 import MuutosilmoitusNotification from '../muutosilmoitus/components/MuutosilmoitusNotification';
-import { MuutosLabelProvider } from '../taydennysAndMuutosilmoitusCommon/MuutosLabelContext';
 
 function TyoalueetList({ tyoalueet }: { tyoalueet: ApplicationArea[] }) {
   const { t } = useTranslation();
@@ -1001,232 +1000,228 @@ function ApplicationView({
 
       <InformationViewContentContainer>
         <InformationViewMainContent>
-          <MuutosLabelProvider
-            value={taydennys ? t('taydennys:labels:taydennys') : t('muutosilmoitus:labels:muutos')}
-          >
-            <Tabs>
-              <TabList style={{ marginBottom: 'var(--spacing-m)' }}>
-                <Tab>{t('hankePortfolio:tabit:perustiedot')}</Tab>
-                <Tab>{t('hankePortfolio:tabit:alueet')}</Tab>
-                {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                  <Tab>{t('hankePortfolio:tabit:haittojenHallinta')}</Tab>
-                )}
-                <Tab>{t('hankePortfolio:tabit:yhteystiedot')}</Tab>
-                <Tab>{t('hankePortfolio:tabit:liitteet')}</Tab>
-              </TabList>
-              <TabPanel>
-                {/* Basic information panel */}
-                {applicationType === 'CABLE_REPORT' && (
-                  <JohtoselvitysBasicInformationSummary
-                    formData={application as Application<JohtoselvitysData>}
-                    changedData={changedData as JohtoselvitysData}
-                    muutokset={muutokset}
-                  >
-                    <SectionItemTitle>{t('hakemus:labels:totalSurfaceArea')}</SectionItemTitle>
-                    <SectionItemContent>
-                      <TotalSurfaceArea tyoalueet={tyoalueet} changedAreas={taydennysTyoalueet} />
-                    </SectionItemContent>
-                  </JohtoselvitysBasicInformationSummary>
-                )}
-                {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                  <KaivuilmoitusBasicInformationSummary
-                    formData={application as Application<KaivuilmoitusData>}
-                    changedData={changedData as KaivuilmoitusData}
-                    muutokset={muutokset}
-                  >
-                    <SectionItemTitle>{t('hakemus:labels:totalSurfaceArea')}</SectionItemTitle>
-                    <SectionItemContent>
-                      <TotalSurfaceArea tyoalueet={tyoalueet} changedAreas={taydennysTyoalueet} />
-                    </SectionItemContent>
-                  </KaivuilmoitusBasicInformationSummary>
-                )}
-              </TabPanel>
-              <TabPanel>
-                {/* Areas information panel */}
-                <FormSummarySection style={{ marginBottom: 'var(--spacing-m)' }}>
-                  <SectionItemTitle>{t('kaivuilmoitusForm:alueet:startDate')}</SectionItemTitle>
+          <Tabs>
+            <TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+              <Tab>{t('hankePortfolio:tabit:perustiedot')}</Tab>
+              <Tab>{t('hankePortfolio:tabit:alueet')}</Tab>
+              {applicationType === 'EXCAVATION_NOTIFICATION' && (
+                <Tab>{t('hankePortfolio:tabit:haittojenHallinta')}</Tab>
+              )}
+              <Tab>{t('hankePortfolio:tabit:yhteystiedot')}</Tab>
+              <Tab>{t('hankePortfolio:tabit:liitteet')}</Tab>
+            </TabList>
+            <TabPanel>
+              {/* Basic information panel */}
+              {applicationType === 'CABLE_REPORT' && (
+                <JohtoselvitysBasicInformationSummary
+                  formData={application as Application<JohtoselvitysData>}
+                  changedData={changedData as JohtoselvitysData}
+                  muutokset={muutokset}
+                >
+                  <SectionItemTitle>{t('hakemus:labels:totalSurfaceArea')}</SectionItemTitle>
                   <SectionItemContent>
-                    {startTime && <p>{formatToFinnishDate(startTime)}</p>}
-                    {muutokset?.includes('startTime') && (
-                      <Box marginTop="var(--spacing-s)">
-                        {!changedData?.startTime ? (
-                          <SectionItemContentRemoved>
-                            {startTime && <p>{formatToFinnishDate(startTime)}</p>}
-                          </SectionItemContentRemoved>
-                        ) : (
-                          <SectionItemContentAdded>
-                            <p>{formatToFinnishDate(changedData.startTime)}</p>
-                          </SectionItemContentAdded>
-                        )}
-                      </Box>
-                    )}
+                    <TotalSurfaceArea tyoalueet={tyoalueet} changedAreas={taydennysTyoalueet} />
                   </SectionItemContent>
-                  <SectionItemTitle>{t('kaivuilmoitusForm:alueet:endDate')}</SectionItemTitle>
+                </JohtoselvitysBasicInformationSummary>
+              )}
+              {applicationType === 'EXCAVATION_NOTIFICATION' && (
+                <KaivuilmoitusBasicInformationSummary
+                  formData={application as Application<KaivuilmoitusData>}
+                  changedData={changedData as KaivuilmoitusData}
+                  muutokset={muutokset}
+                >
+                  <SectionItemTitle>{t('hakemus:labels:totalSurfaceArea')}</SectionItemTitle>
                   <SectionItemContent>
-                    {endTime && <p>{formatToFinnishDate(endTime)}</p>}
-                    {muutokset?.includes('endTime') && (
-                      <Box marginTop="var(--spacing-s)">
-                        {!changedData?.endTime ? (
-                          <SectionItemContentRemoved>
-                            {endTime && <p>{formatToFinnishDate(endTime)}</p>}
-                          </SectionItemContentRemoved>
-                        ) : (
-                          <SectionItemContentAdded>
-                            <p>{formatToFinnishDate(changedData.endTime)}</p>
-                          </SectionItemContentAdded>
-                        )}
-                      </Box>
-                    )}
+                    <TotalSurfaceArea tyoalueet={tyoalueet} changedAreas={taydennysTyoalueet} />
                   </SectionItemContent>
-                </FormSummarySection>
-                {applicationType === 'CABLE_REPORT' && (
-                  <JohtoselvitysAreasInfo
-                    tyoalueet={tyoalueet}
-                    changedAreas={taydennysTyoalueet}
-                    muutokset={muutokset}
-                  />
-                )}
-                {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                  <KaivuilmoitusAreasInfo
-                    originalAreas={kaivuilmoitusAlueet}
-                    changedAreas={changedData?.areas as KaivuilmoitusAlue[]}
-                    muutokset={muutokset}
-                  />
-                )}
-              </TabPanel>
-              <TabPanel>
-                {/* Nuisance management panel */}
-                {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                  <KaivuilmoitusAreasNuisanceInfo
-                    hankeAreas={hankealueet}
-                    originalAreas={kaivuilmoitusAlueet}
-                    changedAreas={changedData?.areas as KaivuilmoitusAlue[]}
-                    muutokset={muutokset}
-                  />
-                )}
-              </TabPanel>
-              <TabPanel>
-                {/* Contacts information panel */}
-                <FormSummarySection>
-                  <ContactsSummary
-                    customerWithContacts={customerWithContacts}
-                    title={t('form:yhteystiedot:titles:customerWithContacts')}
-                  />
-                  {muutokset?.includes('customerWithContacts') &&
-                    changedData?.customerWithContacts && (
-                      <ContactsSummary
-                        customerWithContacts={changedData?.customerWithContacts}
-                        ContentContainer={SectionItemContentAdded}
-                      />
-                    )}
-                  <ContactsSummary
-                    customerWithContacts={contractorWithContacts}
-                    title={t('form:yhteystiedot:titles:contractorWithContacts')}
-                  />
-                  {muutokset?.includes('contractorWithContacts') &&
-                    changedData?.contractorWithContacts && (
-                      <ContactsSummary
-                        customerWithContacts={changedData?.contractorWithContacts}
-                        ContentContainer={SectionItemContentAdded}
-                      />
-                    )}
-                  <ContactsSummary
-                    customerWithContacts={propertyDeveloperWithContacts}
-                    title={t('form:yhteystiedot:titles:rakennuttajat')}
-                  />
-                  {muutokset?.includes('propertyDeveloperWithContacts') && (
-                    <ContactsSummary
-                      customerWithContacts={
-                        changedData?.propertyDeveloperWithContacts ?? propertyDeveloperWithContacts
-                      }
-                      title={
-                        !propertyDeveloperWithContacts
-                          ? t('form:yhteystiedot:titles:rakennuttajat')
-                          : undefined
-                      }
-                      ContentContainer={
-                        changedData?.propertyDeveloperWithContacts
-                          ? SectionItemContentAdded
-                          : SectionItemContentRemoved
-                      }
-                    />
-                  )}
-                  <ContactsSummary
-                    customerWithContacts={representativeWithContacts}
-                    title={t('form:yhteystiedot:titles:representativeWithContacts')}
-                  />
-                  {muutokset?.includes('representativeWithContacts') && (
-                    <ContactsSummary
-                      customerWithContacts={
-                        changedData?.representativeWithContacts ?? representativeWithContacts
-                      }
-                      title={
-                        !representativeWithContacts
-                          ? t('form:yhteystiedot:titles:representativeWithContacts')
-                          : undefined
-                      }
-                      ContentContainer={
-                        changedData?.representativeWithContacts
-                          ? SectionItemContentAdded
-                          : SectionItemContentRemoved
-                      }
-                    />
-                  )}
-                  {applicationType === 'EXCAVATION_NOTIFICATION' && (
-                    <>
-                      <InvoicingCustomerSummary
-                        invoicingCustomer={(applicationData as KaivuilmoitusData).invoicingCustomer}
-                        title={t('form:yhteystiedot:titles:invoicingCustomerInfo')}
-                      />
-                      {muutokset?.includes('invoicingCustomer') &&
-                        (changedData as KaivuilmoitusData).invoicingCustomer && (
-                          <InvoicingCustomerSummary
-                            invoicingCustomer={
-                              (changedData as KaivuilmoitusData).invoicingCustomer ??
-                              (applicationData as KaivuilmoitusData).invoicingCustomer
-                            }
-                            title={
-                              !(applicationData as KaivuilmoitusData).invoicingCustomer
-                                ? t('form:yhteystiedot:titles:invoicingCustomerInfo')
-                                : undefined
-                            }
-                            ContentContainer={SectionItemContentAdded}
-                          />
-                        )}
-                    </>
-                  )}
-                  {paperDecisionReceiver && (
-                    <PaperDecisionReceiverSummary paperDecisionReceiver={paperDecisionReceiver} />
-                  )}
-                </FormSummarySection>
-              </TabPanel>
-              <TabPanel>
-                {/* Attachments panel */}
-                {applicationType === 'EXCAVATION_NOTIFICATION' ? (
-                  <KaivuilmoitusAttachmentSummary
-                    formData={application as Application<KaivuilmoitusData>}
-                    attachments={attachments}
-                    taydennysAttachments={taydennys?.liitteet}
-                    taydennysAdditionalInfo={
-                      (taydennys?.applicationData as KaivuilmoitusData)?.additionalInfo
-                    }
-                  />
-                ) : attachments ? (
-                  <AttachmentSummary
-                    attachments={attachments}
-                    children={
-                      taydennys?.liitteet &&
-                      taydennys.liitteet.length > 0 && (
-                        <SectionItemContentAdded mt="var(--spacing-xs)">
-                          <TaydennysAttachmentsList attachments={taydennys.liitteet} />
+                </KaivuilmoitusBasicInformationSummary>
+              )}
+            </TabPanel>
+            <TabPanel>
+              {/* Areas information panel */}
+              <FormSummarySection style={{ marginBottom: 'var(--spacing-m)' }}>
+                <SectionItemTitle>{t('kaivuilmoitusForm:alueet:startDate')}</SectionItemTitle>
+                <SectionItemContent>
+                  {startTime && <p>{formatToFinnishDate(startTime)}</p>}
+                  {muutokset?.includes('startTime') && (
+                    <Box marginTop="var(--spacing-s)">
+                      {!changedData?.startTime ? (
+                        <SectionItemContentRemoved>
+                          {startTime && <p>{formatToFinnishDate(startTime)}</p>}
+                        </SectionItemContentRemoved>
+                      ) : (
+                        <SectionItemContentAdded>
+                          <p>{formatToFinnishDate(changedData.startTime)}</p>
                         </SectionItemContentAdded>
-                      )
+                      )}
+                    </Box>
+                  )}
+                </SectionItemContent>
+                <SectionItemTitle>{t('kaivuilmoitusForm:alueet:endDate')}</SectionItemTitle>
+                <SectionItemContent>
+                  {endTime && <p>{formatToFinnishDate(endTime)}</p>}
+                  {muutokset?.includes('endTime') && (
+                    <Box marginTop="var(--spacing-s)">
+                      {!changedData?.endTime ? (
+                        <SectionItemContentRemoved>
+                          {endTime && <p>{formatToFinnishDate(endTime)}</p>}
+                        </SectionItemContentRemoved>
+                      ) : (
+                        <SectionItemContentAdded>
+                          <p>{formatToFinnishDate(changedData.endTime)}</p>
+                        </SectionItemContentAdded>
+                      )}
+                    </Box>
+                  )}
+                </SectionItemContent>
+              </FormSummarySection>
+              {applicationType === 'CABLE_REPORT' && (
+                <JohtoselvitysAreasInfo
+                  tyoalueet={tyoalueet}
+                  changedAreas={taydennysTyoalueet}
+                  muutokset={muutokset}
+                />
+              )}
+              {applicationType === 'EXCAVATION_NOTIFICATION' && (
+                <KaivuilmoitusAreasInfo
+                  originalAreas={kaivuilmoitusAlueet}
+                  changedAreas={changedData?.areas as KaivuilmoitusAlue[]}
+                  muutokset={muutokset}
+                />
+              )}
+            </TabPanel>
+            <TabPanel>
+              {/* Nuisance management panel */}
+              {applicationType === 'EXCAVATION_NOTIFICATION' && (
+                <KaivuilmoitusAreasNuisanceInfo
+                  hankeAreas={hankealueet}
+                  originalAreas={kaivuilmoitusAlueet}
+                  changedAreas={changedData?.areas as KaivuilmoitusAlue[]}
+                  muutokset={muutokset}
+                />
+              )}
+            </TabPanel>
+            <TabPanel>
+              {/* Contacts information panel */}
+              <FormSummarySection>
+                <ContactsSummary
+                  customerWithContacts={customerWithContacts}
+                  title={t('form:yhteystiedot:titles:customerWithContacts')}
+                />
+                {muutokset?.includes('customerWithContacts') &&
+                  changedData?.customerWithContacts && (
+                    <ContactsSummary
+                      customerWithContacts={changedData?.customerWithContacts}
+                      ContentContainer={SectionItemContentAdded}
+                    />
+                  )}
+                <ContactsSummary
+                  customerWithContacts={contractorWithContacts}
+                  title={t('form:yhteystiedot:titles:contractorWithContacts')}
+                />
+                {muutokset?.includes('contractorWithContacts') &&
+                  changedData?.contractorWithContacts && (
+                    <ContactsSummary
+                      customerWithContacts={changedData?.contractorWithContacts}
+                      ContentContainer={SectionItemContentAdded}
+                    />
+                  )}
+                <ContactsSummary
+                  customerWithContacts={propertyDeveloperWithContacts}
+                  title={t('form:yhteystiedot:titles:rakennuttajat')}
+                />
+                {muutokset?.includes('propertyDeveloperWithContacts') && (
+                  <ContactsSummary
+                    customerWithContacts={
+                      changedData?.propertyDeveloperWithContacts ?? propertyDeveloperWithContacts
+                    }
+                    title={
+                      !propertyDeveloperWithContacts
+                        ? t('form:yhteystiedot:titles:rakennuttajat')
+                        : undefined
+                    }
+                    ContentContainer={
+                      changedData?.propertyDeveloperWithContacts
+                        ? SectionItemContentAdded
+                        : SectionItemContentRemoved
                     }
                   />
-                ) : null}
-              </TabPanel>
-            </Tabs>
-          </MuutosLabelProvider>
+                )}
+                <ContactsSummary
+                  customerWithContacts={representativeWithContacts}
+                  title={t('form:yhteystiedot:titles:representativeWithContacts')}
+                />
+                {muutokset?.includes('representativeWithContacts') && (
+                  <ContactsSummary
+                    customerWithContacts={
+                      changedData?.representativeWithContacts ?? representativeWithContacts
+                    }
+                    title={
+                      !representativeWithContacts
+                        ? t('form:yhteystiedot:titles:representativeWithContacts')
+                        : undefined
+                    }
+                    ContentContainer={
+                      changedData?.representativeWithContacts
+                        ? SectionItemContentAdded
+                        : SectionItemContentRemoved
+                    }
+                  />
+                )}
+                {applicationType === 'EXCAVATION_NOTIFICATION' && (
+                  <>
+                    <InvoicingCustomerSummary
+                      invoicingCustomer={(applicationData as KaivuilmoitusData).invoicingCustomer}
+                      title={t('form:yhteystiedot:titles:invoicingCustomerInfo')}
+                    />
+                    {muutokset?.includes('invoicingCustomer') &&
+                      (changedData as KaivuilmoitusData).invoicingCustomer && (
+                        <InvoicingCustomerSummary
+                          invoicingCustomer={
+                            (changedData as KaivuilmoitusData).invoicingCustomer ??
+                            (applicationData as KaivuilmoitusData).invoicingCustomer
+                          }
+                          title={
+                            !(applicationData as KaivuilmoitusData).invoicingCustomer
+                              ? t('form:yhteystiedot:titles:invoicingCustomerInfo')
+                              : undefined
+                          }
+                          ContentContainer={SectionItemContentAdded}
+                        />
+                      )}
+                  </>
+                )}
+                {paperDecisionReceiver && (
+                  <PaperDecisionReceiverSummary paperDecisionReceiver={paperDecisionReceiver} />
+                )}
+              </FormSummarySection>
+            </TabPanel>
+            <TabPanel>
+              {/* Attachments panel */}
+              {applicationType === 'EXCAVATION_NOTIFICATION' ? (
+                <KaivuilmoitusAttachmentSummary
+                  formData={application as Application<KaivuilmoitusData>}
+                  attachments={attachments}
+                  taydennysAttachments={taydennys?.liitteet}
+                  taydennysAdditionalInfo={
+                    (taydennys?.applicationData as KaivuilmoitusData)?.additionalInfo
+                  }
+                />
+              ) : attachments ? (
+                <AttachmentSummary
+                  attachments={attachments}
+                  children={
+                    taydennys?.liitteet &&
+                    taydennys.liitteet.length > 0 && (
+                      <SectionItemContentAdded mt="var(--spacing-xs)">
+                        <TaydennysAttachmentsList attachments={taydennys.liitteet} />
+                      </SectionItemContentAdded>
+                    )
+                  }
+                />
+              ) : null}
+            </TabPanel>
+          </Tabs>
         </InformationViewMainContent>
         <InformationViewSidebar testId="application-view-sidebar">
           {hanke && <Sidebar hanke={hanke} application={application} />}

--- a/src/domain/application/applicationView/ApplicationViewContainer.tsx
+++ b/src/domain/application/applicationView/ApplicationViewContainer.tsx
@@ -13,6 +13,7 @@ import { usePermissionsForHanke } from '../../hanke/hankeUsers/hooks/useUserRigh
 import LoadingSpinner from '../../../common/components/spinner/LoadingSpinner';
 import useCreateTaydennys from '../taydennys/hooks/useCreateTaydennys';
 import useCreateMuutosilmoitus from '../muutosilmoitus/hooks/useCreateMuutosilmoitus';
+import { MuutosLabelProvider } from '../taydennysAndMuutosilmoitusCommon/MuutosLabelContext';
 
 type Props = {
   id: number;
@@ -92,7 +93,11 @@ function ApplicationViewContainer({ id }: Readonly<Props>) {
   }
 
   return (
-    <>
+    <MuutosLabelProvider
+      value={
+        application.taydennys ? t('taydennys:labels:taydennys') : t('muutosilmoitus:labels:muutos')
+      }
+    >
       <ApplicationView
         application={application}
         hanke={hanke}
@@ -125,7 +130,7 @@ function ApplicationViewContainer({ id }: Readonly<Props>) {
           {t('common:error')}
         </Notification>
       )}
-    </>
+    </MuutosLabelProvider>
   );
 }
 

--- a/src/domain/application/applicationView/Sidebar.test.tsx
+++ b/src/domain/application/applicationView/Sidebar.test.tsx
@@ -156,6 +156,7 @@ describe('Sidebar', () => {
             areas: getAreas(application),
           },
           sent: null,
+          muutokset: ['areas[0].tyoalueet[2]'],
         };
         const { user } = setup(application);
 

--- a/src/domain/application/muutosilmoitus/types.ts
+++ b/src/domain/application/muutosilmoitus/types.ts
@@ -4,4 +4,5 @@ export type Muutosilmoitus<T> = {
   id: string;
   applicationData: T;
   sent: MuutosilmoitusSent;
+  muutokset: string[];
 };

--- a/src/domain/application/taydennysAndMuutosilmoitusCommon/MuutosLabelContext.tsx
+++ b/src/domain/application/taydennysAndMuutosilmoitusCommon/MuutosLabelContext.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
-import { createContext, useContext } from 'react';
+import React, { createContext, useContext } from 'react';
 
 const MuutosLabelContext = createContext<string | undefined>(undefined);
 
 export function MuutosLabelProvider({
   children,
   value,
-}: {
+}: Readonly<{
   children: React.ReactNode;
   value: string | undefined;
-}) {
+}>) {
   return <MuutosLabelContext.Provider value={value}>{children}</MuutosLabelContext.Provider>;
 }
 

--- a/src/domain/application/taydennysAndMuutosilmoitusCommon/MuutosLabelContext.tsx
+++ b/src/domain/application/taydennysAndMuutosilmoitusCommon/MuutosLabelContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+
+const MuutosLabelContext = createContext<string | undefined>(undefined);
+
+export function MuutosLabelProvider({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: string | undefined;
+}) {
+  return <MuutosLabelContext.Provider value={value}>{children}</MuutosLabelContext.Provider>;
+}
+
+export function useMuutosLabel() {
+  return useContext(MuutosLabelContext);
+}

--- a/src/domain/application/taydennysAndMuutosilmoitusCommon/MuutosLabelContext.tsx
+++ b/src/domain/application/taydennysAndMuutosilmoitusCommon/MuutosLabelContext.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { createContext, useContext } from 'react';
 
 const MuutosLabelContext = createContext<string | undefined>(undefined);

--- a/src/domain/forms/components/FormSummarySection.tsx
+++ b/src/domain/forms/components/FormSummarySection.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Text from '../../../common/components/text/Text';
 import styles from './FormSummarySection.module.scss';
 import { useTranslation } from 'react-i18next';
+import { useMuutosLabel } from '../../application/taydennysAndMuutosilmoitusCommon/MuutosLabelContext';
 
 const SectionTitle: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
@@ -64,11 +65,12 @@ const SectionItemContentAdded: React.FC<Readonly<SectionItemContentProps>> = ({
   ...chakraProps
 }) => {
   const { t } = useTranslation();
+  const label = useMuutosLabel();
 
   return (
     <SectionItemContent border="1px solid black" padding="var(--spacing-2-xs)" {...chakraProps}>
       <Box as="p" marginBottom="var(--spacing-s)" fontWeight={500}>
-        {t('taydennys:labels:taydennys')}:
+        {label ?? t('taydennys:labels:taydennys')}:
       </Box>
       {children}
     </SectionItemContent>

--- a/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
+++ b/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
@@ -24,6 +24,7 @@ function setup(
       id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
       applicationData: application.applicationData,
       sent: new Date('2025-09-01T15:00:00.000Z'),
+      muutokset: [],
     },
     hankeData = hankkeet[1] as HankeData,
     responseStatus = 200,

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -2010,6 +2010,7 @@ const hakemukset: Application[] = [
     muutosilmoitus: {
       id: '6a24e4a6-8f87-4da7-96f9-5f6b54ea6834',
       sent: null,
+      muutokset: [],
       applicationData: {
         applicationType: 'EXCAVATION_NOTIFICATION',
         name: 'Aidasmäentien muutoskaivuut',

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -205,6 +205,7 @@ export async function createMuutosilmoitus(id: number) {
     id: faker.string.uuid(),
     applicationData: cloneDeep(hakemus.applicationData),
     sent: null,
+    muutokset: [],
   };
   hakemus.muutosilmoitus = muutosilmoitus;
   return muutosilmoitus;

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1567,7 +1567,8 @@
     "labels": {
       "muutosilmoitus": "Muutosilmoitus",
       "originalInformation": "$t(taydennys:labels:originalInformation)",
-      "muutokset": "Muutokset"
+      "muutokset": "Muutokset",
+      "muutos": "Muutos"
     },
     "buttons": {
       "createMuutosilmoitus": "Tee muutosilmoitus",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1576,7 +1576,7 @@
     },
     "notification": {
       "label": "Muutosilmoitus",
-      "createdText": "Hakemukselle on luotu muutosilmoitus",
+      "createdText": "Hakemuksella on keskeneräinen muutosilmoitus.",
       "sentText": "Hakemukselle on tehty muutosilmoitus, joka on lähetetty käsittelyyn {{date}}"
     }
   },


### PR DESCRIPTION
# Description

Changes made in kaivuilmoitus muutosilmoitus form are shown in application view in the same way as täydennys changes.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3405

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Make changes in kaivuilmoitus muutosilmoitus form and check that changes are shown correctly in application view.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
