### PR TITLE
HAI-3383 Updates to public areas map project area hover box

### DIFF
--- a/src/common/components/map/interactions/hover/HoverContext.tsx
+++ b/src/common/components/map/interactions/hover/HoverContext.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 
+export type HankeAlueHoverData = {
+  hankeTunnus?: string | null;
+  hankeName?: string | null;
+  areaName?: string | null;
+  startDate?: Date | string | null;
+  endDate?: Date | string | null;
+};
+
 type HoverContext = {
-  hoveredHankeTunnukset: string[];
+  hoveredHankeAreaData: HankeAlueHoverData[];
   hoverPosition: number[];
 };
 
 const HoverContext = React.createContext<HoverContext>({
-  hoveredHankeTunnukset: [],
+  hoveredHankeAreaData: [],
   hoverPosition: [0, 0],
 });
 

--- a/src/domain/map/components/HankeHover/HankeHover.module.scss
+++ b/src/domain/map/components/HankeHover/HankeHover.module.scss
@@ -7,9 +7,12 @@
     min-width: 21.875rem;
     background-color: var(--color-coat-of-arms-light);
     padding: var(--spacing-xs);
-    font-size: var(--fontsize-body-s);
-    line-height: var(--lineheight-xl);
-    font-weight: normal;
     border: 1px solid black;
+
+    p {
+      font-size: var(--fontsize-body-s);
+      line-height: var(--lineheight-xl);
+      font-weight: normal;
+    }
   }
 }

--- a/src/domain/map/components/HankeHover/HankeHoverBox.tsx
+++ b/src/domain/map/components/HankeHover/HankeHoverBox.tsx
@@ -1,16 +1,12 @@
 import React, { useContext } from 'react';
-import { format } from 'date-fns';
 import { Link } from 'hds-react';
 import { useNavigate } from 'react-router-dom';
 import HoverContext from '../../../../common/components/map/interactions/hover/HoverContext';
-import HankkeetContext from '../../HankkeetProviderContext';
 import styles from './HankeHover.module.scss';
-import { HankeData } from '../../../types/hanke';
+import Text from '../../../../common/components/text/Text';
 
 const HankeHoverBox: React.FC<React.PropsWithChildren<unknown>> = () => {
-  const { hoveredHankeTunnukset, hoverPosition } = useContext(HoverContext);
-  const { hankkeet } = useContext(HankkeetContext);
-  const foundHankkeet: HankeData[] = [];
+  const { hoveredHankeAreaData, hoverPosition } = useContext(HoverContext);
 
   const navigate = useNavigate();
 
@@ -19,17 +15,9 @@ const HankeHoverBox: React.FC<React.PropsWithChildren<unknown>> = () => {
     left: hoverPosition[0] + 2 || 0,
   };
 
-  if (hoveredHankeTunnukset.length > 0) {
-    hoveredHankeTunnukset.forEach((hankeTunnus) => {
-      const hanke = hankkeet.find((HANKE) => HANKE.hankeTunnus === hankeTunnus);
-      if (hanke) {
-        foundHankkeet.push(hanke);
-      }
-    });
-  }
-
-  const openHanke = (e: React.MouseEvent, hankeTunnus: string) => {
+  const openHanke = (e: React.MouseEvent, hankeTunnus?: string | null) => {
     e.preventDefault();
+    if (!hankeTunnus) return;
     navigate({
       search: `?hanke=${hankeTunnus}`,
     });
@@ -37,20 +25,19 @@ const HankeHoverBox: React.FC<React.PropsWithChildren<unknown>> = () => {
 
   return (
     <div className={styles.hankeHover} style={hoverBoxPosition}>
-      {foundHankkeet.map((hanke) => (
-        <div key={hanke.hankeTunnus}>
+      {hoveredHankeAreaData.map((hankeArea) => (
+        <div key={hankeArea.hankeTunnus}>
           <Link
-            href={`/?hanke=${hanke.hankeTunnus}`}
+            href={`/?hanke=${hankeArea.hankeTunnus}`}
             size="M"
-            onClick={(e) => openHanke(e, hanke.hankeTunnus)}
+            onClick={(e) => openHanke(e, hankeArea.hankeTunnus)}
           >
-            {`${hanke.nimi} (${hanke.hankeTunnus})`}
+            {`${hankeArea.hankeName} (${hankeArea.hankeTunnus})`}
           </Link>
-          {hanke.alkuPvm && hanke.loppuPvm && (
-            <p>
-              {format(new Date(hanke.alkuPvm), 'dd.MM.yyyy')} -{' '}
-              {format(new Date(hanke.loppuPvm), 'dd.MM.yyyy')}
-            </p>
+          <Text tag="p">{hankeArea.areaName}</Text>
+
+          {hankeArea.startDate && hankeArea.endDate && (
+            <Text tag="p">{`${hankeArea.startDate} - ${hankeArea.endDate}`}</Text>
           )}
         </div>
       ))}

--- a/src/domain/map/components/interations/HighlightFeatureOnMap.tsx
+++ b/src/domain/map/components/interations/HighlightFeatureOnMap.tsx
@@ -12,13 +12,13 @@ type Props = {
 const HighlightFeatureOnMap: React.FC<React.PropsWithChildren<Props>> = ({ source }) => {
   const location = useLocation();
   const { map } = useContext(MapContext);
-  const { hoveredHankeTunnukset } = useContext(HoverContext);
+  const { hoveredHankeAreaData } = useContext(HoverContext);
   const hankeTunnus = new URLSearchParams(location.search).get('hanke');
 
   const highlightFeature = useCallback(() => {
     source.getFeatures().some((feature) => {
       if (
-        hoveredHankeTunnukset.includes(feature.get('hankeTunnus')) ||
+        hoveredHankeAreaData.includes(feature.get('hankeTunnus')) ||
         feature.get('hankeTunnus') === hankeTunnus
       ) {
         feature.setStyle(styleFunction(feature, undefined, true));
@@ -27,7 +27,7 @@ const HighlightFeatureOnMap: React.FC<React.PropsWithChildren<Props>> = ({ sourc
       }
       return false;
     });
-  }, [hankeTunnus, hoveredHankeTunnukset, source]);
+  }, [hankeTunnus, hoveredHankeAreaData, source]);
 
   useEffect(() => {
     source.on('addfeature', () => {
@@ -37,7 +37,7 @@ const HighlightFeatureOnMap: React.FC<React.PropsWithChildren<Props>> = ({ sourc
 
   useEffect(() => {
     highlightFeature();
-  }, [hankeTunnus, hoveredHankeTunnukset, highlightFeature]);
+  }, [hankeTunnus, hoveredHankeAreaData, highlightFeature]);
 
   return null;
 };


### PR DESCRIPTION
# Description

Changes to hover box for project areas in public projects map:
* Project area name is visible
* Dates are area start and end date, not project start and end

### Jira Issue:

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

In public projects map, hover over and area. In the hover box:
* Project area name is visible
* Dates are area start and end date, not project start and end.
* Works correctly for overlapping areas as well.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location: