### PR TITLE
HAI-1149 Allow resending invitation for completed hanke

### DIFF
--- a/src/domain/hanke/accessRights/AccessRightsView.test.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.test.tsx
@@ -528,4 +528,20 @@ describe('Completed hanke', () => {
     expect(screen.queryByRole('img', { name: 'Poista käyttäjä' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Poista käyttäjä' })).not.toBeInTheDocument();
   });
+
+  test('Should show resending invitation button', async () => {
+    const { user } = render(<AccessRightsViewContainer hankeTunnus="HAI22-12" />);
+    await waitForLoadingToFinish();
+
+    const invitationMenus = await screen.findAllByRole('button', {
+      name: 'Käyttäjävalikko',
+    });
+    const invitationMenu = invitationMenus[0];
+    await user.click(invitationMenu);
+    expect(
+      await screen.findByRole('menuitem', {
+        name: 'Lähetä kutsulinkki uudelleen',
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/domain/hanke/accessRights/AccessRightsView.tsx
+++ b/src/domain/hanke/accessRights/AccessRightsView.tsx
@@ -309,9 +309,7 @@ function AccessRightsView({ hankeUsers, hankeTunnus, signedInUser, readonly }: R
             )}
           </button>
         ) : null}
-        {!readonly &&
-        !args.tunnistautunut &&
-        signedInUser?.kayttooikeudet.includes('RESEND_INVITATION') ? (
+        {!args.tunnistautunut && signedInUser?.kayttooikeudet.includes('RESEND_INVITATION') ? (
           <Menu>
             <MenuButton as="button">
               {isSending ? (

--- a/src/domain/mocks/data/users-data.json
+++ b/src/domain/mocks/data/users-data.json
@@ -164,5 +164,19 @@
     "tunnistautunut": true,
     "hankeTunnus": "HAI22-2",
     "kutsuttu": null
+  },
+  {
+    "id": "9c4002e4-db74-4aad-8b70-67210f3c5af6",
+    "sahkoposti": "teppo@test.com",
+    "etunimi": "Teppo",
+    "sukunimi": "Työmies",
+    "puhelinnumero": "0401234567",
+    "kayttooikeustaso": "KAIKKIEN_MUOKKAUS",
+    "roolit": [
+      "RAKENNUTTAJA"
+    ],
+    "tunnistautunut": false,
+    "hankeTunnus": "HAI22-12",
+    "kutsuttu": "2024-01-15T19:59:59.999Z"
   }
 ]


### PR DESCRIPTION
# Description

Allow resending invitation for completed hanke.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1149

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Have a completed hanke with some new contact persons (a completed hanke can be created by creating a hanke with dates in the past and setting in the backend `HankeCompletionScheduler.completeHankkeet()` to have annotation `@EventListener(ApplicationReadyEvent::class)` or by setting `haitaton.hanke.completions.cron = 0 * * * * *` in `application yml` or running the backend with `HAITATON_COMPLETIONS_CRON="0 * * * * *"`.
2. Check that you can resend the invitation to contact persons in user management of the hanke

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
