### PR TITLE
Hai 2476 kaivuilmoitus geometria ylitys

### DIFF
--- a/src/domain/hanke/edit/utils.tsx
+++ b/src/domain/hanke/edit/utils.tsx
@@ -28,7 +28,6 @@ import {
 } from '../../application/types/application';
 import { isApplicationCancelled, isApplicationPending } from '../../application/utils';
 import { TFunction } from 'i18next';
-import booleanContains from '@turf/boolean-contains';
 import { feature } from '@turf/helpers';
 
 function mapToAreaDates(areas: HankeAlue[] | undefined, key: 'haittaAlkuPvm' | 'haittaLoppuPvm') {
@@ -244,14 +243,14 @@ export function getApplicationsInsideHankealue(
   const johtoselvitysApplicationInsideHankealue: HankkeenHakemus[] =
     johtoselvitysApplications.filter((hakemus) =>
       ((hakemus.applicationData.areas || []) as ApplicationArea[]).some(
-        (area) => area.geometry && booleanContains(hankeFeature, area.geometry),
+        (area) => area.geometry && featureContains(hankeFeature, feature(area.geometry)),
       ),
     );
   const kaivuilmoitusApplicationInsideHankealue: HankkeenHakemus[] =
     kaivuilmoitusApplications.filter((hakemus) =>
       ((hakemus.applicationData.areas || []) as KaivuilmoitusAlue[])
         .flatMap((area) => area.tyoalueet)
-        .some((area) => area.geometry && booleanContains(hankeFeature, area.geometry)),
+        .some((area) => area.geometry && featureContains(hankeFeature, feature(area.geometry))),
     );
   return [...johtoselvitysApplicationInsideHankealue, ...kaivuilmoitusApplicationInsideHankealue];
 }

--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -39,7 +39,7 @@ import Dropdown from '../../common/components/dropdown/Dropdown';
 import DropdownMultiselect from '../../common/components/dropdown/DropdownMultiselect';
 import TextArea from '../../common/components/textArea/TextArea';
 import DrawProvider from '../../common/components/map/modules/draw/DrawProvider';
-import { formatFeaturesToHankeGeoJSON, getTotalSurfaceArea } from '../map/utils';
+import { formatFeaturesToHankeGeoJSON, getTotalSurfaceArea, featureContains } from '../map/utils';
 import TyoalueTable from './components/TyoalueTable';
 import AreaSelectDialog from './components/AreaSelectDialog';
 import { getAreaDefaultName } from '../application/utils';
@@ -52,7 +52,6 @@ import HakemusLayer from '../map/components/Layers/HakemusLayer';
 import { OverlayProps } from '../../common/components/map/types';
 import { LIIKENNEHAITTA_STATUS } from '../common/utils/liikennehaittaindeksi';
 import useFieldArrayWithStateUpdate from '../../common/hooks/useFieldArrayWithStateUpdate';
-import { featureContains } from "../map/utils";
 
 function getEmptyArea(
   hankeData: HankeData,
@@ -289,18 +288,8 @@ export default function Areas({ hankeData, hankkeenHakemukset, originalHakemus }
       // If the new tyoalue is contained in exactly one hanke area, add it to that
       addTyoAlueToHankeArea(hankeAlueetContainingNewArea[0], feature);
     } else {
-      // check is the new tyoalue inside more than one hanke area
-      const allAreasContainFeature = hankeAlueetContainingNewArea.every((alue) => {
-        const hankeAlueFeature = alue.geometriat?.featureCollection.features[0];
-        return hankeAlueFeature && featureContains(hankeAlueFeature, newAreaPolygon);
-      });
-
-      if (allAreasContainFeature) {
-        // New työalue is contained in multiple hanke areas, open dialog for user to select one
-        setMultipleHankeAreaSpanningFeature(feature);
-      } else {
-        drawSource.removeFeature(feature);
-      }
+      // New työalue is contained in multiple hanke areas, open dialog for user to select one
+      setMultipleHankeAreaSpanningFeature(feature);
     }
   }
 

--- a/src/domain/map/utils.ts
+++ b/src/domain/map/utils.ts
@@ -147,13 +147,13 @@ export function getFeatureFromHankeGeometry(geometry: HankeGeometria) {
  * Equality is checked without properties.
  */
 export function featureContains(
-  feature1: GeoJSONFeature<GeoJSONPolygon>,
-  feature2: GeoJSONFeature<GeoJSONPolygon>,
+  outer: GeoJSONFeature<GeoJSONPolygon>,
+  inner: GeoJSONFeature<GeoJSONPolygon>,
 ): boolean {
-  const features: FeatureCollection<GeoJSONPolygon> = featureCollection([feature1, feature2]);
+  const features: FeatureCollection<GeoJSONPolygon> = featureCollection([outer, inner]);
   const intersected = intersect(features);
-  const feature2WithoutProperties: GeoJSONFeature<GeoJSONPolygon> = { ...feature2, properties: {} };
-  return (intersected && booleanEqual(intersected, feature2WithoutProperties)) || false;
+  const innerWithoutProperties: GeoJSONFeature<GeoJSONPolygon> = { ...inner, properties: {} };
+  return (intersected && booleanEqual(intersected, innerWithoutProperties)) || false;
 }
 
 export function applicationGeometryContains(

--- a/src/domain/map/utils/isFeatureWithinFeatures.ts
+++ b/src/domain/map/utils/isFeatureWithinFeatures.ts
@@ -3,6 +3,7 @@ import { Polygon } from 'ol/geom';
 import { Feature } from 'geojson';
 import booleanContains from '@turf/boolean-contains';
 import { polygon as turfPolygon } from '@turf/helpers';
+import { featureContains } from '../utils';
 
 /**
  * Check if feature is completely contained within any of the features given as second argument
@@ -11,8 +12,16 @@ export default function isFeatureWithinFeatures(featureToCheck: Feature, feature
   if (features.length === 0) {
     return false;
   }
+  const typeToCheck = featureToCheck.geometry.type;
+  const polygonToCheck =
+    typeToCheck === 'Polygon' ? turfPolygon(featureToCheck.geometry.coordinates) : undefined;
   return features.some((feature) => {
     const polygon = turfPolygon((feature.getGeometry() as Polygon).getCoordinates());
-    return booleanContains(polygon, featureToCheck);
+
+    if (typeToCheck === 'Polygon') {
+      return featureContains(polygon, polygonToCheck!);
+    } else {
+      return booleanContains(polygon, featureToCheck);
+    }
   });
 }


### PR DESCRIPTION
# Description

Work area is possible to draw so that the corner points are inside the hanke area but the boundary is outside of area. 
This change will check that the entire work area is inside the hanke area.

### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-2476
## Type of change

- [ ] Bug fix
- [ ] New feature
- [x ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
