### PR TITLE
HAI-2421 Fix checking whether johtoselvitys area contains work area

### DIFF
--- a/src/domain/kaivuilmoitus/components/TyoalueTable.tsx
+++ b/src/domain/kaivuilmoitus/components/TyoalueTable.tsx
@@ -22,11 +22,11 @@ import {
   Tyoalue,
 } from '../../application/types/application';
 import { booleanIntersects } from '@turf/boolean-intersects';
-import booleanContains from '@turf/boolean-contains';
 import useLinkPath from '../../../common/hooks/useLinkPath';
 import { ROUTES } from '../../../common/types/route';
 import Link from '../../../common/components/Link/Link';
 import { TFunction } from 'i18next';
+import { applicationGeometryContains } from '../../map/utils';
 
 type Props = {
   alueIndex: number;
@@ -124,7 +124,7 @@ export default function TyoalueTable({
             (alue.openlayersFeature!.getGeometry()! as OlPolygon).getCoordinates(),
           );
           const areaIntersects = booleanIntersects(applicationArea.geometry, alueGeometry);
-          const areaContains = booleanContains(applicationArea.geometry, alueGeometry);
+          const areaContains = applicationGeometryContains(applicationArea.geometry, alueGeometry);
           return areaIntersects && !areaContains;
         });
       }) || [];


### PR DESCRIPTION
# Description

When drawing kaivuilmoitus work areas a notification is shown if the work area is not fully contained inside a johtoselvitys area. This had a bug that checked only the work area geometry points and not the whole geometry including its sides. This PR fixes this bug using the same functionality as a previous fix where hanke area could not have been changed to be smaller than work areas inside it.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2421

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

This is how I tested this:
1. Create a hanke with similar geometry as in Jira ticket
2. Create a johtoselvitys for the hanke with similar area as in Jira ticket
3. Send johtoselvitys and create a päätös for it in Allu
4. Create a kaivuilmoitus for the hanke using the johtoselvitys
5. Try to draw a similar work area as in Jira ticket - now it should show notification where previously it did not

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
