### PR TITLE
HAI-3407 Add cancel functionality for muutosilmoitus

### DIFF
--- a/src/common/components/HDSConfirmationDialog/ConfirmDialog.test.tsx
+++ b/src/common/components/HDSConfirmationDialog/ConfirmDialog.test.tsx
@@ -32,4 +32,28 @@ describe('confirmationDialog', () => {
     renderedDialog.getByTestId('dialog-cancel-test').click();
     expect(handleMainAction).toHaveBeenCalledTimes(1);
   });
+
+  it('renders error message', () => {
+    const titleText = 'title text';
+    const descriptionText = 'description text';
+    const buttonText = 'button text';
+    const open = true;
+    const variant = 'primary';
+    const errorMessage = 'error occurred';
+
+    const renderedDialog = render(
+      <ConfirmationDialog
+        title={titleText}
+        description={descriptionText}
+        isOpen={open}
+        close={() => {}}
+        mainAction={() => {}}
+        mainBtnLabel={buttonText}
+        variant={variant}
+        errorMsg={errorMessage}
+      />,
+    );
+
+    expect(renderedDialog.getAllByText(errorMessage)).toHaveLength(2);
+  });
 });

--- a/src/common/components/HDSConfirmationDialog/ConfirmationDialog.module.scss
+++ b/src/common/components/HDSConfirmationDialog/ConfirmationDialog.module.scss
@@ -1,4 +1,0 @@
-.errorMsg {
-  display: flex;
-  color: #c4123e;
-}

--- a/src/common/components/HDSConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/common/components/HDSConfirmationDialog/ConfirmationDialog.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Dialog, Button, DialogVariant } from 'hds-react';
-import { IconAlertCircleFill, IconErrorFill } from 'hds-react/icons';
+import { Dialog, Button, DialogVariant, LoadingSpinner, Notification } from 'hds-react';
+import { IconAlertCircleFill } from 'hds-react/icons';
 import { useTranslation } from 'react-i18next';
