### PR TITLE
HAI-3409 Enable and disable the confirm send button correctly

### DIFF
--- a/src/domain/application/components/ApplicationSendDialog.tsx
+++ b/src/domain/application/components/ApplicationSendDialog.tsx
@@ -62,16 +62,21 @@ const ApplicationSendDialog: React.FC<Props> = ({
   const [showPaperDecision, setShowPaperDecision] = React.useState(
     applicationData.paperDecisionReceiver != null,
   );
+  const [originalPaperDecisionReceiver] = React.useState(
+    applicationData.paperDecisionReceiver || null,
+  );
   const formContext = useForm<ApplicationSendData>({
+    mode: 'onChange',
     resolver: yupResolver(sendSchema),
     defaultValues: {
       orderPaperDecision: applicationData.paperDecisionReceiver != null,
-      paperDecisionReceiver: applicationData.paperDecisionReceiver,
+      paperDecisionReceiver: applicationData.paperDecisionReceiver ?? null,
     },
   });
 
-  const { handleSubmit, formState, register, setValue } = formContext;
+  const { handleSubmit, formState, register, setValue, clearErrors } = formContext;
   const isConfirmButtonEnabled = formState.isValid;
+
   const dialogTitle = isMuutosilmoitus
     ? t('muutosilmoitus:sendDialog:title')
     : t('hakemus:sendDialog:title');
@@ -101,9 +106,18 @@ const ApplicationSendDialog: React.FC<Props> = ({
 
   function handleOrderPaperDecisionChange() {
     const newValue = !showPaperDecision;
-    setValue('orderPaperDecision', newValue, {
-      shouldDirty: true,
-    });
+    setValue('orderPaperDecision', newValue, { shouldDirty: true, shouldValidate: true });
+    if (!newValue) {
+      // Clear the form state value so validation passes
+      setValue('paperDecisionReceiver', null, { shouldDirty: true, shouldValidate: true });
+      clearErrors('paperDecisionReceiver');
+    } else {
+      // Restore the original value if the user toggles back on
+      setValue('paperDecisionReceiver', originalPaperDecisionReceiver, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    }
     setShowPaperDecision(newValue);
   }
 

--- a/src/domain/application/yupSchemas.ts
+++ b/src/domain/application/yupSchemas.ts
@@ -148,18 +148,19 @@ export const applicationTypeSchema = yup.mixed<ApplicationType>().defined().requ
 
 export const sendSchema = yup.object().shape({
   orderPaperDecision: yup.boolean().required(),
-  paperDecisionReceiver: yup.lazy((_value, context) => {
-    // Checking the value of `orderPaperDecision` from the context
-    if (context.parent.orderPaperDecision) {
-      return yup
-        .object({
-          name: yup.string().trim().max(100).required(),
-          streetAddress: yup.string().trim().max(100).required(),
-          postalCode: yup.string().trim().max(10).required(),
-          city: yup.string().trim().max(100).required(),
-        })
-        .required();
-    }
-    return yup.mixed().nullable();
-  }),
+  paperDecisionReceiver: yup
+    .object({
+      name: yup.string().trim().max(100).required(),
+      streetAddress: yup.string().trim().max(100).required(),
+      postalCode: yup.string().trim().max(10).required(),
+      city: yup.string().trim().max(100).required(),
+    })
+    .nullable()
+    .test('paperDecisionConditional', 'Paper decision fields are invalid', function (value) {
+      const { orderPaperDecision } = this.parent;
+      // If toggle is off, ignore the inner fields
+      if (!orderPaperDecision) return true;
+      // Otherwise, validate the object (returning true if it exists)
+      return !!value;
+    }),
 });


### PR DESCRIPTION
# Description

Fix bug with send dialog when the confirm button was disabled even when it should have been enabled.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3409

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Try sending with a kaivuilmoitus and set paper decision to true and fill the details and send it (test toggling too)
2. Create päätös for it in Allu
3. Create a muutosilmoitus for it and change some data so that it can be sent
4. Send dialog should now have the paper decision data filled as default
5. Toggling the button should work and confirmation button be enabled or disabled correctly even with cancelling and sending again

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
