### PR TITLE
HAI-3452 Add loading overlay for file upload loading state

### DIFF
--- a/src/common/components/fileUpload/FileUpload.module.scss
+++ b/src/common/components/fileUpload/FileUpload.module.scss
@@ -10,6 +10,7 @@
 
 .loadingContainer {
   margin-left: var(--spacing-m);
+  margin-right: var(--spacing-m);
   align-items: center;
   column-gap: var(--spacing-2-xs);
   row-gap: var(--spacing-2-xs);

--- a/src/common/components/fileUpload/FileUpload.tsx
+++ b/src/common/components/fileUpload/FileUpload.tsx
@@ -255,7 +255,7 @@ export default function FileUpload<T extends AttachmentMetadata>({
               <Button
                 variant="supplementary"
                 iconLeft={<IconCross aria-hidden />}
-                style={{ color: 'var(--color-error)' }}
+                theme="black"
                 onClick={cancelRequests}
               >
                 {t('common:confirmationDialog:cancelButton')}

--- a/src/common/components/fileUpload/FileUpload.tsx
+++ b/src/common/components/fileUpload/FileUpload.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useMutation } from 'react-query';
-import { Flex } from '@chakra-ui/react';
+import { Flex, ModalContent, ModalOverlay } from '@chakra-ui/react';
 import { Button, FileInput, IconAlertCircleFill, IconCheckCircleFill, IconCross } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { differenceBy } from 'lodash';
@@ -14,6 +14,7 @@ import FileList from './FileList';
 import { FileDeleteFunction, FileDownLoadFunction, ShowDeleteButtonFunction } from './types';
 import ErrorLoadingText from '../errorLoadingText/ErrorLoadingText';
 import LoadingSpinner from '../spinner/LoadingSpinner';
+import InlineModal from '../inlineModal/InlineModal';
 
 function useDragAndDropFiles() {
   const ref = useRef<HTMLDivElement>(null);
@@ -236,22 +237,33 @@ export default function FileUpload<T extends AttachmentMetadata>({
   return (
     <div>
       <Flex alignItems="center" className={styles.uploadContainer} ref={dropZoneRef}>
-        {filesUploading ? (
-          <Flex className={styles.loadingContainer} direction={{ base: 'column', sm: 'row' }}>
-            <LoadingSpinner small className={styles.loadingSpinner} />
-            <Text tag="p" className={styles.loadingText}>
-              {t('common:components:fileUpload:loadingText')}
-            </Text>
-            <Button
-              variant="supplementary"
-              iconLeft={<IconCross aria-hidden />}
-              style={{ color: 'var(--color-error)' }}
-              onClick={cancelRequests}
-            >
-              {t('common:confirmationDialog:cancelButton')}
-            </Button>
-          </Flex>
-        ) : (
+        <InlineModal
+          isOpen={filesUploading}
+          onClose={() => {}}
+          blockScrollOnMount={false}
+          closeOnEsc={false}
+          closeOnOverlayClick={false}
+          motionPreset="none"
+        >
+          <ModalOverlay bg="whiteAlpha.700" />
+          <ModalContent boxShadow="none">
+            <Flex className={styles.loadingContainer} direction={{ base: 'column', sm: 'row' }}>
+              <LoadingSpinner small className={styles.loadingSpinner} />
+              <Text tag="p" className={styles.loadingText}>
+                {t('common:components:fileUpload:loadingText')}
+              </Text>
+              <Button
+                variant="supplementary"
+                iconLeft={<IconCross aria-hidden />}
+                style={{ color: 'var(--color-error)' }}
+                onClick={cancelRequests}
+              >
+                {t('common:confirmationDialog:cancelButton')}
+              </Button>
+            </Flex>
+          </ModalContent>
+        </InlineModal>
+        {!filesUploading && (
           <FileInput
             id={id}
             accept={accept}

--- a/src/common/components/inlineModal/InlineModal.scss
+++ b/src/common/components/inlineModal/InlineModal.scss
@@ -1,0 +1,7 @@
+.inline-modal-container {
+  .chakra-modal__content-container {
+    position: static;
+    width: auto;
+    height: auto;
+  }
+}

--- a/src/common/components/inlineModal/InlineModal.tsx
+++ b/src/common/components/inlineModal/InlineModal.tsx
@@ -1,0 +1,23 @@
+import React, { useRef } from 'react';
+import { Modal, ModalProps } from '@chakra-ui/react';
+import './InlineModal.scss';
+
+interface Props extends ModalProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Wrapper for chakra-ui Modal component that positions the modal according
+ * to the normal document flow.
+ */
+export default function InlineModal({ children, ...props }: Readonly<Props>) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  return (
+    <div ref={containerRef} className="inline-modal-container">
+      <Modal portalProps={{ containerRef }} {...props}>
+        {children}
+      </Modal>
+    </div>
+  );
+}

--- a/src/domain/hanke/edit/HankeForm.tsx
+++ b/src/domain/hanke/edit/HankeForm.tsx
@@ -57,7 +57,6 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
   const { setNotification } = useGlobalNotification();
   const [showNotification, setShowNotification] = useState<FormNotification | null>(null);
   const [showAddApplicationDialog, setShowAddApplicationDialog] = useState(false);
-  const [attachmentsUploading, setAttachmentsUploading] = useState(false);
   const hakemukset = useApplicationsForHanke(formData.hankeTunnus, true);
   const validationContext = {
     hanke: formData,
@@ -131,11 +130,8 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
     },
   });
 
-  const attachmentsUploadingText: string = t('common:components:fileUpload:loadingText');
-  const saveAndQuitButtonIsLoading = hankeMutation.isLoading || attachmentsUploading;
-  const saveAndQuitButtonLoadingText = attachmentsUploading
-    ? attachmentsUploadingText
-    : t('common:buttons:savingText');
+  const saveAndQuitButtonIsLoading = hankeMutation.isLoading;
+  const saveAndQuitButtonLoadingText = t('common:buttons:savingText');
 
   const [drawSource] = useState<VectorSource>(new VectorSource());
 
@@ -176,10 +172,6 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
   useEffect(() => {
     onIsDirtyChange(isDirty);
   }, [isDirty, onIsDirtyChange]);
-
-  function handleFileUpload(uploading: boolean) {
-    setAttachmentsUploading(uploading);
-  }
 
   function handleStepChange(stepIndex: number) {
     setActiveStepIndex(stepIndex);
@@ -225,7 +217,7 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
       validationSchema: hankeYhteystiedotPublicSchema,
     },
     {
-      element: <HankeFormLiitteet onFileUpload={handleFileUpload} />,
+      element: <HankeFormLiitteet />,
       label: t('hankePortfolio:tabit:liitteet'),
       state: StepState.available,
     },
@@ -332,8 +324,6 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
           heading={formHeading}
           formSteps={formSteps}
           onStepChange={handleStepChange}
-          isLoading={attachmentsUploading}
-          isLoadingText={attachmentsUploadingText}
           topElement={formErrorsNotification}
           formData={watchFormValues}
           validationContext={validationContext}
@@ -348,17 +338,11 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
                 totalSteps={formSteps.length}
                 onPrevious={handlePrevious}
                 onNext={handleNext}
-                previousButtonIsLoading={attachmentsUploading}
-                previousButtonLoadingText={attachmentsUploadingText}
-                nextButtonIsLoading={attachmentsUploading}
-                nextButtonLoadingText={attachmentsUploadingText}
               >
                 <Button
                   variant="danger"
                   iconLeft={<IconCross aria-hidden />}
                   onClick={() => onFormClose(formValues.hankeTunnus)}
-                  isLoading={attachmentsUploading}
-                  loadingText={attachmentsUploadingText}
                 >
                   {t('hankeForm:cancelButton')}
                 </Button>

--- a/src/domain/hanke/edit/HankeFormLiitteet.tsx
+++ b/src/domain/hanke/edit/HankeFormLiitteet.tsx
@@ -13,11 +13,7 @@ import {
 } from '../hankeAttachments/hankeAttachmentsApi';
 import { AttachmentMetadata } from '../../../common/types/attachment';
 
-type Props = {
-  onFileUpload: (uploading: boolean) => void;
-};
-
-function HankeFormLiitteet({ onFileUpload }: Readonly<Props>) {
+function HankeFormLiitteet() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const { getValues } = useFormContext<HankeDataFormState>();
@@ -40,7 +36,6 @@ function HankeFormLiitteet({ onFileUpload }: Readonly<Props>) {
   }
 
   function handleUpload(uploading: boolean) {
-    onFileUpload(uploading);
     if (!uploading) {
       queryClient.invalidateQueries(HANKE_ATTACHMENTS_QUERY_KEY);
     }

--- a/src/domain/johtoselvitys/Attachments.tsx
+++ b/src/domain/johtoselvitys/Attachments.tsx
@@ -12,17 +12,15 @@ import FileUpload from '../../common/components/fileUpload/FileUpload';
 type Props = {
   existingAttachments: ApplicationAttachmentMetadata[] | undefined;
   attachmentsLoadError: boolean;
-  onFileUpload: (isUploading: boolean) => void;
 };
 
-function Attachments({ existingAttachments, attachmentsLoadError, onFileUpload }: Readonly<Props>) {
+function Attachments({ existingAttachments, attachmentsLoadError }: Readonly<Props>) {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
   const { getValues } = useFormContext<JohtoselvitysFormValues>();
   const alluStatus = getValues('alluStatus');
 
   function handleFileUpload(uploading: boolean) {
-    onFileUpload(uploading);
     if (!uploading) {
       queryClient.invalidateQueries('attachments');
     }

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -134,8 +134,6 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
 
   const navigateToApplicationView = useNavigateToApplicationView();
 
-  const [attachmentsUploading, setAttachmentsUploading] = useState(false);
-
   const [isSendButtonDisabled, setIsSendButtonDisabled] = useState(false);
   const [showSendDialog, setShowSendDialog] = useState(false);
 
@@ -260,10 +258,6 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
     saveCableApplication(handleSuccess);
   }
 
-  function handleAttachmentUpload(isUploading: boolean) {
-    setAttachmentsUploading(isUploading);
-  }
-
   function closeAttachmentUploadErrorDialog() {
     setAttachmentUploadErrors([]);
   }
@@ -338,7 +332,6 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
           <Attachments
             existingAttachments={existingAttachments}
             attachmentsLoadError={attachmentsLoadError}
-            onFileUpload={handleAttachmentUpload}
           />
         ),
         label: t('hankePortfolio:tabit:liitteet'),
@@ -374,8 +367,6 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
     return changeFormStep(changeStep, pageFieldsToValidate[stepIndex], trigger);
   }
 
-  const attachmentsUploadingText: string = t('common:components:fileUpload:loadingText');
-
   return (
     <FormProvider {...formContext}>
       {/* Notifications for saving application */}
@@ -396,8 +387,6 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
         heading={t('johtoselvitysForm:pageHeader')}
         subHeading={hankeNameText}
         formSteps={formSteps}
-        isLoading={attachmentsUploading}
-        isLoadingText={attachmentsUploadingText}
         onStepChange={handleStepChange}
         onSubmit={handleSubmit(openSendDialog)}
         stepChangeValidator={validateStepChange}
@@ -420,22 +409,14 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
           const disableSendButton = showSendButton && !isContact;
 
           const saveAndQuitIsLoading =
-            applicationCreateMutation.isLoading ||
-            applicationUpdateMutation.isLoading ||
-            attachmentsUploading;
-          const saveAndQuitLoadingText = attachmentsUploading
-            ? attachmentsUploadingText
-            : t('common:buttons:savingText');
+            applicationCreateMutation.isLoading || applicationUpdateMutation.isLoading;
+          const saveAndQuitLoadingText = t('common:buttons:savingText');
           return (
             <FormActions
               activeStepIndex={activeStepIndex}
               totalSteps={formSteps.length}
               onPrevious={handlePrevious}
               onNext={handleNext}
-              previousButtonIsLoading={attachmentsUploading}
-              previousButtonLoadingText={attachmentsUploadingText}
-              nextButtonIsLoading={attachmentsUploading}
-              nextButtonLoadingText={attachmentsUploadingText}
             >
               <ApplicationCancel
                 applicationId={getValues('id')}

--- a/src/domain/johtoselvitysTaydennys/Attachments.tsx
+++ b/src/domain/johtoselvitysTaydennys/Attachments.tsx
@@ -24,21 +24,18 @@ type Props = {
   applicationId: number;
   taydennysAttachments: TaydennysAttachmentMetadata[];
   originalAttachments?: ApplicationAttachmentMetadata[];
-  onFileUpload: (isUploading: boolean) => void;
 };
 
 export default function Attachments({
   applicationId,
   taydennysAttachments,
   originalAttachments,
-  onFileUpload,
 }: Readonly<Props>) {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
   const { getValues } = useFormContext<JohtoselvitysTaydennysFormValues>();
 
   function handleFileUpload(uploading: boolean) {
-    onFileUpload(uploading);
     if (!uploading) {
       queryClient.invalidateQueries(['application', applicationId]);
     }

--- a/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennysContainer.tsx
+++ b/src/domain/johtoselvitysTaydennys/JohtoselvitysTaydennysContainer.tsx
@@ -70,8 +70,6 @@ export default function JohtoselvitysTaydennysContainer({
   const sendTaydennysMutation = useSendTaydennys();
   const [showSendDialog, setShowSendDialog] = useState(false);
   const { data: signedInUser } = usePermissionsForHanke(hankeData.hankeTunnus);
-  const [attachmentsUploading, setAttachmentsUploading] = useState(false);
-  const attachmentsUploadingText: string = t('common:components:fileUpload:loadingText');
   const { data: originalAttachments } = useAttachments(originalApplication.id);
 
   const formContext = useForm<JohtoselvitysTaydennysFormValues>({
@@ -95,10 +93,6 @@ export default function JohtoselvitysTaydennysContainer({
     JohtoselvitysData,
     JohtoselvitysUpdateData
   >(originalApplication.id, updateTaydennys);
-
-  function handleAttachmentUpload(isUploading: boolean) {
-    setAttachmentsUploading(isUploading);
-  }
 
   // Fields that are validated in each page when moving in the form
   const pageFieldsToValidate: FieldPath<JohtoselvitysTaydennysFormValues>[][] = [
@@ -141,7 +135,6 @@ export default function JohtoselvitysTaydennysContainer({
           applicationId={originalApplication.id!}
           taydennysAttachments={taydennys.liitteet}
           originalAttachments={originalAttachments}
-          onFileUpload={handleAttachmentUpload}
         />
       ),
       label: t('hankePortfolio:tabit:liitteet'),
@@ -312,8 +305,6 @@ export default function JohtoselvitysTaydennysContainer({
             <Box mt="var(--spacing-s)">{formErrorsNotification}</Box>
           </>
         }
-        isLoading={attachmentsUploading}
-        isLoadingText={attachmentsUploadingText}
         onStepChange={handleStepChange}
         stepChangeValidator={validateStepChange}
         onSubmit={handleSubmit(openSendDialog)}
@@ -337,10 +328,8 @@ export default function JohtoselvitysTaydennysContainer({
           const isContact = isContactIn(signedInUser, getValues('applicationData'));
           const disableSendButton = showSendButton && !isContact;
 
-          const saveAndQuitIsLoading = hakemusUpdateMutation.isLoading || attachmentsUploading;
-          const saveAndQuitLoadingText = attachmentsUploading
-            ? attachmentsUploadingText
-            : t('common:buttons:savingText');
+          const saveAndQuitIsLoading = hakemusUpdateMutation.isLoading;
+          const saveAndQuitLoadingText = t('common:buttons:savingText');
           return (
             <FormActions
               activeStepIndex={activeStep}

--- a/src/domain/kaivuilmoitus/Attachments.tsx
+++ b/src/domain/kaivuilmoitus/Attachments.tsx
@@ -14,17 +14,15 @@ import TextArea from '../../common/components/textArea/TextArea';
 type Props = {
   existingAttachments: ApplicationAttachmentMetadata[] | undefined;
   attachmentsLoadError: boolean;
-  onFileUpload: (isUploading: boolean) => void;
 };
 
-function Attachments({ existingAttachments, attachmentsLoadError, onFileUpload }: Readonly<Props>) {
+function Attachments({ existingAttachments, attachmentsLoadError }: Readonly<Props>) {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
   const { getValues } = useFormContext<KaivuilmoitusFormValues>();
   const alluStatus = getValues('alluStatus');
 
   function handleFileUpload(uploading: boolean) {
-    onFileUpload(uploading);
     if (!uploading) {
       queryClient.invalidateQueries('attachments');
     }

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -115,8 +115,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
     getValues('id'),
   );
 
-  const [attachmentsUploading, setAttachmentsUploading] = useState(false);
-
   const [isSendButtonDisabled, setIsSendButtonDisabled] = useState(false);
   const [showSendDialog, setShowSendDialog] = useState(false);
 
@@ -252,10 +250,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
     saveApplication(handleSuccess);
   }
 
-  function handleAttachmentUpload(isUploading: boolean) {
-    setAttachmentsUploading(isUploading);
-  }
-
   function closeAttachmentUploadErrorDialog() {
     setAttachmentUploadErrors([]);
   }
@@ -316,7 +310,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
         <Attachments
           existingAttachments={existingAttachments}
           attachmentsLoadError={attachmentsLoadError}
-          onFileUpload={handleAttachmentUpload}
         />
       ),
       label: t('form:headers:liitteetJaLisatiedot'),
@@ -339,8 +332,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
       saveApplication();
     }
   }
-
-  const attachmentsUploadingText: string = t('common:components:fileUpload:loadingText');
 
   function validateStepChange(changeStep: () => void, stepIndex: number) {
     return changeFormStep(changeStep, pageFieldsToValidate[stepIndex] || [], trigger, errors, [
@@ -365,8 +356,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
         }
         validationContext={{ application: watchFormValues }}
         onStepChange={handleStepChange}
-        isLoading={attachmentsUploading}
-        isLoadingText={attachmentsUploadingText}
         stepChangeValidator={validateStepChange}
         onSubmit={handleSubmit(openSendDialog)}
       >
@@ -382,12 +371,8 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
           }
 
           const saveAndQuitIsLoading =
-            applicationCreateMutation.isLoading ||
-            applicationUpdateMutation.isLoading ||
-            attachmentsUploading;
-          const saveAndQuitLoadingText = attachmentsUploading
-            ? attachmentsUploadingText
-            : t('common:buttons:savingText');
+            applicationCreateMutation.isLoading || applicationUpdateMutation.isLoading;
+          const saveAndQuitLoadingText = t('common:buttons:savingText');
 
           const isDraft = isApplicationDraft(getValues('alluStatus') as AlluStatus | null);
           const isContact = isContactIn(signedInUser, getValues('applicationData'));
@@ -400,10 +385,6 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
               totalSteps={formSteps.length}
               onPrevious={handlePrevious}
               onNext={handleNext}
-              previousButtonIsLoading={attachmentsUploading}
-              previousButtonLoadingText={attachmentsUploadingText}
-              nextButtonIsLoading={attachmentsUploading}
-              nextButtonLoadingText={attachmentsUploadingText}
             >
               <ApplicationCancel
                 applicationId={getValues('id')}

--- a/src/domain/kaivuilmoitusTaydennys/Attachments.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/Attachments.tsx
@@ -26,14 +26,12 @@ type Props = {
   applicationId: number;
   taydennysAttachments: TaydennysAttachmentMetadata[];
   originalAttachments?: ApplicationAttachmentMetadata[];
-  onFileUpload: (isUploading: boolean) => void;
 };
 
 export default function Attachments({
   applicationId,
   taydennysAttachments,
   originalAttachments,
-  onFileUpload,
 }: Readonly<Props>) {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
@@ -53,7 +51,6 @@ export default function Attachments({
   }
 
   function handleFileUpload(uploading: boolean) {
-    onFileUpload(uploading);
     if (!uploading) {
       queryClient.invalidateQueries(['application', applicationId]);
     }

--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennysContainer.tsx
@@ -72,8 +72,6 @@ export default function KaivuilmoitusTaydennysContainer({
   const [showSendDialog, setShowSendDialog] = useState(false);
   const { data: signedInUser } = usePermissionsForHanke(hankeData.hankeTunnus);
   const { data: originalAttachments } = useAttachments(originalApplication.id);
-  const [attachmentsUploading, setAttachmentsUploading] = useState(false);
-  const attachmentsUploadingText: string = t('common:components:fileUpload:loadingText');
 
   const formContext = useForm<KaivuilmoitusTaydennysFormValues>({
     mode: 'onTouched',
@@ -118,10 +116,6 @@ export default function KaivuilmoitusTaydennysContainer({
       }
     },
   );
-
-  function handleAttachmentUpload(isUploading: boolean) {
-    setAttachmentsUploading(isUploading);
-  }
 
   // Fields that are validated in each page when moving in the form
   // If validation of a field fails, the form will not move to the next page
@@ -188,7 +182,6 @@ export default function KaivuilmoitusTaydennysContainer({
           applicationId={originalApplication.id!}
           taydennysAttachments={taydennys.liitteet}
           originalAttachments={originalAttachments}
-          onFileUpload={handleAttachmentUpload}
         />
       ),
       label: t('hankePortfolio:tabit:liitteet'),
@@ -293,8 +286,6 @@ export default function KaivuilmoitusTaydennysContainer({
             </Box>
           </>
         }
-        isLoading={attachmentsUploading}
-        isLoadingText={attachmentsUploadingText}
         onStepChange={handleStepChange}
         stepChangeValidator={validateStepChange}
         onSubmit={handleSubmit(openSendDialog)}
@@ -317,10 +308,8 @@ export default function KaivuilmoitusTaydennysContainer({
           const isContact = isContactIn(signedInUser, getValues('applicationData'));
           const disableSendButton = showSendButton && !isContact;
 
-          const saveAndQuitIsLoading = hakemusUpdateMutation.isLoading || attachmentsUploading;
-          const saveAndQuitLoadingText = attachmentsUploading
-            ? attachmentsUploadingText
-            : t('common:buttons:savingText');
+          const saveAndQuitIsLoading = hakemusUpdateMutation.isLoading;
+          const saveAndQuitLoadingText = t('common:buttons:savingText');
 
           return (
             <FormActions
@@ -328,10 +317,6 @@ export default function KaivuilmoitusTaydennysContainer({
               totalSteps={formSteps.length}
               onPrevious={handlePrevious}
               onNext={handleNext}
-              previousButtonIsLoading={attachmentsUploading}
-              previousButtonLoadingText={attachmentsUploadingText}
-              nextButtonIsLoading={attachmentsUploading}
-              nextButtonLoadingText={attachmentsUploadingText}
             >
               <TaydennysCancel
                 application={originalApplication}


### PR DESCRIPTION
# Description

Moved file upload loading element inside modal to block other interactions in the site while files are being uploaded. Only upload cancel button is usable.

Removed file upload loading states from buttons in hanke, johtoselvitys, johtoselvitys täydennys, kaivuilmoitus and kaivuilmoitus täydennys forms.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3452

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Try to upload attachments in hanke, johtoselvitys and kaivuilmoitus forms
2. When uploading is ongoing check that only cancel button is usable in the whole page

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