-
-import styles from './ConfirmationDialog.module.scss';
+import { Box } from '@chakra-ui/react';
 
 type Props = {
   title: string;
@@ -47,17 +46,17 @@ const ConfirmationDialog: React.FC<React.PropsWithChildren<Props>> = ({
 }) => {
   const { t } = useTranslation();
 
+  const iconLeft = isLoading ? <LoadingSpinner small /> : mainBtnIcon;
+
   const mainButton = (
     <Button
       onClick={mainAction}
       data-testid="dialog-button-test"
       variant={variant}
-      iconLeft={mainBtnIcon}
-      isLoading={isLoading}
-      loadingText={loadingText}
+      iconLeft={iconLeft}
       disabled={disabled}
     >
-      {mainBtnLabel ?? t('common:confirmationDialog:confirmButton')}
+      {isLoading ? loadingText : mainBtnLabel ?? t('common:confirmationDialog:confirmButton')}
     </Button>
   );
 
@@ -93,10 +92,11 @@ const ConfirmationDialog: React.FC<React.PropsWithChildren<Props>> = ({
           <div data-testid="dialog-description-test">{description}</div>
         )}
         {errorMsg && (
-          <div className={styles.errorMsg}>
-            <IconErrorFill />
-            <p>{errorMsg}</p>
-          </div>
+          <Box paddingTop="var(--spacing-s)">
+            <Notification type="error" size="small" label={errorMsg}>
+              {errorMsg}
+            </Notification>
+          </Box>
         )}
       </Dialog.Content>
       <Dialog.ActionButtons>

--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -2132,5 +2132,35 @@ describe('Excavation notification application view', () => {
       expect(screen.getByText('newMail@test.com')).toBeInTheDocument();
       expect(screen.getByText('Uusi Laskutus Oy')).toBeInTheDocument();
     });
+
+    test('Should be able to cancel muutosilmoitus', async () => {
+      const application = cloneDeep(hakemukset[13]) as Application<KaivuilmoitusData>;
+      const { user } = await setup(application);
+      await user.click(screen.getByRole('button', { name: 'Peru muutosilmoitus' }));
+      await user.click(await screen.findByRole('button', { name: /vahvista/i }));
+
+      expect(await screen.findByText('Muutosilmoitus peruttiin')).toBeInTheDocument();
+      expect(screen.getByText('Muutosilmoitus peruttiin onnistuneesti')).toBeInTheDocument();
+    });
+
+    test('Cancel muutosilmoitus button is not visible if muutosilmoitus field is null', async () => {
+      const application = cloneDeep(hakemukset[13]) as Application<KaivuilmoitusData>;
+      application.muutosilmoitus = null;
+      await setup(application);
+
+      expect(screen.queryByRole('button', { name: 'Peru muutosilmoitus' })).not.toBeInTheDocument();
+    });
+
+    test('Cancel muutosilmoitus button is not visible if user does not have permission', async () => {
+      server.use(
+        http.get('/api/hankkeet/:hankeTunnus/whoami', async () => {
+          return HttpResponse.json<SignedInUser>(USER_VIEW);
+        }),
+      );
+      const application = cloneDeep(hakemukset[13]) as Application<KaivuilmoitusData>;
+      await setup(application);
+
+      expect(screen.queryByRole('button', { name: 'Peru muutosilmoitus' })).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -93,6 +93,7 @@ import TaydennysCancel from '../taydennys/components/TaydennysCancel';
 import TaydennysAttachmentsList from '../taydennys/components/TaydennysAttachmentsList';
 import { HaittojenhallintasuunnitelmaInfo } from '../../kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo';
 import MuutosilmoitusNotification from '../muutosilmoitus/components/MuutosilmoitusNotification';
+import MuutosilmoitusCancel from '../muutosilmoitus/components/MuutosilmoitusCancel';
 
 function TyoalueetList({ tyoalueet }: { tyoalueet: ApplicationArea[] }) {
   const { t } = useTranslation();
@@ -927,16 +928,19 @@ function ApplicationView({
           )}
           {showMuutosilmoitusButton && (
             <CheckRightsByHanke requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>
-              <Button
-                theme="coat"
-                iconLeft={<IconPen />}
-                onClick={onEditMuutosilmoitus}
-                isLoading={creatingMuutosilmoitus}
-              >
-                {!muutosilmoitus
-                  ? t('muutosilmoitus:buttons:createMuutosilmoitus')
-                  : t('muutosilmoitus:buttons:editMuutosilmoitus')}
-              </Button>
+              <>
+                <Button
+                  theme="coat"
+                  iconLeft={<IconPen />}
+                  onClick={onEditMuutosilmoitus}
+                  isLoading={creatingMuutosilmoitus}
+                >
+                  {!muutosilmoitus
+                    ? t('muutosilmoitus:buttons:createMuutosilmoitus')
+                    : t('muutosilmoitus:buttons:editMuutosilmoitus')}
+                </Button>
+                <MuutosilmoitusCancel application={application} />
+              </>
             </CheckRightsByHanke>
           )}
           {showReportOperationalConditionButton && (

--- a/src/domain/application/applicationView/Sidebar.tsx
+++ b/src/domain/application/applicationView/Sidebar.tsx
@@ -21,6 +21,7 @@ import { HankeAlue, HankeData } from '../../types/hanke';
 import CustomAccordion from '../../../common/components/customAccordion/CustomAccordion';
 import { Taydennys } from '../taydennys/types';
 import { Muutosilmoitus } from '../muutosilmoitus/types';
+import React from 'react';
 
 function getTyoalueet(
   applicationType: ApplicationType,
@@ -108,7 +109,7 @@ type AreaTabsProps = {
   hanke: HankeData;
   applicationType: ApplicationType;
   taydennys?: Taydennys<JohtoselvitysData | KaivuilmoitusData> | null;
-  muutosilmoitus?: Muutosilmoitus<JohtoselvitysData | KaivuilmoitusData>;
+  muutosilmoitus?: Muutosilmoitus<JohtoselvitysData | KaivuilmoitusData> | null;
   originalHakemusContent: React.ReactNode;
 };
 

--- a/src/domain/application/muutosilmoitus/components/MuutosilmoitusCancel.tsx
+++ b/src/domain/application/muutosilmoitus/components/MuutosilmoitusCancel.tsx
@@ -7,7 +7,7 @@ import useNavigateToApplicationView from '../../hooks/useNavigateToApplicationVi
 import { useGlobalNotification } from '../../../../common/components/globalNotification/GlobalNotificationContext';
 import useDebouncedMutation from '../../../../common/hooks/useDebouncedMutation';
 import ConfirmationDialog from '../../../../common/components/HDSConfirmationDialog/ConfirmationDialog';
-import { cancelTaydennys } from '../taydennysApi';
+import { cancelMuutosilmoitus } from '../muutosilmoitusApi';
 
 type Props = {
   application: Application;
@@ -17,7 +17,7 @@ type Props = {
   buttonIsLoadingText?: string;
 };
 
-export default function TaydennysCancel({
+export default function MuutosilmoitusCancel({
   application,
   navigateToApplicationViewOnSuccess,
   buttonVariant,
@@ -33,9 +33,9 @@ export default function TaydennysCancel({
   const [errorMessage, setErrorMessage] = useState('');
   const [isButtonDisabled, setIsButtonDisabled] = useState(false);
 
-  const isCancelPossible = Boolean(application.taydennys);
+  const isCancelPossible = Boolean(application.muutosilmoitus);
 
-  const taydennysCancelMutation = useDebouncedMutation(cancelTaydennys, {
+  const muutosilmoitusCancelMutation = useDebouncedMutation(cancelMuutosilmoitus, {
     onError() {
       setErrorMessage(t('common:error'));
       setIsButtonDisabled(false);
@@ -43,8 +43,8 @@ export default function TaydennysCancel({
     onSuccess() {
       const closeButtonLabelText = t('common:components:notification:closeButtonLabelText');
       setNotification(true, {
-        label: t('taydennys:notifications:cancelSuccessLabel'),
-        message: t('taydennys:notifications:cancelSuccessText'),
+        label: t('muutosilmoitus:notification:cancelSuccessLabel'),
+        message: t('muutosilmoitus:notification:cancelSuccessText'),
         type: 'success',
         dismissible: true,
         closeButtonLabelText,
@@ -63,8 +63,8 @@ export default function TaydennysCancel({
 
   function doApplicationCancel() {
     setIsButtonDisabled(true);
-    if (application.taydennys?.id) {
-      taydennysCancelMutation.mutate(application.taydennys.id);
+    if (application.muutosilmoitus?.id) {
+      muutosilmoitusCancelMutation.mutate(application.muutosilmoitus.id);
     }
   }
 
@@ -82,7 +82,7 @@ export default function TaydennysCancel({
   }
 
   const buttonIconStart =
-    taydennysCancelMutation.isLoading || isButtonDisabled ? (
+    muutosilmoitusCancelMutation.isLoading || isButtonDisabled ? (
       <LoadingSpinner small />
     ) : (
       <IconCross />
@@ -91,8 +91,8 @@ export default function TaydennysCancel({
   return (
     <>
       <ConfirmationDialog
-        title={t('taydennys:labels:cancelTitle')}
-        description={t('taydennys:labels:cancelDescription')}
+        title={t('muutosilmoitus:labels:cancelTitle')}
+        description={t('muutosilmoitus:labels:cancelDescription')}
         isOpen={isConfirmationDialogOpen}
         close={closeConfirmationDialog}
         mainAction={doApplicationCancel}
@@ -100,9 +100,9 @@ export default function TaydennysCancel({
         mainBtnIcon={<IconTrash />}
         variant="danger"
         errorMsg={errorMessage}
-        isLoading={taydennysCancelMutation.isLoading || isButtonDisabled}
+        isLoading={muutosilmoitusCancelMutation.isLoading || isButtonDisabled}
         loadingText={t('common:buttons:sendingText')}
-        disabled={taydennysCancelMutation.isLoading || isButtonDisabled}
+        disabled={muutosilmoitusCancelMutation.isLoading || isButtonDisabled}
       />
 
       <Button
@@ -114,7 +114,7 @@ export default function TaydennysCancel({
       >
         {buttonIsLoading || isButtonDisabled
           ? buttonIsLoadingText
-          : t('taydennys:buttons:cancelTaydennys')}
+          : t('muutosilmoitus:buttons:cancelMuutosilmoitus')}
       </Button>
     </>
   );

--- a/src/domain/application/muutosilmoitus/muutosilmoitusApi.ts
+++ b/src/domain/application/muutosilmoitus/muutosilmoitusApi.ts
@@ -15,6 +15,7 @@ export async function createMuutosilmoitus<ApplicationData>(id: number) {
 /**
  * Update muutosilmoitus
  * @param id muutosilmoitus id
+ * @param data updated data
  */
 export async function updateMuutosilmoitus<ApplicationData, UpdateData>({
   id,
@@ -25,4 +26,11 @@ export async function updateMuutosilmoitus<ApplicationData, UpdateData>({
 }) {
   const response = await api.put<Muutosilmoitus<ApplicationData>>(`/muutosilmoitukset/${id}`, data);
   return response.data;
+}
+
+/**
+ * Delete muutosilmoitus
+ */
+export async function cancelMuutosilmoitus(id: string) {
+  await api.delete(`/muutosilmoitukset/${id}`);
 }

--- a/src/domain/application/types/application.ts
+++ b/src/domain/application/types/application.ts
@@ -270,7 +270,7 @@ export interface Application<T = JohtoselvitysData | KaivuilmoitusData> {
   valmistumisilmoitukset?: Valmistumisilmoitukset | null;
   taydennyspyynto?: Taydennyspyynto | null;
   taydennys?: Taydennys<T> | null;
-  muutosilmoitus?: Muutosilmoitus<T>;
+  muutosilmoitus?: Muutosilmoitus<T> | null;
 }
 
 export interface HankkeenHakemus {
@@ -286,7 +286,7 @@ export interface HankkeenHakemus {
     areas: ApplicationArea[] | KaivuilmoitusAlue[] | null;
   };
   paatokset?: { [key: string]: Paatos[] };
-  muutosilmoitus?: Muutosilmoitus<JohtoselvitysData | KaivuilmoitusData>;
+  muutosilmoitus?: Muutosilmoitus<JohtoselvitysData | KaivuilmoitusData> | null;
 }
 
 export interface ApplicationDeletionResult {

--- a/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
+++ b/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
@@ -111,3 +111,19 @@ describe('Saving the form', () => {
     );
   });
 });
+
+describe('Canceling muutosilmoitus', () => {
+  test('Should be able to cancel muutosilmoitus', async () => {
+    const application = cloneDeep(hakemukset[13]) as Application<KaivuilmoitusData>;
+    const { user } = setup({
+      application,
+      muutosilmoitus: application.muutosilmoitus!,
+    });
+    await user.click(screen.getByRole('button', { name: /peru muutosilmoitus/i }));
+    await user.click(await screen.findByRole('button', { name: /vahvista/i }));
+
+    expect(await screen.findByText('Muutosilmoitus peruttiin')).toBeInTheDocument();
+    expect(screen.getByText('Muutosilmoitus peruttiin onnistuneesti')).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/fi/hakemus/14');
+  });
+});

--- a/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitusContainer.tsx
@@ -37,6 +37,7 @@ import useAttachments from '../application/hooks/useAttachments';
 import { useGlobalNotification } from '../../common/components/globalNotification/GlobalNotificationContext';
 import useNavigateToApplicationView from '../application/hooks/useNavigateToApplicationView';
 import FormErrorsNotification from '../kaivuilmoitus/components/FormErrorsNotification';
+import MuutosilmoitusCancel from '../application/muutosilmoitus/components/MuutosilmoitusCancel';
 
 type Props = {
   muutosilmoitus: Muutosilmoitus<KaivuilmoitusData>;
@@ -254,6 +255,13 @@ export default function KaivuilmoitusMuutosilmoitusContainer({
               onPrevious={handlePrevious}
               onNext={handleNext}
             >
+              <MuutosilmoitusCancel
+                application={originalApplication}
+                navigateToApplicationViewOnSuccess
+                buttonVariant="danger"
+                buttonIsLoading={saveAndQuitIsLoading}
+                buttonIsLoadingText={saveAndQuitLoadingText}
+              />
               <Button
                 variant="secondary"
                 onClick={handleSaveAndQuit}

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -223,3 +223,12 @@ export async function updateMuutosilmoitus(
   muutosilmoitus.applicationData = Object.assign(muutosilmoitus.applicationData, updates);
   return muutosilmoitus;
 }
+
+export async function cancelMuutosilmoitus(id: string) {
+  const hakemus = await readMuutosilmoitus(id);
+  const muutosilmoitus = hakemus?.muutosilmoitus;
+  if (!muutosilmoitus) {
+    throw new ApiError(`No muutosilmoitus with id ${id}`, 404);
+  }
+  hakemus.muutosilmoitus = null;
+}

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -419,4 +419,10 @@ export const handlers = [
       }
     },
   ),
+
+  http.delete(`${apiUrl}/muutosilmoitukset/:id`, async ({ params }) => {
+    const { id } = params;
+    await hakemuksetDB.cancelMuutosilmoitus(id as string);
+    return new HttpResponse();
+  }),
 ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1564,16 +1564,21 @@
       "muutosilmoitus": "Muutosilmoitus",
       "originalInformation": "$t(taydennys:labels:originalInformation)",
       "muutokset": "Muutokset",
-      "muutos": "Muutos"
+      "muutos": "Muutos",
+      "cancelTitle": "Peru muutosilmoitus?",
+      "cancelDescription": "Haluatko varmasti perua hakemukseen tehdyt muutokset ja palauttaa aiemman päätöksen tiedot?"
     },
     "buttons": {
       "createMuutosilmoitus": "Tee muutosilmoitus",
-      "editMuutosilmoitus": "Jatka muutosilmoitusta"
+      "editMuutosilmoitus": "Jatka muutosilmoitusta",
+      "cancelMuutosilmoitus": "Peru muutosilmoitus"
     },
     "notification": {
       "label": "Muutosilmoitus",
       "createdText": "Hakemuksella on keskeneräinen muutosilmoitus.",
-      "sentText": "Hakemukselle on tehty muutosilmoitus, joka on lähetetty käsittelyyn {{date}}"
+      "sentText": "Hakemukselle on tehty muutosilmoitus, joka on lähetetty käsittelyyn {{date}}",
+      "cancelSuccessLabel": "Muutosilmoitus peruttiin",
+      "cancelSuccessText": "Muutosilmoitus peruttiin onnistuneesti"
     }
   },
   "hankeSidebar": {


### PR DESCRIPTION
# Description

Add cancel functionality for muutosilmoitus.
Also, change some (just a few) Button components to not use deprecated parameters `isLoading` and `loadingText` in order to make it a bit easier to move into newer HDS version.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3407

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Have a kaivuilmoitus with decision
2. Create a muutosilmoitus for it
3. Cancel the muutosilmoitus from application view or the form
4. Muutosilmoitus should be cancelled

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
