### PR TITLE
HAI-137 Show completed status in hanke view

### DIFF
--- a/src/domain/hanke/components/HankeStatusTag.module.scss
+++ b/src/domain/hanke/components/HankeStatusTag.module.scss
@@ -1,0 +1,9 @@
+.hankeStatusTag {
+  display: flex;
+  align-items: center;
+}
+
+.bgGreen {
+  background-color: var(--color-success) !important;
+  color: var(--color-white) !important;
+}

--- a/src/domain/hanke/components/HankeStatusTag.test.tsx
+++ b/src/domain/hanke/components/HankeStatusTag.test.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { fireEvent, render, screen } from '../../../testUtils/render';
+import HankeStatusTag from './HankeStatusTag';
+import { HANKE_STATUS_KEY } from '../../types/hanke';
+
+test('Should show tag with default background (not have green background) when status is null', () => {
+  render(<HankeStatusTag status={null} />);
+  const tag = screen.getByTestId('hanke-status-tag');
+
+  expect(tag).toHaveTextContent('Luonnos');
+  expect(tag).not.toHaveClass('bgGreen');
+});
+
+test('Should show tag with default background (not have green background) when status is DRAFT', () => {
+  render(<HankeStatusTag status="DRAFT" />);
+  const tag = screen.getByTestId('hanke-status-tag');
+
+  expect(tag).not.toHaveClass('bgGreen');
+  expect(tag).toHaveTextContent('Luonnos');
+});
+
+test('Should show tag with green background when status is COMPLETED', () => {
+  render(<HankeStatusTag status="COMPLETED" />);
+  const tag = screen.getByTestId('hanke-status-tag');
+
+  expect(tag).toHaveClass('bgGreen');
+  expect(tag).toHaveTextContent('Valmis');
+});
+
+function TestComponent({ changedStatus }: { changedStatus: HANKE_STATUS_KEY }) {
+  const [status, setStatus] = useState<HANKE_STATUS_KEY | null>('DRAFT');
+
+  function changeStatus() {
+    setStatus(changedStatus);
+  }
+
+  return (
+    <>
+      <HankeStatusTag status={status} />
+      <button onClick={changeStatus}>Change status</button>
+    </>
+  );
+}
+
+test('Should change background color from default to green when status changes from DRAFT to COMPLETED', async () => {
+  render(<TestComponent changedStatus="COMPLETED" />);
+  const tag = screen.getByTestId('hanke-status-tag');
+  const button = screen.getByRole('button');
+
+  expect(tag).not.toHaveClass('bgGreen');
+
+  fireEvent.click(button);
+
+  expect(tag).toHaveClass('bgGreen');
+});

--- a/src/domain/hanke/components/HankeStatusTag.test.tsx
+++ b/src/domain/hanke/components/HankeStatusTag.test.tsx
@@ -27,7 +27,7 @@ test('Should show tag with green background when status is COMPLETED', () => {
   expect(tag).toHaveTextContent('Valmis');
 });
 
