### PR TITLE
HAI Add Allu trigger calls to E2E tests

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,6 +1,7 @@
 #haitatonurls
 TA_HAITATON_TESTING="http://localhost:3001/fi"
 TA_HAIT_TEST_HANKESALKKU="http://localhost:3001/fi/hankesalkku/"
+TA_ALLU_TRIGGER="http://localhost:3001/api/testdata/trigger-allu"
 #alluurls
 TA_ALLU_PW=
 TA_ALLU_TESTING=

--- a/e2e/_setup.ts
+++ b/e2e/_setup.ts
@@ -21,6 +21,7 @@ export const testiData: HaitatonTestData = {
   suomifilogin: process.env.TA_SUOMIFI_LOGIN ?? '',
   allupw: process.env.TA_ALLU_PW ?? '',
   hankesalkku: process.env.TA_HAIT_TEST_HANKESALKKU ?? '',
+  alluTriggerUrl: process.env.TA_ALLU_TRIGGER ?? '',
   tomorrowType: tommorowType,
 };
 
@@ -83,6 +84,7 @@ interface HaitatonTestData {
   suomifilogin: string;
   allupw: string;
   hankesalkku: string;
+  alluTriggerUrl: string;
   tomorrowType: string;
 }
 

--- a/e2e/johtoselvitys_ja_liite_hankkeelle.spec.ts
+++ b/e2e/johtoselvitys_ja_liite_hankkeelle.spec.ts
@@ -269,6 +269,7 @@ test('Johtoselvitys ja liite hankkeelle', async ({ page }) => {
   await page.getByRole('button', { name: 'PÄÄTÄ' }).click();
   await expect(page.getByRole('heading', { name: 'TYÖJONO' })).toBeVisible();
 
+  await page.goto(testiData.alluTriggerUrl);
   await expect(async () => {
     await page.goto(hakemusLinkki);
     await page.getByText('Hakemukset').click();

--- a/e2e/johtoselvitys_tilaus_taydennyspyynto.spec.ts
+++ b/e2e/johtoselvitys_tilaus_taydennyspyynto.spec.ts
@@ -180,6 +180,7 @@ test('Johtoselvityshakemus_tilaus_taydennyspyynto', async ({ page }) => {
     .getByText('Hakemus siirretty odottamaan täydennystä')
     .waitFor({ state: 'hidden', timeout: 10000 });
 
+  await page.goto(testiData.alluTriggerUrl);
   await expect(async () => {
     await page.goto(hakemusLinkki);
     await page.getByText('Hakemukset').click();
@@ -217,6 +218,7 @@ test('Johtoselvityshakemus_tilaus_taydennyspyynto', async ({ page }) => {
   await page.getByText('Lähetä täydennys').click();
   await page.getByText('Vahvista').click();
 
+  await page.goto(testiData.alluTriggerUrl);
   await expect(async () => {
     await page.goto(hakemusLinkki);
     await page.getByText('Hakemukset').click();
@@ -255,6 +257,7 @@ test('Johtoselvityshakemus_tilaus_taydennyspyynto', async ({ page }) => {
   await page.getByRole('button', { name: 'PÄÄTÄ' }).click();
   await expect(page.getByRole('heading', { name: 'TYÖJONO' })).toBeVisible();
 
+  await page.goto(testiData.alluTriggerUrl);
   await expect(async () => {
     await page.goto(hakemusLinkki);
     await page.getByText('Hakemukset').click();

--- a/e2e/kaivuilmoitus_taydennyspyynto.spec.ts
+++ b/e2e/kaivuilmoitus_taydennyspyynto.spec.ts
@@ -339,7 +339,9 @@ test('Kaivuilmoitus täydennyspyyntö', async ({ page }) => {
   await page.getByLabel('Selite *').click();
   await page.getByLabel('Selite *').fill('Testiautomaatio täydennyspyyntö');
   await page.getByRole('button', { name: 'LÄHETÄ PYYNTÖ' }).click();
+
   // Odotetaan tuloksia
+  await page.goto(testiData.alluTriggerUrl);
   await expect(async () => {
     await page.goto(`${testiData.hankesalkku}${hanketunnus}`);
     await page.getByText('Hakemukset').click();
@@ -417,6 +419,7 @@ test('Kaivuilmoitus täydennyspyyntö', async ({ page }) => {
   await expect(page.getByTestId('dialog-description-test')).not.toBeVisible({ timeout: 30000 });
 
   // täydennyspyynnöt suoritettu
+  await page.goto(testiData.alluTriggerUrl);
   await expect(async () => {
     await page.goto(`${testiData.hankesalkku}${hanketunnus}`);
     await page.getByText('Hakemukset').click();
@@ -476,6 +479,7 @@ test('Kaivuilmoitus täydennyspyyntö', async ({ page }) => {
   await expect(page.getByLabel('Hakemus päätetty')).toBeVisible();
 
   // tarkista haitattomasta
+  await page.goto(testiData.alluTriggerUrl);
   await expect(async () => {
     await page.goto(`${testiData.hankesalkku}${hanketunnus}`);
     await page.getByText('Hakemukset').click();
@@ -538,6 +542,7 @@ test('Kaivuilmoitus täydennyspyyntö', async ({ page }) => {
   await expect(page.getByText('TYÖJONO')).toBeVisible();
 
   // Odotetaan tuloksia "valmis"
+  await page.goto(testiData.alluTriggerUrl);
   await expect(async () => {
     await page.goto(`${testiData.hankesalkku}${hanketunnus}`);
     await page.getByText('Hakemukset').click();

--- a/e2e/kaivuilmoitus_toiminnallinen_kunto.spec.ts
+++ b/e2e/kaivuilmoitus_toiminnallinen_kunto.spec.ts
@@ -376,6 +376,7 @@ test('Kaivuilmoitus => toiminnallinen kunto ja valmis', async ({ page }) => {
   await page.getByRole('button', { name: 'HYVÄKSY' }).click();
 
   // Odotetaan tuloksia "toiminnallinen kunto"
+  await page.goto(testiData.alluTriggerUrl);
   await expect(async () => {
     await page.goto(`${testiData.hankesalkku}${hanketunnus}`);
     await page.getByText('Hakemukset').click();
@@ -424,6 +425,7 @@ test('Kaivuilmoitus => toiminnallinen kunto ja valmis', async ({ page }) => {
   await expect(page.getByText('VALMIS', { exact: true })).toBeVisible();
 
   // Odotetaan tuloksia "valmis"
+  await page.goto(testiData.alluTriggerUrl);
   await expect(async () => {
     await page.goto(`${testiData.hankesalkku}${hanketunnus}`);
     await page.getByText('Hakemukset').click();


### PR DESCRIPTION
# Description

Add calls to manually trigger Allu updates to E2E tests. The call will trigger Allu status updates instantly in the backend, so there's no need to wait up to 60 seconds for the next update. The trigger is available only in test environments, but we can't and don't want to run the e2e test against production.

I left the wait loops untouched, in case there's a delay in Allu having the status update in the status history.

### Jira Issue:

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Other

# Instructions for testing

Run the tests. One test was already failing for me, I didn't attempt to fix it.