### PR TITLE
HAI-1416: Modifying area selects the area and changes tab

### DIFF
--- a/src/domain/application/components/ApplicationMap.tsx
+++ b/src/domain/application/components/ApplicationMap.tsx
@@ -33,6 +33,7 @@ import { styleFunction } from '../../map/utils/geometryStyle';
 import { OverlayProps } from '../../../common/components/map/types';
 import AreaOverlay from '../../map/components/AreaOverlay/AreaOverlay';
 import FullScreenControl from '../../../common/components/map/controls/FullscreenControl';
+import useDrawContext from '../../../common/components/map/modules/draw/useDrawContext';
 
 type Props = {
   drawSource: VectorSource;
@@ -67,6 +68,10 @@ export default function ApplicationMap({
 
   const { mapTileLayers, toggleMapTileLayer } = useMapDataLayers();
   const ortoLayerOpacity = mapTileLayers.kantakartta.visible ? 0.5 : 1;
+
+  const {
+    actions: { setSelectedFeature },
+  } = useDrawContext();
 
   useEffect(() => {
     function handleAddFeature(e: VectorSourceEvent<FeatureLike>) {
@@ -182,9 +187,11 @@ export default function ApplicationMap({
       ) {
         // If mofified feature is going over hanke feature, revert back to original geometry
         modifiedFeature.setGeometry(originalFeature.getGeometry());
+      } else {
+        setSelectedFeature(modifiedFeature as Feature<Geometry>);
       }
     },
-    [hankeLayerFilter],
+    [hankeLayerFilter, setSelectedFeature],
   );
 
   function handleCopyArea(feature: Feature<Geometry>) {

--- a/src/domain/application/components/ApplicationMap.tsx
+++ b/src/domain/application/components/ApplicationMap.tsx
@@ -188,7 +188,7 @@ export default function ApplicationMap({
         // If mofified feature is going over hanke feature, revert back to original geometry
         modifiedFeature.setGeometry(originalFeature.getGeometry());
       } else {
-        setSelectedFeature(modifiedFeature as Feature<Geometry>);
+        setSelectedFeature(modifiedFeature);
       }
     },
     [hankeLayerFilter, setSelectedFeature],

--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -329,6 +329,8 @@ export default function Areas({ hankeData, hankkeenHakemukset, originalHakemus }
             changedTyoalue.tormaystarkasteluTulos = data;
             feature.set('liikennehaittaindeksi', data.liikennehaittaindeksi.indeksi);
             refreshHaittaIndexesChanged(changedApplicationArea);
+            const existingAreaIndex = wathcApplicationAreas.indexOf(changedApplicationArea);
+            setSelectedTabIndex(existingAreaIndex);
           },
         });
       }

--- a/src/domain/map/components/HankeDrawer/HankeDrawer.tsx
+++ b/src/domain/map/components/HankeDrawer/HankeDrawer.tsx
@@ -29,6 +29,7 @@ import { HankkeenHakemus } from '../../../application/types/application';
 import { ModifyEvent } from 'ol/interaction/Modify';
 import { getWorkAreasInsideHankealueFeature } from '../../../hanke/edit/utils';
 import FullScreenControl from '../../../../common/components/map/controls/FullscreenControl';
+import useDrawContext from '../../../../common/components/map/modules/draw/useDrawContext';
 
 type Props = {
   features: Array<Feature | undefined> | undefined;
@@ -56,6 +57,10 @@ const HankeDrawer: React.FC<React.PropsWithChildren<Props>> = ({
   const { mapTileLayers, toggleMapTileLayer, handleUpdateGeometryState } = useMapDataLayers();
   const ortoLayerOpacity = mapTileLayers.kantakartta.visible ? 0.5 : 1;
   const [drawSource] = useState<VectorSource>(existingDrawSource || new VectorSource());
+
+  const {
+    actions: { setSelectedFeature },
+  } = useDrawContext();
 
   // Draw existing features
   useEffect(() => {
@@ -128,9 +133,11 @@ const HankeDrawer: React.FC<React.PropsWithChildren<Props>> = ({
         // If original hankealue feature has different work area features than modified feature,
         // revert back to original geometry
         modifiedFeature.setGeometry(originalFeature.getGeometry());
+      } else {
+        setSelectedFeature(modifiedFeature as Feature<Geometry>);
       }
     },
-    [hankkeenHakemukset],
+    [hankkeenHakemukset, setSelectedFeature],
   );
 
   return (

--- a/src/domain/map/components/HankeDrawer/HankeDrawer.tsx
+++ b/src/domain/map/components/HankeDrawer/HankeDrawer.tsx
@@ -134,7 +134,7 @@ const HankeDrawer: React.FC<React.PropsWithChildren<Props>> = ({
         // revert back to original geometry
         modifiedFeature.setGeometry(originalFeature.getGeometry());
       } else {
-        setSelectedFeature(modifiedFeature as Feature<Geometry>);
+        setSelectedFeature(modifiedFeature);
       }
     },
     [hankkeenHakemukset, setSelectedFeature],


### PR DESCRIPTION
# Description

After area is selected or modified, area is selected and correct tab is activated. This adds calls to selecting the feature into modifyEnd handlers in both hanke and kaivuilmoitus form area pages.

### Jira Issue:

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

* In Hanke form: Have multiple areas. Click an area or change its geometry. Correct area tab is activated.
* In Kaivuilmoitus form. Place work area inside different hanke areas. Click a work area or change its geometry. Correct hanke area tab is activated and correct work area is selected in the list.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

