### PR TITLE
HAI-367 Add validation error notification to kaivuilmoitus muutosilmoitus form

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -828,9 +828,9 @@ function ApplicationView({
           {muutosilmoitus && <MuutosilmoitusNotification sent={muutosilmoitus.sent} />}
           <Box mt="var(--spacing-s)">
             <FormPagesErrorSummary
-              data={taydennys ?? application}
+              data={taydennys ?? muutosilmoitus ?? application}
               schema={validationSchema}
-              validationContext={{ application: taydennys ?? application }}
+              validationContext={{ application: taydennys ?? muutosilmoitus ?? application }}
               notificationLabel={t('hakemus:missingFields:notification:hakemusLabel')}
             />
           </Box>

--- a/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitusContainer.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FieldPath, FormProvider, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -35,6 +36,7 @@ import ReviewAndSend from './ReviewAndSend';
 import useAttachments from '../application/hooks/useAttachments';
 import { useGlobalNotification } from '../../common/components/globalNotification/GlobalNotificationContext';
 import useNavigateToApplicationView from '../application/hooks/useNavigateToApplicationView';
+import FormErrorsNotification from '../kaivuilmoitus/components/FormErrorsNotification';
 
 type Props = {
   muutosilmoitus: Muutosilmoitus<KaivuilmoitusData>;
@@ -169,6 +171,9 @@ export default function KaivuilmoitusMuutosilmoitusContainer({
     },
   ];
 
+  const [activeStepIndex, setActiveStepIndex] = useState(0);
+  const lastStep = activeStepIndex === formSteps.length - 1;
+
   function saveMuutosilmoitus(handleSuccess?: () => void) {
     const formData = getValues();
     hakemusUpdateMutation.mutate(
@@ -179,7 +184,8 @@ export default function KaivuilmoitusMuutosilmoitusContainer({
     );
   }
 
-  function handleStepChange() {
+  function handleStepChange(stepIndex: number) {
+    setActiveStepIndex(stepIndex);
     // Save application when page is changed
     // only if something has changed
     if (isDirty) {
@@ -218,6 +224,14 @@ export default function KaivuilmoitusMuutosilmoitusContainer({
         validationContext={{ application: watchFormValues }}
         onStepChange={handleStepChange}
         stepChangeValidator={validateStepChange}
+        topElement={
+          <FormErrorsNotification
+            data={watchFormValues}
+            validationContext={{ application: watchFormValues }}
+            activeStepIndex={activeStepIndex}
+            lastStep={lastStep}
+          />
+        }
       >
         {function renderFormActions(activeStep, handlePrevious, handleNext) {
           async function handleSaveAndQuit() {


### PR DESCRIPTION
# Description

Display form validation errors in kaivuilmoitus muutosilmoitus form in similar way as in other forms. Also add muutosilmoitus data to FormPagesErrorSummary in application view to show pages with errors there as well.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-367

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

Check that validation errors are shown in kaivuilmoitus muutosilmoitus form in similar way than in other kaivuilmoitus forms.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
