### PR TITLE
HAI-3409 Implementation for sending muutosilmoitus

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.test.tsx
+++ b/src/domain/application/applicationView/ApplicationView.test.tsx
@@ -1,4 +1,4 @@
-import { http, HttpResponse, delay } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
 import { render, screen, within } from '../../../testUtils/render';
 import ApplicationViewContainer from './ApplicationViewContainer';
 import { waitForLoadingToFinish } from '../../../testUtils/helperFunctions';
@@ -9,12 +9,18 @@ import hakemukset from '../../mocks/data/hakemukset-data';
 import { cloneDeep } from 'lodash';
 import { format } from 'date-fns/format';
 import { fi } from 'date-fns/locale';
-import { Application, JohtoselvitysData, KaivuilmoitusData } from '../types/application';
+import {
+  Application,
+  JohtoselvitysData,
+  KaivuilmoitusData,
+  PaperDecisionReceiver,
+} from '../types/application';
 import * as taydennysApi from '../taydennys/taydennysApi';
 import { USER_VIEW } from '../../mocks/signedInUser';
 import { createTaydennysAttachments } from '../../mocks/attachments';
 import * as muutosilmoitusApi from '../muutosilmoitus/muutosilmoitusApi';
 import { HAITTA_INDEX_TYPE } from '../../common/haittaIndexes/types';
