### PR TITLE
HAI-3530 Add haittojenhallintasuunnitelma on hanke form summary page

### DIFF
--- a/src/domain/common/haittojenhallinta/utils.ts
+++ b/src/domain/common/haittojenhallinta/utils.ts
@@ -11,7 +11,7 @@ function getHaittaIndexValue(v: number | { indeksi: number }): number {
  * the result will be [[PYORALIIKENNE, 1.3], [AUTOLIIKENNE, 1.0], [LINJAAUTOLIIKENNE, 0.0], [RAITIOLIIKENNE, 0.0]].
  */
 export function sortedLiikenneHaittojenhallintatyyppi(
-  tormaystarkasteluTulos: HaittaIndexData | undefined,
+  tormaystarkasteluTulos: HaittaIndexData | undefined | null,
 ): [HAITTOJENHALLINTATYYPPI, number][] {
   const defaultOrder = Object.values(HAITTOJENHALLINTATYYPPI).filter(
     (type) => type !== HAITTOJENHALLINTATYYPPI.YLEINEN && type !== HAITTOJENHALLINTATYYPPI.MUUT,

--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -1067,6 +1067,39 @@ describe('Selecting user in user name search input', () => {
   });
 });
 
+describe('Summary page', () => {
+  test('Should show nuisance management summary', async () => {
+    const hanke = hankkeet[2] as HankeDataFormState;
+    const { user } = render(
+      <HankeForm formData={hanke} onIsDirtyChange={() => ({})} onFormClose={() => ({})}>
+        <></>
+      </HankeForm>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /yhteenveto/i }));
+    expect(await screen.findByText('Vaihe 6/6: Yhteenveto')).toBeInTheDocument();
+    expect(await screen.findAllByText('Haittojen hallinta')).toHaveLength(2);
+    expect(await screen.findAllByText('Hankealue 1')).toHaveLength(2);
+    expect(await screen.findByText('Toimet haittojen hallintaan')).toBeInTheDocument();
+    expect(await screen.findByText('Yleisten haittojen hallintasuunnitelma')).toBeInTheDocument();
+    expect(await screen.findByText('Pyöräliikenteen merkittävyys')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Pyöräliikenteelle koituvien haittojen hallintasuunnitelma'),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Autoliikenteen ruuhkautuminen')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Autoliikenteelle koituvien haittojen hallintasuunnitelma'),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Raitioliikenne')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Raitioliikenteelle koituvien haittojen hallintasuunnitelma'),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('Linja-autojen paikallisliikenne')).toBeInTheDocument();
+    expect(await screen.findByText('Muut haittojenhallintatoimet')).toBeInTheDocument();
+    expect(await screen.findByText('Muiden haittojen hallintasuunnitelma')).toBeInTheDocument();
+  });
+});
+
 describe('Yhteystieto ytunnus validation', () => {
   describe('Draft hanke', () => {
     test('Should be able to move to next page if ytunnus field is empty', async () => {

--- a/src/domain/hanke/edit/HankeFormSummary.tsx
+++ b/src/domain/hanke/edit/HankeFormSummary.tsx
@@ -15,6 +15,7 @@ import { calculateTotalSurfaceArea } from './utils';
 import AttachmentSummary from './components/AttachmentSummary';
 import useHankeAttachments from '../hankeAttachments/useHankeAttachments';
 import AlertBulletin from './components/AlertBulletin';
+import HaittojenhallintaSummary from './components/HaittojenhallintaSummary';
 
 type Props = {
   formData: HankeDataFormState;
@@ -42,7 +43,6 @@ const HankeFormSummary: React.FC<Props> = ({ formData }) => {
       <BasicInformationSummary formData={formData} />
 
       <SectionTitle>{t('form:labels:areas')}</SectionTitle>
-
       {formData.alueet !== undefined && formData.alueet?.length > 0 ? (
         <FormSummarySection>
           <SectionItemTitle>{t('hanke:alue:totalSurfaceArea')}</SectionItemTitle>
@@ -60,8 +60,16 @@ const HankeFormSummary: React.FC<Props> = ({ formData }) => {
         <AlertBulletin info={t('hankeForm:hankkeenYhteenvetoForm:dataNotFound')} />
       )}
 
-      <SectionTitle>{t('form:yhteystiedot:header')}</SectionTitle>
+      <SectionTitle>{t('form:headers:haittojenHallinta')}</SectionTitle>
+      {formData.alueet !== undefined && formData.alueet?.length > 0 ? (
+        <Box mb="var(--spacing-l)">
+          <HaittojenhallintaSummary hankealueet={formData.alueet} />
+        </Box>
+      ) : (
+        <AlertBulletin info={t('hankeForm:hankkeenYhteenvetoForm:dataNotFound')} />
+      )}
 
+      <SectionTitle>{t('form:yhteystiedot:header')}</SectionTitle>
       {contactAmount > 0 ? (
         <FormSummarySection>
           {formData.omistajat.length > 0 && (

--- a/src/domain/hanke/edit/components/HaittojenhallintaSummary.tsx
+++ b/src/domain/hanke/edit/components/HaittojenhallintaSummary.tsx
@@ -1,0 +1,26 @@
+import { Tab, TabList, TabPanel, Tabs } from 'hds-react';
+import { HankeAlue } from '../../../types/hanke';
+import { HaittojenhallintasuunnitelmaInfo } from './HaittojenhallintasuunnitelmaInfo';
+
+type Props = {
+  hankealueet: HankeAlue[];
+};
+
+export default function HaittojenhallintaSummary({ hankealueet }: Readonly<Props>) {
+  return (
+    <Tabs>
+      <TabList style={{ marginBottom: 'var(--spacing-m)' }}>
+        {hankealueet.map((alue) => {
+          return <Tab key={alue.id}>{alue.nimi}</Tab>;
+        })}
+      </TabList>
+      {hankealueet.map((alue) => {
+        return (
+          <TabPanel key={alue.id}>
+            <HaittojenhallintasuunnitelmaInfo key={alue.id} hankealue={alue} />
+          </TabPanel>
+        );
+      })}
+    </Tabs>
+  );
+}

--- a/src/domain/hanke/edit/components/HaittojenhallintasuunnitelmaInfo.module.scss
+++ b/src/domain/hanke/edit/components/HaittojenhallintasuunnitelmaInfo.module.scss
@@ -1,0 +1,3 @@
+.haittojenhallintaSection:nth-child(even) {
+  background-color: var(--color-black-5);
+}

--- a/src/domain/hanke/edit/components/HaittojenhallintasuunnitelmaInfo.tsx
+++ b/src/domain/hanke/edit/components/HaittojenhallintasuunnitelmaInfo.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { $enum } from 'ts-enum-util';
+import { sortedLiikenneHaittojenhallintatyyppi } from '../../../common/haittojenhallinta/utils';
+import {
+  FormSummarySection,
+  SectionItemContent,
+  SectionItemTitle,
+} from '../../../forms/components/FormSummarySection';
+import { Box, Grid, GridItem } from '@chakra-ui/react';
+import { HAITTOJENHALLINTATYYPPI } from '../../../common/haittojenhallinta/types';
+import { HankeAlue } from '../../../types/hanke';
+import HaittaIndex from '../../../common/haittaIndexes/HaittaIndex';
+import HaittaTooltipContent from '../../../common/haittaIndexes/HaittaTooltipContent';
+import styles from './HaittojenhallintasuunnitelmaInfo.module.scss';
+
+const haittojenhallintaTyypit = $enum(HAITTOJENHALLINTATYYPPI).getKeys();
+
+type LiikennehaitanHallintasuunnitelmaProps = {
+  tyyppi: HAITTOJENHALLINTATYYPPI;
+  indeksi: number;
+  hankealue: HankeAlue;
+};
+
+const LiikennehaitanHallintasuunnitelmaInfo: React.FC<LiikennehaitanHallintasuunnitelmaProps> = ({
+  tyyppi,
+  indeksi,
+  hankealue,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <FormSummarySection
+      padding="var(--spacing-s)"
+      marginBottom="var(--spacing-xs)"
+      className={styles.haittojenhallintaSection}
+    >
+      <SectionItemTitle>
+        {t(`hankeForm:haittojenHallintaForm:nuisanceType:${tyyppi}`)}
+      </SectionItemTitle>
+      <SectionItemContent>
+        <Grid templateColumns="9fr 1fr" gap="var(--spacing-xs)">
+          <GridItem>
+            <Box whiteSpace="pre-wrap" wordBreak="break-word">
+              {hankealue.haittojenhallintasuunnitelma?.[tyyppi] ?? ''}
+            </Box>
+          </GridItem>
+          <GridItem width="80px">
+            <HaittaIndex
+              index={indeksi}
+              label={t('hankeIndexes:haittaindeksi')}
+              tooltipContent={
+                <HaittaTooltipContent
+                  translationKey={`hankeIndexes:tooltips:${tyyppi}`}
+                  showHeading={false}
+                />
+              }
+              testId={`test-${tyyppi}`}
+            />
+          </GridItem>
+        </Grid>
+      </SectionItemContent>
+    </FormSummarySection>
+  );
+};
+
+type HaittojenHallintaProps = {
+  hankealue: HankeAlue;
+  visibleHaittojenhallintaTyypit?: HAITTOJENHALLINTATYYPPI[];
+};
+
+export const HaittojenhallintasuunnitelmaInfo: React.FC<HaittojenHallintaProps> = ({
+  hankealue,
+  visibleHaittojenhallintaTyypit = haittojenhallintaTyypit,
+}) => {
+  const { t } = useTranslation();
+  const tormaystarkasteluTulos = hankealue.tormaystarkasteluTulos;
+  const haittojenhallintatyypit = sortedLiikenneHaittojenhallintatyyppi(
+    tormaystarkasteluTulos,
+  ).filter(([haitta]) => visibleHaittojenhallintaTyypit.includes(haitta));
+
+  return (
+    <>
+      {visibleHaittojenhallintaTyypit.includes(HAITTOJENHALLINTATYYPPI.YLEINEN) && (
+        <FormSummarySection
+          padding="var(--spacing-s)"
+          marginBottom="var(--spacing-xs)"
+          className={styles.haittojenhallintaSection}
+        >
+          <SectionItemTitle>
+            {t('hankeForm:haittojenHallintaForm:nuisanceType:YLEINEN')}
+          </SectionItemTitle>
+          <SectionItemContent>
+            <Grid templateColumns="9fr 1fr" gap="var(--spacing-xs)">
+              <GridItem>
+                <Box whiteSpace="pre-wrap" wordBreak="break-word">
+                  {hankealue.haittojenhallintasuunnitelma?.YLEINEN ?? ''}
+                </Box>
+              </GridItem>
+              <GridItem width="80px"></GridItem>
+            </Grid>
+          </SectionItemContent>
+        </FormSummarySection>
+      )}
+      {haittojenhallintatyypit.map(([haitta, indeksi]) => {
+        return (
+          <LiikennehaitanHallintasuunnitelmaInfo
+            tyyppi={haitta}
+            indeksi={indeksi}
+            hankealue={hankealue}
+            key={haitta}
+          />
+        );
+      })}
+      {visibleHaittojenhallintaTyypit.includes(HAITTOJENHALLINTATYYPPI.MUUT) && (
+        <FormSummarySection
+          padding="var(--spacing-s)"
+          marginBottom="var(--spacing-xs)"
+          className={styles.haittojenhallintaSection}
+        >
+          <SectionItemTitle>
+            {t('hankeForm:haittojenHallintaForm:nuisanceType:MUUT')}
+          </SectionItemTitle>
+          <SectionItemContent>
+            <Grid templateColumns="9fr 1fr" gap="var(--spacing-xs)">
+              <GridItem>
+                <Box whiteSpace="pre-wrap" wordBreak="break-word">
+                  {hankealue.haittojenhallintasuunnitelma?.MUUT ?? ''}
+                </Box>
+              </GridItem>
+              <GridItem width="80px"></GridItem>
+            </Grid>
+          </SectionItemContent>
+        </FormSummarySection>
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
# Description

Add haittojenhallintasuunnitelma on hanke form summary page

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3530

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

1. Create hanke, add some areas and fill haittojenhallintasuunnitelma for them
2. Check the summary form page that it is according to specs

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
