### PR TITLE
HAI-2493 Fix notification shown when kaivuilmoitus work area within johtoselvitys areas union

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@turf/helpers": "^7.1.0",
     "@turf/intersect": "^7.2.0",
     "@turf/kinks": "^7.1.0",
+    "@turf/union": "^7.2.0",
     "@types/geojson": "^7946.0.14",
     "@types/jest": "^29.5.12",
     "@types/node": "^22.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4588,6 +4588,17 @@
     "@types/geojson" "^7946.0.10"
     tslib "^2.6.2"
 
+"@turf/union@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/union/-/union-7.2.0.tgz#f396ca5c8a66c424a0e2d0664280ef3d16974dac"
+  integrity sha512-Xex/cfKSmH0RZRWSJl4RLlhSmEALVewywiEXcu0aIxNbuZGTcpNoI0h4oLFrE/fUd0iBGFg/EGLXRL3zTfpg6g==
+  dependencies:
+    "@turf/helpers" "^7.2.0"
+    "@turf/meta" "^7.2.0"
+    "@types/geojson" "^7946.0.10"
+    polyclip-ts "^0.16.8"
+    tslib "^2.8.1"
+
 "@types/aria-query@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.1.tgz#3286741fb8f1e1580ac28784add4c7a1d49bdfbc"


### PR DESCRIPTION
# Description

There was a problem that notification for kaivuilmoitus work area exceeding johtoselvitys area(s) was shown even if multiple johtoselvitys areas would cover the work area. Fixed that by checking if the work area is also within union of intersecting johtoselvitys areas.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-2493

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Try steps described in https://helsinkisolutionoffice.atlassian.net/browse/HAI-2493.

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