+import { PathParams } from 'msw/lib/core/utils/matching/matchRequestUrl';
 
 describe('Cable report application view', () => {
   test('Correct information about application should be displayed', async () => {
@@ -2131,6 +2137,265 @@ describe('Excavation notification application view', () => {
       expect(screen.getByText('New name')).toBeInTheDocument();
       expect(screen.getByText('newMail@test.com')).toBeInTheDocument();
       expect(screen.getByText('Uusi Laskutus Oy')).toBeInTheDocument();
+    });
+
+    test('Should be able to send muutosilmoitus without paper decision order', async () => {
+      const application = cloneDeep(hakemukset[7]) as Application<KaivuilmoitusData>;
+      application.muutosilmoitus = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: application.applicationData,
+        sent: null,
+        muutokset: ['workDescription'],
+      };
+      const { user } = await setup(application);
+      server.use(
+        http.get(`/api/hakemukset/:id`, async () => {
+          return HttpResponse.json({
+            ...application,
+            muutosilmoitus: {
+              ...application.muutosilmoitus,
+              sent: new Date(),
+            },
+          });
+        }),
+        http.post(`/api/muutosilmoitukset/:id/laheta`, async () => {
+          return HttpResponse.json({
+            ...application,
+            muutosilmoitus: null,
+          });
+        }),
+      );
+
+      const sendButton = await screen.findByRole('button', { name: 'Lähetä muutosilmoitus' });
+      expect(sendButton).toBeEnabled();
+      await user.click(sendButton);
+
+      expect(await screen.findByText('Lähetä muutosilmoitus?')).toBeInTheDocument();
+      const confirmButton = screen.getByRole('button', { name: 'Vahvista' });
+      expect(confirmButton).toBeEnabled();
+      await user.click(confirmButton);
+
+      expect(await screen.findByText('Muutosilmoitus lähetetty')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Lähetä muutosilmoitus' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('Should be able to send application with paper decision order', async () => {
+      const application = cloneDeep(hakemukset[7]) as Application<KaivuilmoitusData>;
+      application.muutosilmoitus = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: application.applicationData,
+        sent: null,
+        muutokset: ['workDescription'],
+      };
+      application.applicationData.paperDecisionReceiver = null;
+      let pdr: PaperDecisionReceiver | null = null;
+      const { user } = await setup(application);
+
+      server.use(
+        http.get(`/api/hakemukset/:id`, async () => {
+          return HttpResponse.json({
+            ...application,
+            muutosilmoitus: {
+              ...application.muutosilmoitus,
+              sent: new Date(),
+            },
+          });
+        }),
+        http.post<PathParams, { paperDecisionReceiver: PaperDecisionReceiver }>(
+          `/api/muutosilmoitukset/:id/laheta`,
+          async ({ request }) => {
+            const { paperDecisionReceiver } = await request.json();
+            pdr = paperDecisionReceiver;
+            return HttpResponse.json({
+              ...application,
+              muutosilmoitus: null,
+            });
+          },
+        ),
+      );
+
+      const sendButton = await screen.findByRole('button', { name: 'Lähetä muutosilmoitus' });
+      expect(sendButton).toBeEnabled();
+      await user.click(sendButton);
+
+      expect(await screen.findByText('Lähetä muutosilmoitus?')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Tilaan päätöksen myös paperisena' }));
+
+      const confirmButton = screen.getByRole('button', { name: 'Vahvista' });
+      expect(confirmButton).toBeDisabled();
+
+      expect(await screen.findByText('Täytä vastaanottajan tiedot')).toBeInTheDocument();
+      const nameInput = screen.getByText('Nimi');
+      await user.type(nameInput, 'Pekka Paperinen');
+      const streetAddressInput = screen.getByText('Katuosoite');
+      await user.type(streetAddressInput, 'Paperipolku 3 A 4');
+      const postalCodeInput = screen.getByText('Postinumero');
+      await user.type(postalCodeInput, '00451');
+      const cityInput = screen.getByText('Postitoimipaikka');
+      await user.type(cityInput, 'Helsinki');
+
+      expect(confirmButton).toBeEnabled();
+      await user.click(confirmButton);
+
+      expect(await screen.findByText('Muutosilmoitus lähetetty')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Lähetä hakemus' })).not.toBeInTheDocument();
+      expect(pdr).toEqual({
+        name: 'Pekka Paperinen',
+        streetAddress: 'Paperipolku 3 A 4',
+        postalCode: '00451',
+        city: 'Helsinki',
+      });
+    });
+
+    test('Should not be able to send muutosilmoitus if it has moved to handling in Allu', async () => {
+      const application = cloneDeep(hakemukset[7]) as Application<KaivuilmoitusData>;
+      application.muutosilmoitus = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: application.applicationData,
+        sent: new Date(),
+        muutokset: ['workDescription'],
+      };
+      await setup(application);
+
+      expect(
+        screen.queryByRole('button', { name: 'Lähetä muutosilmoitus' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('Should disable Send button if user is not a contact person on application', async () => {
+      server.resetHandlers();
+      server.use(
+        http.get('/api/hankkeet/:hankeTunnus/whoami', async () => {
+          return HttpResponse.json<SignedInUser>({
+            hankeKayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afb4',
+            kayttooikeustaso: 'HAKEMUSASIOINTI',
+            kayttooikeudet: ['EDIT_APPLICATIONS'],
+          });
+        }),
+      );
+      const application = cloneDeep(hakemukset[7]) as Application<KaivuilmoitusData>;
+      application.muutosilmoitus = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: application.applicationData,
+        sent: null,
+        muutokset: ['workDescription'],
+      };
+      await setup(application);
+
+      await screen.findByRole('button', { name: 'Lähetä muutosilmoitus' }, { timeout: 10000 });
+      const sendButton = screen.getByRole('button', { name: 'Lähetä muutosilmoitus' });
+      expect(sendButton).toBeDisabled();
+    });
+
+    test('Should not show buttons if user does not have correct permission', async () => {
+      server.resetHandlers();
+      server.use(
+        http.get('/api/hankkeet/:hankeTunnus/whoami', async () => {
+          return HttpResponse.json<SignedInUser>({
+            hankeKayttajaId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            kayttooikeustaso: 'KATSELUOIKEUS',
+            kayttooikeudet: ['VIEW'],
+          });
+        }),
+      );
+      const application = cloneDeep(hakemukset[7]) as Application<KaivuilmoitusData>;
+      application.muutosilmoitus = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: application.applicationData,
+        sent: null,
+        muutokset: ['workDescription'],
+      };
+      await setup(application);
+
+      expect(
+        screen.queryByRole('button', { name: 'Jatka muutosilmoitusta' }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Peru muutosilmoitus' })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Lähetä muutosilmoitus' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Ilmoita toiminnalliseen kuntoon' }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Ilmoita valmiiksi' })).not.toBeInTheDocument();
+    });
+
+    test('Should not send multiple requests if clicking muutosilmoitus cancel confirm button many times', async () => {
+      server.use(
+        http.delete('/api/muutosilmoitukset/:id', async () => {
+          await delay(200);
+          return new HttpResponse();
+        }),
+      );
+      const application = cloneDeep(hakemukset[7]) as Application<KaivuilmoitusData>;
+      application.muutosilmoitus = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: application.applicationData,
+        sent: null,
+        muutokset: ['workDescription'],
+      };
+      const cancelMuutosilmoitus = jest.spyOn(muutosilmoitusApi, 'cancelMuutosilmoitus');
+      const { user } = await setup(application);
+
+      await screen.findByRole('button', { name: 'Peru muutosilmoitus' });
+
+      await user.click(screen.getByRole('button', { name: 'Peru muutosilmoitus' }));
+      const confirmCancelButton = screen.getByRole('button', { name: 'Vahvista' });
+      await user.click(confirmCancelButton);
+      await user.click(confirmCancelButton);
+      await user.click(confirmCancelButton);
+      await screen.findByText('Muutosilmoitus peruttiin onnistuneesti');
+
+      expect(cancelMuutosilmoitus).toHaveBeenCalledTimes(1);
+
+      cancelMuutosilmoitus.mockRestore();
+    });
+
+    test('Confirming send disables dialog buttons', async () => {
+      const application = cloneDeep(hakemukset[7]) as Application<KaivuilmoitusData>;
+      application.muutosilmoitus = {
+        id: 'c0a1fe7b-326c-4b25-a7bc-d1797762c01d',
+        applicationData: application.applicationData,
+        sent: null,
+        muutokset: ['workDescription'],
+      };
+      const { user } = await setup(application);
+      server.use(
+        http.get(`/api/hakemukset/:id`, async () => {
+          return HttpResponse.json({
+            ...application,
+            muutosilmoitus: {
+              ...application.muutosilmoitus,
+              sent: new Date(),
+            },
+          });
+        }),
+        http.post(`/api/muutosilmoitukset/:id/laheta`, async () => {
+          await delay(500);
+          return HttpResponse.json({
+            ...application,
+            muutosilmoitus: null,
+          });
+        }),
+      );
+      const sendApplication = jest.spyOn(muutosilmoitusApi, 'sendMuutosilmoitus');
+
+      const sendButton = await screen.findByRole('button', { name: 'Lähetä muutosilmoitus' });
+      await user.click(sendButton);
+
+      expect(await screen.findByText('Lähetä muutosilmoitus?')).toBeInTheDocument();
+      const confirmButton = screen.getByRole('button', { name: 'Vahvista' });
+      expect(confirmButton).toBeEnabled();
+      await user.click(confirmButton);
+      expect(confirmButton).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Lähetetään' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Peruuta' })).toBeDisabled();
+
+      expect(sendApplication).toHaveBeenCalledTimes(1);
+
+      sendApplication.mockRestore();
     });
 
     test('Should be able to cancel muutosilmoitus', async () => {

--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -94,6 +94,7 @@ import TaydennysAttachmentsList from '../taydennys/components/TaydennysAttachmen
 import { HaittojenhallintasuunnitelmaInfo } from '../../kaivuilmoitus/components/HaittojenhallintasuunnitelmaInfo';
 import MuutosilmoitusNotification from '../muutosilmoitus/components/MuutosilmoitusNotification';
 import MuutosilmoitusCancel from '../muutosilmoitus/components/MuutosilmoitusCancel';
+import useSendMuutosilmoitus from './hooks/useSendMuutosilmoitus';
 
 function TyoalueetList({ tyoalueet }: { tyoalueet: ApplicationArea[] }) {
   const { t } = useTranslation();
@@ -764,6 +765,10 @@ function ApplicationView({
   const informationRequestFeatureEnabled = useIsInformationRequestFeatureEnabled();
 
   const { sendTaydennysButton, sendTaydennysDialog } = useSendTaydennys(application, signedInUser);
+  const { sendMuutosilmoitusButton, sendMuutosilmoitusDialog } = useSendMuutosilmoitus(
+    application,
+    signedInUser,
+  );
 
   const showMuutosilmoitusButton =
     applicationType === 'EXCAVATION_NOTIFICATION' &&
@@ -943,6 +948,9 @@ function ApplicationView({
               </>
             </CheckRightsByHanke>
           )}
+          <CheckRightsByHanke requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>
+            {sendMuutosilmoitusButton}
+          </CheckRightsByHanke>
           {showReportOperationalConditionButton && (
             <CheckRightsByHanke requiredRight="EDIT_APPLICATIONS" hankeTunnus={hanke?.hankeTunnus}>
               <Button
@@ -1235,12 +1243,12 @@ function ApplicationView({
         />
       )}
       <ApplicationSendDialog
-        type={applicationType}
-        id={application.id}
+        application={application}
         isOpen={showSendDialog}
         onClose={closeSendDialog}
       />
       {sendTaydennysDialog}
+      {sendMuutosilmoitusDialog}
     </InformationViewContainer>
   );
 }

--- a/src/domain/application/applicationView/hooks/useSendMuutosilmoitus.tsx
+++ b/src/domain/application/applicationView/hooks/useSendMuutosilmoitus.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { Button, IconEnvelope, Notification } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { AlluStatus, Application } from '../../types/application';
+import { validationSchema as johtoselvitysValidationSchema } from '../../../johtoselvitysTaydennys/validationSchema';
+import { validationSchema as kaivuilmoitusValidationSchema } from '../../../kaivuilmoitusTaydennys/validationSchema';
+import { isContactIn } from '../../utils';
+import { SignedInUser } from '../../../hanke/hankeUsers/hankeUser';
+import ApplicationSendDialog from '../../components/ApplicationSendDialog';
+
+const validationSchemas = {
+  CABLE_REPORT: johtoselvitysValidationSchema,
+  EXCAVATION_NOTIFICATION: kaivuilmoitusValidationSchema,
+};
+
+export default function useSendMuutosilmoitus(
+  application: Application,
+  signedInUser: SignedInUser | undefined,
+) {
+  const { t } = useTranslation();
+  const validationSchema = validationSchemas[application.applicationType];
+  const isValid = validationSchema?.isValidSync(application.muutosilmoitus);
+  const showSendButton =
+    application.alluStatus === AlluStatus.DECISION &&
+    isValid &&
+    application.muutosilmoitus &&
+    application.muutosilmoitus.sent == null &&
+    application.muutosilmoitus.muutokset.length >
+      0 /* TODO when muutosilmoitus have attachments add this or-clause: || application.muutosilmoitus.liitteet.length > 0*/;
+  const [showSendDialog, setShowSendDialog] = useState(false);
+  const isContact =
+    application.muutosilmoitus &&
+    isContactIn(signedInUser, application.muutosilmoitus.applicationData);
+
+  function openSendDialog() {
+    setShowSendDialog(true);
+  }
+
+  function closeSendDialog() {
+    setShowSendDialog(false);
+  }
+
+  const sendButton = showSendButton ? (
+    <>
+      <Button
+        theme="coat"
+        iconLeft={<IconEnvelope />}
+        onClick={openSendDialog}
+        disabled={showSendButton && !isContact}
+      >
+        {t('muutosilmoitus:buttons:sendMuutosilmoitus')}
+      </Button>
+      {!isContact && (
+        <Notification
+          size="small"
+          style={{ marginTop: 'var(--spacing-xs)' }}
+          type="info"
+          label={t('hakemus:notifications:sendApplicationDisabled')}
+        >
+          {t('hakemus:notifications:sendApplicationDisabled')}
+        </Notification>
+      )}
+    </>
+  ) : null;
+
+  const sendDialog = (
+    <ApplicationSendDialog
+      application={application}
+      muutosilmoitus={application.muutosilmoitus}
+      isOpen={showSendDialog}
+      onClose={closeSendDialog}
+    />
+  );
+
+  return { sendMuutosilmoitusButton: sendButton, sendMuutosilmoitusDialog: sendDialog };
+}

--- a/src/domain/application/applicationView/hooks/useSendMuutosilmoitus.tsx
+++ b/src/domain/application/applicationView/hooks/useSendMuutosilmoitus.tsx
@@ -21,12 +21,13 @@ export default function useSendMuutosilmoitus(
   const validationSchema = validationSchemas[application.applicationType];
   const isValid = validationSchema?.isValidSync(application.muutosilmoitus);
   const showSendButton =
-    application.alluStatus === AlluStatus.DECISION &&
+    (application.alluStatus === AlluStatus.DECISION ||
+      application.alluStatus === AlluStatus.OPERATIONAL_CONDITION) &&
     isValid &&
     application.muutosilmoitus &&
     application.muutosilmoitus.sent == null &&
     application.muutosilmoitus.muutokset.length >
-      0 /* TODO when muutosilmoitus have attachments add this or-clause: || application.muutosilmoitus.liitteet.length > 0*/;
+      0; /* TODO when muutosilmoitus have attachments add this or-clause: || application.muutosilmoitus.liitteet.length > 0*/
   const [showSendDialog, setShowSendDialog] = useState(false);
   const isContact =
     application.muutosilmoitus &&

--- a/src/domain/application/components/ApplicationSendDialog.test.tsx
+++ b/src/domain/application/components/ApplicationSendDialog.test.tsx
@@ -7,14 +7,8 @@ import { cloneDeep } from 'lodash';
 import hakemukset from '../../mocks/data/hakemukset-data';
 
 test('Shows correct information when opened for excavation notification', async () => {
-  render(
-    <ApplicationSendDialog
-      type="EXCAVATION_NOTIFICATION"
-      id={1}
-      isOpen={true}
-      onClose={() => {}}
-    />,
-  );
+  const hakemus = cloneDeep(hakemukset[0]);
+  render(<ApplicationSendDialog application={hakemus} isOpen={true} onClose={() => {}} />);
 
   expect(screen.getByText(/lähetä hakemus\?/i)).toBeInTheDocument();
   expect(
@@ -36,7 +30,8 @@ test('Shows correct information when opened for excavation notification', async 
 });
 
 test('Shows correct information when opened for cable report', async () => {
-  render(<ApplicationSendDialog type="CABLE_REPORT" id={1} isOpen={true} onClose={() => {}} />);
+  const hakemus = cloneDeep(hakemukset[0]);
+  render(<ApplicationSendDialog application={hakemus} isOpen={true} onClose={() => {}} />);
 
   expect(screen.getByText(/lähetä hakemus\?/i)).toBeInTheDocument();
   expect(
@@ -60,7 +55,8 @@ test('Shows correct information when opened for cable report', async () => {
 test('Shows correct information when opened for cable report when paper decision feature is disabled', async () => {
   const OLD_ENV = { ...window._env_ };
   window._env_ = { ...OLD_ENV, REACT_APP_FEATURE_CABLE_REPORT_PAPER_DECISION: 0 };
-  render(<ApplicationSendDialog type="CABLE_REPORT" id={1} isOpen={true} onClose={() => {}} />);
+  const hakemus = cloneDeep(hakemukset[0]);
+  render(<ApplicationSendDialog application={hakemus} isOpen={true} onClose={() => {}} />);
 
   expect(screen.getByText(/lähetä hakemus\?/i)).toBeInTheDocument();
   expect(
@@ -84,13 +80,9 @@ test('Shows correct information when opened for cable report when paper decision
 });
 
 test('Shows correct information when ordering paper decision', async () => {
+  const hakemus = cloneDeep(hakemukset[0]);
   const { user } = render(
-    <ApplicationSendDialog
-      type="EXCAVATION_NOTIFICATION"
-      id={1}
-      isOpen={true}
-      onClose={() => {}}
-    />,
+    <ApplicationSendDialog application={hakemus} isOpen={true} onClose={() => {}} />,
   );
 
   const orderPaperDecisionButton = screen.getByRole('button', {
@@ -122,13 +114,9 @@ test('Shows correct information when ordering paper decision', async () => {
 });
 
 test('Enables confirmation button when form is filled', async () => {
+  const hakemus = cloneDeep(hakemukset[0]);
   const { user } = render(
-    <ApplicationSendDialog
-      type="EXCAVATION_NOTIFICATION"
-      id={1}
-      isOpen={true}
-      onClose={() => {}}
-    />,
+    <ApplicationSendDialog application={hakemus} isOpen={true} onClose={() => {}} />,
   );
 
   const confirmButton = screen.getByRole('button', { name: 'Vahvista' });
@@ -153,7 +141,7 @@ test('Enables confirmation button when form is filled', async () => {
 });
 
 test('Sends the application when confirmed', async () => {
-  const hakemus = cloneDeep(hakemukset[0]);
+  const hakemus = cloneDeep(hakemukset[4]);
   let sent = false;
   server.use(
     http.post(`/api/hakemukset/:id/laheta`, async () => {
@@ -164,12 +152,7 @@ test('Sends the application when confirmed', async () => {
   );
 
   const { user } = render(
-    <ApplicationSendDialog
-      type="EXCAVATION_NOTIFICATION"
-      id={1}
-      isOpen={true}
-      onClose={() => {}}
-    />,
+    <ApplicationSendDialog application={hakemus} isOpen={true} onClose={() => {}} />,
   );
 
   const orderPaperDecisionButton = screen.getByRole('button', {
@@ -197,13 +180,9 @@ test('Shows error message when sending fails', async () => {
     }),
   );
 
+  const hakemus = cloneDeep(hakemukset[4]);
   const { user } = render(
-    <ApplicationSendDialog
-      type="EXCAVATION_NOTIFICATION"
-      id={1}
-      isOpen={true}
-      onClose={() => {}}
-    />,
+    <ApplicationSendDialog application={hakemus} isOpen={true} onClose={() => {}} />,
   );
 
   const orderPaperDecisionButton = screen.getByRole('button', {
@@ -229,9 +208,10 @@ test('Shows error message when sending fails', async () => {
 });
 
 test('Calls onClose when cancelled', async () => {
+  const hakemus = cloneDeep(hakemukset[4]);
   const onClose = jest.fn();
   const { user } = render(
-    <ApplicationSendDialog type="EXCAVATION_NOTIFICATION" id={1} isOpen={true} onClose={onClose} />,
+    <ApplicationSendDialog application={hakemus} isOpen={true} onClose={onClose} />,
   );
 
   const cancelButton = screen.getByRole('button', { name: 'Peruuta' });

--- a/src/domain/application/components/ApplicationSendDialog.tsx
+++ b/src/domain/application/components/ApplicationSendDialog.tsx
@@ -87,7 +87,7 @@ const ApplicationSendDialog: React.FC<Props> = ({
       : null;
     applicationSendMutation.mutate(
       {
-        id: isMuutosilmoitus ? (muutosilmoitus.id! as string) : (id as number),
+        id: isMuutosilmoitus ? muutosilmoitus.id : (id as number),
         paperDecisionReceiver: paperDecisionReceiver,
       },
       {

--- a/src/domain/application/components/ApplicationSendDialog.tsx
+++ b/src/domain/application/components/ApplicationSendDialog.tsx
@@ -10,7 +10,13 @@ import {
 } from 'hds-react';
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { ApplicationSendData, ApplicationType, PaperDecisionReceiver } from '../types/application';
+import {
+  Application,
+  ApplicationSendData,
+  JohtoselvitysData,
+  KaivuilmoitusData,
+  PaperDecisionReceiver,
+} from '../types/application';
 import { FormProvider, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { sendSchema } from '../yupSchemas';
@@ -20,66 +26,89 @@ import TextInput from '../../../common/components/textInput/TextInput';
 import { useFeatureFlags } from '../../../common/components/featureFlags/FeatureFlagsContext';
 import useSendApplication from '../hooks/useSendApplication';
 import useApplicationSendNotification from '../hooks/useApplicationSendNotification';
+import { KaivuilmoitusMuutosilmoitusFormValues } from '../../kaivuilmoitusMuutosilmoitus/types';
+import { Muutosilmoitus } from '../muutosilmoitus/types';
 
 type Props = {
-  type: ApplicationType;
-  id?: number | null;
+  application: Application;
+  muutosilmoitus?:
+    | KaivuilmoitusMuutosilmoitusFormValues
+    | Muutosilmoitus<KaivuilmoitusData | JohtoselvitysData>
+    | null;
   isOpen: boolean;
   onClose: (id?: number | null) => void;
 };
 
-const ApplicationSendDialog: React.FC<Props> = ({ type, id, isOpen, onClose }) => {
+/**
+ * A dialog for sending an application or muutosilmoitus to Allu.
+ *
+ * @param application
+ * @param muutosilmoitus
+ * @param isOpen
+ * @param onClose
+ * @constructor
+ */
+const ApplicationSendDialog: React.FC<Props> = ({
+  application,
+  muutosilmoitus,
+  isOpen,
+  onClose,
+}) => {
   const { t } = useTranslation();
+  const { applicationType } = application;
+  const { id, applicationData } = muutosilmoitus ?? application;
+  const isMuutosilmoitus = muutosilmoitus != null;
   const features = useFeatureFlags();
+  const [showPaperDecision, setShowPaperDecision] = React.useState(
+    applicationData.paperDecisionReceiver != null,
+  );
   const formContext = useForm<ApplicationSendData>({
     resolver: yupResolver(sendSchema),
     defaultValues: {
-      orderPaperDecision: false,
-      paperDecisionReceiver: null,
+      orderPaperDecision: applicationData.paperDecisionReceiver != null,
+      paperDecisionReceiver: applicationData.paperDecisionReceiver,
     },
   });
 
-  const { handleSubmit, formState, register, watch, setValue, resetField, reset } = formContext;
-  const [orderPaperDecisionChecked] = watch(['orderPaperDecision']);
+  const { handleSubmit, formState, register, setValue } = formContext;
   const isConfirmButtonEnabled = formState.isValid;
-  const dialogTitle = t('hakemus:sendDialog:title');
+  const dialogTitle = isMuutosilmoitus
+    ? t('muutosilmoitus:sendDialog:title')
+    : t('hakemus:sendDialog:title');
   const paperDecisionFeatureEnabled =
-    type === 'EXCAVATION_NOTIFICATION' || features.cableReportPaperDecision;
+    applicationType === 'EXCAVATION_NOTIFICATION' || features.cableReportPaperDecision;
 
-  const applicationSendMutation = useSendApplication();
-  const { showSendSuccess } = useApplicationSendNotification();
+  const applicationSendMutation = useSendApplication({ isMuutosilmoitus: isMuutosilmoitus });
+  const { showSendSuccess } = useApplicationSendNotification(isMuutosilmoitus);
 
-  async function submitForm(data: ApplicationSendData) {
-    const paperDecisionReceiver = data.orderPaperDecision
-      ? (data.paperDecisionReceiver as PaperDecisionReceiver)
+  async function submitForm(sendData: ApplicationSendData) {
+    const paperDecisionReceiver = sendData.orderPaperDecision
+      ? (sendData.paperDecisionReceiver as PaperDecisionReceiver)
       : null;
     applicationSendMutation.mutate(
       {
-        id: id as number,
+        id: isMuutosilmoitus ? (muutosilmoitus.id! as string) : (id as number),
         paperDecisionReceiver: paperDecisionReceiver,
       },
       {
-        onSuccess(applicationData) {
+        onSuccess(data) {
           showSendSuccess();
-          onClose(applicationData.id);
+          onClose(data.id);
         },
       },
     );
   }
 
   function handleOrderPaperDecisionChange() {
-    const newValue = !orderPaperDecisionChecked;
+    const newValue = !showPaperDecision;
     setValue('orderPaperDecision', newValue, {
       shouldDirty: true,
     });
-    if (!newValue) {
-      resetField('paperDecisionReceiver', { defaultValue: null });
-    }
+    setShowPaperDecision(newValue);
   }
 
   function handleClose() {
     if (!applicationSendMutation.isLoading) {
-      reset();
       applicationSendMutation.reset();
       onClose();
     }
@@ -120,13 +149,13 @@ const ApplicationSendDialog: React.FC<Props> = ({ type, id, isOpen, onClose }) =
                   {...register('orderPaperDecision')}
                   id="orderPaperDecision"
                   label={t('hakemus:sendDialog:orderPaperDecision')}
-                  checked={orderPaperDecisionChecked}
+                  checked={showPaperDecision}
                   onChange={handleOrderPaperDecisionChange}
                   disabled={applicationSendMutation.isLoading}
                 />
               </Box>
             )}
-            {paperDecisionFeatureEnabled && orderPaperDecisionChecked && (
+            {paperDecisionFeatureEnabled && showPaperDecision && (
               <Box>
                 <Notification label={t('hakemus:sendDialog:paperDecisionNotificationLabel')}>
                   {t('hakemus:sendDialog:paperDecisionNotificationText')}
@@ -143,7 +172,7 @@ const ApplicationSendDialog: React.FC<Props> = ({ type, id, isOpen, onClose }) =
                       {...register('paperDecisionReceiver.name')}
                       name="paperDecisionReceiver.name"
                       label={t('hakemus:sendDialog:name')}
-                      required={orderPaperDecisionChecked}
+                      required={showPaperDecision}
                       disabled={applicationSendMutation.isLoading}
                     />
                   </GridItem>
@@ -152,7 +181,7 @@ const ApplicationSendDialog: React.FC<Props> = ({ type, id, isOpen, onClose }) =
                       {...register('paperDecisionReceiver.streetAddress')}
                       name="paperDecisionReceiver.streetAddress"
                       label={t('hakemus:sendDialog:streetAddress')}
-                      required={orderPaperDecisionChecked}
+                      required={showPaperDecision}
                       disabled={applicationSendMutation.isLoading}
                     />
                   </GridItem>
@@ -161,7 +190,7 @@ const ApplicationSendDialog: React.FC<Props> = ({ type, id, isOpen, onClose }) =
                       {...register('paperDecisionReceiver.postalCode')}
                       name="paperDecisionReceiver.postalCode"
                       label={t('hakemus:sendDialog:postalCode')}
-                      required={orderPaperDecisionChecked}
+                      required={showPaperDecision}
                       disabled={applicationSendMutation.isLoading}
                     />
                   </GridItem>
@@ -170,7 +199,7 @@ const ApplicationSendDialog: React.FC<Props> = ({ type, id, isOpen, onClose }) =
                       {...register('paperDecisionReceiver.city')}
                       name="paperDecisionReceiver.city"
                       label={t('hakemus:sendDialog:city')}
-                      required={orderPaperDecisionChecked}
+                      required={showPaperDecision}
                       disabled={applicationSendMutation.isLoading}
                     />
                   </GridItem>
@@ -178,19 +207,36 @@ const ApplicationSendDialog: React.FC<Props> = ({ type, id, isOpen, onClose }) =
               </Box>
             )}
             {applicationSendMutation.isError && (
-              <Notification
-                type="error"
-                size="small"
-                label={t('hakemus:notifications:sendErrorLabel')}
-              >
-                <Trans i18nKey="hakemus:notifications:sendErrorText">
-                  <p>
-                    Hakemuksen lähettäminen käsittelyyn epäonnistui. Yritä lähettämistä myöhemmin
-                    uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa
-                    <Link href="mailto:haitatontuki@hel.fi">haitatontuki@hel.fi</Link>.
-                  </p>
-                </Trans>
-              </Notification>
+              <Box paddingTop="var(--spacing-s)">
+                <Notification
+                  type="error"
+                  size="small"
+                  label={
+                    isMuutosilmoitus
+                      ? t('muutosilmoitus:notification:sendErrorLabel')
+                      : t('hakemus:notifications:sendErrorLabel')
+                  }
+                >
+                  {isMuutosilmoitus ? (
+                    <Trans i18nKey="muutosilmoitus:notification:sendErrorText">
+                      <p>
+                        Lähettämisessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä
+                        Haitattoman tekniseen tukeen sähköpostiosoitteessa
+                        <Link href="mailto:haitatontuki@hel.fi">haitatontuki@hel.fi</Link>.
+                      </p>
+                    </Trans>
+                  ) : (
+                    <Trans i18nKey="hakemus:notifications:sendErrorText">
+                      <p>
+                        Hakemuksen lähettäminen käsittelyyn epäonnistui. Yritä lähettämistä
+                        myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen
+                        sähköpostiosoitteessa
+                        <Link href="mailto:haitatontuki@hel.fi">haitatontuki@hel.fi</Link>.
+                      </p>
+                    </Trans>
+                  )}
+                </Notification>
+              </Box>
             )}
           </Dialog.Content>
 

--- a/src/domain/application/hooks/useApplicationSendNotification.tsx
+++ b/src/domain/application/hooks/useApplicationSendNotification.tsx
@@ -4,7 +4,7 @@ import { useGlobalNotification } from '../../../common/components/globalNotifica
 /**
  * Returns functions for showing success notification for sending application
  */
-export default function useApplicationSendNotification() {
+export default function useApplicationSendNotification(isMuutosilmoitus: boolean = false) {
   const { t } = useTranslation();
   const { setNotification } = useGlobalNotification();
 
@@ -14,8 +14,12 @@ export default function useApplicationSendNotification() {
       dismissible: true,
       autoClose: true,
       autoCloseDuration: 8000,
-      label: t('hakemus:notifications:sendSuccessLabel'),
-      message: t('hakemus:notifications:sendSuccessText'),
+      label: isMuutosilmoitus
+        ? t('muutosilmoitus:notification:sendSuccessLabel')
+        : t('hakemus:notifications:sendSuccessLabel'),
+      message: isMuutosilmoitus
+        ? t('muutosilmoitus:notification:sendSuccessText')
+        : t('hakemus:notifications:sendSuccessText'),
       type: 'success',
       closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
     });

--- a/src/domain/application/hooks/useSendApplication.ts
+++ b/src/domain/application/hooks/useSendApplication.ts
@@ -2,18 +2,28 @@ import { useQueryClient } from 'react-query';
 import { sendApplication } from '../utils';
 import { Application, PaperDecisionReceiver } from '../types/application';
 import useDebouncedMutation from '../../../common/hooks/useDebouncedMutation';
+import { sendMuutosilmoitus } from '../muutosilmoitus/muutosilmoitusApi';
 
 type Options = {
-  onSuccess: (data: Application) => void;
+  isMuutosilmoitus?: boolean;
+  onSuccess?: (data: Application) => void;
 };
 
+/**
+ * Send application or muutosilmoitus to Allu.
+ */
 export default function useSendApplication(options?: Options) {
-  const { onSuccess } = options || {};
+  const { isMuutosilmoitus, onSuccess } = options || {};
   const queryClient = useQueryClient();
 
   return useDebouncedMutation(
-    (variables: { id: number; paperDecisionReceiver: PaperDecisionReceiver | undefined | null }) =>
-      sendApplication(variables.id, variables.paperDecisionReceiver),
+    (variables: {
+      id: number | string;
+      paperDecisionReceiver: PaperDecisionReceiver | undefined | null;
+    }) =>
+      isMuutosilmoitus
+        ? sendMuutosilmoitus(variables.id as string, variables.paperDecisionReceiver)
+        : sendApplication(variables.id as number, variables.paperDecisionReceiver),
     {
       async onSuccess(data) {
         await queryClient.invalidateQueries(['application', data.id], { refetchInactive: true });

--- a/src/domain/application/muutosilmoitus/muutosilmoitusApi.ts
+++ b/src/domain/application/muutosilmoitus/muutosilmoitusApi.ts
@@ -1,5 +1,6 @@
 import api from '../../api/api';
 import { Muutosilmoitus } from './types';
+import { Application, PaperDecisionReceiver } from '../types/application';
 
 /**
  * Create muutosilmoitus
@@ -25,6 +26,24 @@ export async function updateMuutosilmoitus<ApplicationData, UpdateData>({
   data: UpdateData;
 }) {
   const response = await api.put<Muutosilmoitus<ApplicationData>>(`/muutosilmoitukset/${id}`, data);
+  return response.data;
+}
+
+/**
+ * Send muutosilmoitus to Allu
+ */
+export async function sendMuutosilmoitus(
+  id: string,
+  paperDecisionReceiver: PaperDecisionReceiver | null | undefined,
+) {
+  const response = await api.post<Application>(
+    `/muutosilmoitukset/${id}/laheta`,
+    paperDecisionReceiver
+      ? {
+          paperDecisionReceiver: paperDecisionReceiver,
+        }
+      : null,
+  );
   return response.data;
 }
 

--- a/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
+++ b/src/domain/johtoselvitys/JohtoselvitysContainer.tsx
@@ -458,8 +458,7 @@ const JohtoselvitysContainer: React.FC<React.PropsWithChildren<Props>> = ({
       />
 
       <ApplicationSendDialog
-        type="CABLE_REPORT"
-        id={getValues('id')}
+        application={getValues()}
         isOpen={showSendDialog}
         onClose={closeSendDialog}
       />

--- a/src/domain/johtoselvitys/types.ts
+++ b/src/domain/johtoselvitys/types.ts
@@ -10,8 +10,7 @@ export interface JohtoselvitysFormData extends JohtoselvitysData {
   areas: JohtoselvitysArea[];
 }
 
-export interface JohtoselvitysFormValues
-  extends Omit<Application<JohtoselvitysData>, 'paatokset' | 'muutosilmoitus'> {
+export interface JohtoselvitysFormValues extends Omit<Application<JohtoselvitysData>, 'paatokset'> {
   applicationData: JohtoselvitysFormData;
   geometriesChanged?: boolean; // virtualField
   selfIntersectingPolygon?: boolean; // virtualField

--- a/src/domain/johtoselvitys/validationSchema.ts
+++ b/src/domain/johtoselvitys/validationSchema.ts
@@ -8,6 +8,7 @@ import {
 } from '../application/yupSchemas';
 import { Taydennys, Taydennyspyynto } from '../application/taydennys/types';
 import { FORM_PAGES } from '../forms/types';
+import { Muutosilmoitus } from '../application/muutosilmoitus/types';
 
 const addressSchema = yup
   .object({
@@ -74,6 +75,7 @@ export const validationSchema: yup.ObjectSchema<JohtoselvitysFormValues> = yup.o
   taydennys: yup.mixed<Taydennys<JohtoselvitysData>>().nullable(),
   selfIntersectingPolygon: yup.boolean().isFalse(),
   geometriesChanged: yup.boolean(),
+  muutosilmoitus: yup.mixed<Muutosilmoitus<JohtoselvitysData>>().nullable(),
 });
 
 export const newJohtoselvitysSchema = yup.object({

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -439,8 +439,7 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
       />
 
       <ApplicationSendDialog
-        type="EXCAVATION_NOTIFICATION"
-        id={getValues('id')}
+        application={getValues()}
         isOpen={showSendDialog}
         onClose={closeSendDialog}
       />

--- a/src/domain/kaivuilmoitus/types.ts
+++ b/src/domain/kaivuilmoitus/types.ts
@@ -1,7 +1,6 @@
 import { Application, KaivuilmoitusData } from '../application/types/application';
 
-export interface KaivuilmoitusFormValues
-  extends Omit<Application<KaivuilmoitusData>, 'paatokset' | 'muutosilmoitus'> {
+export interface KaivuilmoitusFormValues extends Omit<Application<KaivuilmoitusData>, 'paatokset'> {
   geometriesChanged?: boolean; // virtualField
   selfIntersectingPolygon?: boolean; // virtualField
 }

--- a/src/domain/kaivuilmoitus/validationSchema.ts
+++ b/src/domain/kaivuilmoitus/validationSchema.ts
@@ -21,6 +21,7 @@ import { HaittaIndexData } from '../common/haittaIndexes/types';
 import { Taydennys, Taydennyspyynto } from '../application/taydennys/types';
 import haittojenhallintaSchema from '../common/haittojenhallinta/haittojenhallintaSchema';
 import { FORM_PAGES } from '../forms/types';
+import { Muutosilmoitus } from '../application/muutosilmoitus/types';
 
 const tyoalueSchema = yup.object({
   geometry: geometrySchema.required(),
@@ -161,6 +162,7 @@ export const validationSchema: yup.ObjectSchema<KaivuilmoitusFormValues> = yup.o
   taydennys: yup.mixed<Taydennys<KaivuilmoitusData>>().nullable(),
   selfIntersectingPolygon: yup.boolean().isFalse(),
   geometriesChanged: yup.boolean(),
+  muutosilmoitus: yup.mixed<Muutosilmoitus<KaivuilmoitusData>>().nullable(),
 });
 
 export const perustiedotSchema = yup.object({

--- a/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
+++ b/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
@@ -130,14 +130,18 @@ describe('Canceling muutosilmoitus', () => {
 
 describe('Sending muutosilmoitus', () => {
   test('Should be able to send muutosilmoitus', async () => {
-    const application = cloneDeep(hakemukset[13]) as Application<KaivuilmoitusData>;
-    const { user } = setup({
-      ...application,
+    const applicationBase = cloneDeep(hakemukset[13]) as Application<KaivuilmoitusData>;
+    const application = {
+      ...applicationBase,
       muutosilmoitus: {
-        ...application.muutosilmoitus!,
+        ...applicationBase.muutosilmoitus!,
         sent: null,
         muutokset: ['workDescription'],
       },
+    };
+    const { user } = setup({
+      application: application,
+      muutosilmoitus: application.muutosilmoitus,
     });
     await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
     await user.click(screen.getByRole('button', { name: /lähetä muutosilmoitus/i }));

--- a/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
+++ b/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
@@ -127,3 +127,23 @@ describe('Canceling muutosilmoitus', () => {
     expect(window.location.pathname).toBe('/fi/hakemus/14');
   });
 });
+
+describe('Sending muutosilmoitus', () => {
+  test('Should be able to send muutosilmoitus', async () => {
+    const application = cloneDeep(hakemukset[13]) as Application<KaivuilmoitusData>;
+    const { user } = setup({
+      application,
+      muutosilmoitus: {
+        ...application.muutosilmoitus!,
+        sent: null,
+        muutokset: ['workDescription'],
+      },
+    });
+    await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
+    await user.click(screen.getByRole('button', { name: /lähetä muutosilmoitus/i }));
+    await user.click(await screen.findByRole('button', { name: /vahvista/i }));
+
+    expect(await screen.findByText('Muutosilmoitus lähetetty')).toBeInTheDocument();
+    expect(screen.getByText('Muutosilmoitus on lähetetty käsiteltäväksi.')).toBeInTheDocument();
+  });
+});

--- a/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
+++ b/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
@@ -132,7 +132,7 @@ describe('Sending muutosilmoitus', () => {
   test('Should be able to send muutosilmoitus', async () => {
     const application = cloneDeep(hakemukset[13]) as Application<KaivuilmoitusData>;
     const { user } = setup({
-      application,
+      ...application,
       muutosilmoitus: {
         ...application.muutosilmoitus!,
         sent: null,

--- a/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
+++ b/src/domain/kaivuilmoitusMuutosilmoitus/KaivuilmoitusMuutosilmoitus.test.tsx
@@ -57,6 +57,21 @@ function setup(
         { status: responseStatus },
       );
     }),
+    http.post('/api/muutosilmoitukset/:id/laheta', async () => {
+      return HttpResponse.json<Application>(
+        {
+          ...application,
+          muutosilmoitus: {
+            ...muutosilmoitus,
+            sent: new Date(),
+          },
+        },
+        { status: responseStatus },
+      );
+    }),
+    http.delete('/api/muutosilmoitukset/:id', async () => {
+      return new HttpResponse(null, { status: responseStatus });
+    }),
   );
   return {
     ...render(
@@ -118,6 +133,7 @@ describe('Canceling muutosilmoitus', () => {
     const { user } = setup({
       application,
       muutosilmoitus: application.muutosilmoitus!,
+      responseStatus: 204,
     });
     await user.click(screen.getByRole('button', { name: /peru muutosilmoitus/i }));
     await user.click(await screen.findByRole('button', { name: /vahvista/i }));

--- a/src/domain/mocks/data/hakemukset.ts
+++ b/src/domain/mocks/data/hakemukset.ts
@@ -232,3 +232,12 @@ export async function cancelMuutosilmoitus(id: string) {
   }
   hakemus.muutosilmoitus = null;
 }
+
+export async function sendMuutosilmoitus(id: string) {
+  const hakemus = await readMuutosilmoitus(id);
+  const muutosilmoitus = hakemus?.muutosilmoitus;
+  if (!muutosilmoitus) {
+    throw new ApiError(`No muutosilmoitus with id ${id}`, 404);
+  }
+  return muutosilmoitus;
+}

--- a/src/domain/mocks/handlers.ts
+++ b/src/domain/mocks/handlers.ts
@@ -425,4 +425,10 @@ export const handlers = [
     await hakemuksetDB.cancelMuutosilmoitus(id as string);
     return new HttpResponse();
   }),
+
+  http.post(`${apiUrl}/muutosilmoitukset/:id/laheta`, async ({ params }) => {
+    const { id } = params;
+    const muutosilmoitus = await hakemuksetDB.sendMuutosilmoitus(id as string);
+    return HttpResponse.json(muutosilmoitus);
+  }),
 ];

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -1571,14 +1571,22 @@
     "buttons": {
       "createMuutosilmoitus": "Tee muutosilmoitus",
       "editMuutosilmoitus": "Jatka muutosilmoitusta",
-      "cancelMuutosilmoitus": "Peru muutosilmoitus"
+      "cancelMuutosilmoitus": "Peru muutosilmoitus",
+      "sendMuutosilmoitus": "Lähetä muutosilmoitus"
     },
     "notification": {
       "label": "Muutosilmoitus",
       "createdText": "Hakemuksella on keskeneräinen muutosilmoitus.",
+      "sendSuccessLabel": "Muutosilmoitus lähetetty",
+      "sendSuccessText": "Muutosilmoitus on lähetetty käsiteltäväksi.",
+      "sendErrorLabel": "Muutosilmoituksen lähettäminen epäonnistui",
+      "sendErrorText": "$t(hakemus:notifications:reportCompletionDateErrorText)",
       "sentText": "Hakemukselle on tehty muutosilmoitus, joka on lähetetty käsittelyyn {{date}}",
       "cancelSuccessLabel": "Muutosilmoitus peruttiin",
       "cancelSuccessText": "Muutosilmoitus peruttiin onnistuneesti"
+    },
+    "sendDialog": {
+      "title": "Lähetä muutosilmoitus?"
     }
   },
   "hankeSidebar": {


### PR DESCRIPTION
# Description

Sending muutosilmoitus for both muutosilmoitus form and application view.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3409

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create a muutosilmoitus for a kaivuilmoitus
2. Make a change
3. Send button should be availabe when there are changes (and the user has correct rights)
4. Send dialog should work without paper decision and with it
5. The same send dialog is used for sending applications, so that should also be tested that it still works as before

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