-function TestComponent({ changedStatus }: { changedStatus: HANKE_STATUS_KEY }) {
+function TestComponent({ changedStatus }: Readonly<{ changedStatus: HANKE_STATUS_KEY }>) {
   const [status, setStatus] = useState<HANKE_STATUS_KEY | null>('DRAFT');
 
   function changeStatus() {

--- a/src/domain/hanke/components/HankeStatusTag.tsx
+++ b/src/domain/hanke/components/HankeStatusTag.tsx
@@ -1,0 +1,46 @@
+import { IconAlertCircle, IconCheckCircle, Tag } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+import styles from './HankeStatusTag.module.scss';
+import { HANKE_STATUS_KEY } from '../../types/hanke';
+
+function HankeStatusTag({ status }: Readonly<{ status: HANKE_STATUS_KEY | null }>) {
+  const { t } = useTranslation();
+
+  if (status === 'PUBLIC') {
+    // Public status is not shown as a tag
+    return null;
+  }
+
+  const statusText = t(`hanke:status:${status}`);
+
+  let icon = null;
+  if (status === null || status === 'DRAFT') {
+    icon = <IconAlertCircle style={{ marginRight: 'var(--spacing-2-xs)' }} />;
+  }
+  if (status === 'COMPLETED') {
+    icon = <IconCheckCircle style={{ marginRight: 'var(--spacing-2-xs)' }} />;
+  }
+
+  /*
+   * Determine background color for status tag.
+   * Grey (default) background if there is no status or the status is DRAFT,
+   * green background with white text if status is completed hanke.
+   */
+  const bgGreen = status === 'COMPLETED';
+
+  return (
+    <Tag
+      className={clsx({
+        [styles.bgGreen]: bgGreen,
+      })}
+      data-testid="hanke-status-tag"
+    >
+      <div className={styles.hankeStatusTag}>
+        {icon} {statusText}
+      </div>
+    </Tag>
+  );
+}
+
+export default HankeStatusTag;

--- a/src/domain/hanke/hankeView/HankeView.test.tsx
+++ b/src/domain/hanke/hankeView/HankeView.test.tsx
@@ -31,6 +31,32 @@ test('Draft state notification is rendered when hanke is in draft state', async 
   expect(getByRole('listitem', { name: /yhteystiedot/i })).toBeInTheDocument();
 });
 
+test('Should show DRAFT state tag', async () => {
+  render(<HankeViewContainer hankeTunnus="HAI22-1" />);
+  await waitForLoadingToFinish();
+
+  const tag = screen.getByTestId('hanke-status-tag');
+
+  expect(tag).not.toHaveClass('bgGreen');
+  expect(tag).toHaveTextContent('Luonnos');
+});
+
+test('Should show duration', async () => {
+  render(<HankeViewContainer hankeTunnus="HAI22-1" />);
+  await waitForLoadingToFinish();
+
+  expect(screen.getByText('Hankkeen kesto:')).toBeInTheDocument();
+  expect(screen.getByText('26.11.2022 - 17.12.2022')).toBeInTheDocument();
+});
+
+test('Should show access rights', async () => {
+  render(<HankeViewContainer hankeTunnus="HAI22-1" />);
+  await waitForLoadingToFinish();
+
+  expect(screen.getByText('Käyttöoikeutesi hankkeelle:')).toBeInTheDocument();
+  expect(screen.getByText('Kaikki oikeudet')).toBeInTheDocument();
+});
+
 test('Draft state notification only shows form pages with missing information', async () => {
   render(<HankeViewContainer hankeTunnus="HAI22-4" />);
 
@@ -349,5 +375,15 @@ describe('Completed hanke', () => {
         'Hanketta ei voi enää muokata eikä sille voi lisätä hakemuksia. Hanke poistetaan aikaisintaan 16.4.2024, jolloin kaikki hankkeen ja sen hakemusten tiedot poistuvat Haitattomasta.',
       ),
     ).toBeInTheDocument();
+  });
+
+  test('Should show tag', async () => {
+    render(<HankeViewContainer hankeTunnus="HAI22-12" />);
+    await waitForLoadingToFinish();
+
+    const tag = screen.getByTestId('hanke-status-tag');
+
+    expect(tag).toHaveClass('bgGreen');
+    expect(tag).toHaveTextContent('Valmis');
   });
 });

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -350,7 +350,7 @@ const HankeView: React.FC<Props> = ({
 
       <InformationViewHeader backgroundColor="var(--color-summer-light)">
         <MainHeading>{hankeData?.nimi}</MainHeading>
-        <Flex style={{ marginBottom: 'var(--spacing-m)' }} gap="4">
+        <Flex marginBottom="var(--spacing-m)" gap="4">
           <Text tag="h2" styleAs="h3" weight="bold" data-testid="hanke-tunnus">
             {hankeData?.hankeTunnus}
           </Text>

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -60,6 +60,7 @@ import HaittaIndex from '../../common/haittaIndexes/HaittaIndex';
 import HaittaTooltipContent from '../../common/haittaIndexes/HaittaTooltipContent';
 import FormPagesErrorSummary from '../../forms/components/FormPagesErrorSummary';
 import { hankeSchema } from '../edit/hankeSchema';
+import HankeStatusTag from '../components/HankeStatusTag';
 
 type AreaProps = {
   area: HankeAlue;
@@ -307,7 +308,17 @@ const HankeView: React.FC<Props> = ({
 
   const areasTotalSurfaceArea = calculateTotalSurfaceArea(hankeData.alueet);
 
-  const { omistajat, rakennuttajat, toteuttajat, muut, alueet, status, deletionDate } = hankeData;
+  const {
+    omistajat,
+    rakennuttajat,
+    toteuttajat,
+    muut,
+    alueet,
+    status,
+    deletionDate,
+    alkuPvm,
+    loppuPvm,
+  } = hankeData;
   const isHankePublic = status === 'PUBLIC';
   const isHankeCompleted = status === 'COMPLETED';
   const isCancelPossible =
@@ -339,15 +350,26 @@ const HankeView: React.FC<Props> = ({
 
       <InformationViewHeader backgroundColor="var(--color-summer-light)">
         <MainHeading>{hankeData?.nimi}</MainHeading>
-        <Text tag="h2" styleAs="h3" weight="bold" spacingBottom="l" data-testid="hanke-tunnus">
-          {hankeData?.hankeTunnus}
-        </Text>
-        <Text tag="p" styleAs="body-s" spacingBottom="l">
-          <strong style={{ marginRight: 'var(--spacing-s)' }}>
-            {t('hankePortfolio:labels:oikeudet')}:
-          </strong>
-          {t(`hankeUsers:accessRightLevels:${signedInUser?.kayttooikeustaso}`)}
-        </Text>
+        <Flex style={{ marginBottom: 'var(--spacing-m)' }} gap="4">
+          <Text tag="h2" styleAs="h3" weight="bold" data-testid="hanke-tunnus">
+            {hankeData?.hankeTunnus}
+          </Text>
+          <HankeStatusTag status={status} />
+        </Flex>
+        <FormSummarySection>
+          <>
+            <SectionItemTitle>{t('hankePortfolio:labels:hankkeenKesto')}:</SectionItemTitle>
+            <SectionItemContent>
+              {`${formatToFinnishDate(alkuPvm) ?? ''} - ${formatToFinnishDate(loppuPvm) ?? ''}`}{' '}
+            </SectionItemContent>
+          </>
+          <>
+            <SectionItemTitle>{t('hankePortfolio:labels:oikeudet')}:</SectionItemTitle>
+            <SectionItemContent>
+              {t(`hankeUsers:accessRightLevels:${signedInUser?.kayttooikeustaso}`)}
+            </SectionItemContent>
+          </>
+        </FormSummarySection>
 
         <InformationViewHeaderButtons>
           <FeatureFlags flags={['hanke']}>
@@ -408,13 +430,15 @@ const HankeView: React.FC<Props> = ({
               generated={hankeData.generated}
               className={styles.stateNotification}
             />
-            <FormPagesErrorSummary
-              data={hankeData}
-              schema={hankeSchema}
-              validationContext={{ hanke: hankeData }}
-              notificationLabel={t('hankePortfolio:draftState:labels:insufficientPhases')}
-              testId="hankeDraftStateNotification"
-            />
+            {!isHankeCompleted && (
+              <FormPagesErrorSummary
+                data={hankeData}
+                schema={hankeSchema}
+                validationContext={{ hanke: hankeData }}
+                notificationLabel={t('hankePortfolio:draftState:labels:insufficientPhases')}
+                testId="hankeDraftStateNotification"
+              />
+            )}
             {isHankeCompleted && (
               <Notification
                 type="success"

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -580,6 +580,11 @@
           "TYO_VALMIS": "Lataa työ valmis (PDF)"
         }
       }
+    },
+    "status": {
+      "null": "$t(hanke:status:DRAFT)",
+      "DRAFT": "Luonnos",
+      "COMPLETED": "Valmis"
     }
   },
   "hankeForm": {


### PR DESCRIPTION
# Description

Show completed status tag in hanke view.
Also, show draft status tag and hanke duration (as in Figma).
Also, do not show draft status notification (with missing data) if hanke is completed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-137

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Have a hanke that is completed
2. Check hanke view for status tag
3. Check status tag for a draft hanke as well
4. Check that duration is shown in hanke view (if hanke is draft and has no start and end dates, there is just a dash (-))

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
