### PR TITLE
HAI-3470 Fixes in areas in kaivuilmoitus and johtoselvitys form summary pages

### DIFF
--- a/src/domain/application/applicationView/ApplicationView.tsx
+++ b/src/domain/application/applicationView/ApplicationView.tsx
@@ -202,13 +202,13 @@ function JohtoselvitysAreasInfo({
             })}
           </SectionItemContentAdded>
         )}
-        {areasRemoved && areasRemoved.length === tyoalueet.length && (
+        {areasRemoved && areasRemoved.length > 0 && (
           <SectionItemContentRemoved marginTop="var(--spacing-s)">
             {areasRemoved.map((area, index) => {
               return (
                 <AreaInformation
                   area={area}
-                  areaName={getAreaDefaultName(t, tyoalueet.indexOf(area), tyoalueet.length)}
+                  areaName={getAreaDefaultName(t, index, tyoalueet.length)}
                   key={index}
                 />
               );

--- a/src/domain/application/applicationView/Sidebar.test.tsx
+++ b/src/domain/application/applicationView/Sidebar.test.tsx
@@ -125,7 +125,7 @@ describe('Sidebar', () => {
         const { user } = setup(application);
 
         expect(screen.getByText('Täydennykset')).toBeInTheDocument();
-        await user.click(screen.getByText('Hankealue 2'));
+        await user.click(screen.getByText('Hankealue 1'));
         expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
         expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();
         expect(screen.getByText('Työalue 3 (62 m²)')).toBeInTheDocument();
@@ -163,7 +163,7 @@ describe('Sidebar', () => {
 
         expect(screen.getByText('Muutokset')).toBeInTheDocument();
 
-        await user.click(screen.getByText('Hankealue 2'));
+        await user.click(screen.getByText('Hankealue 1'));
 
         expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
         expect(screen.getByText('Työalue 2 (31 m²)')).toBeInTheDocument();

--- a/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.tsx
@@ -45,7 +45,7 @@ export default function JohtoselvitysAreaSummary({
     return null;
   }
 
-  const geometries: Geometry[] = getAreaGeometries(areasChanged);
+  const geometries: Geometry[] = getAreaGeometries(data.areas);
   const totalSurfaceArea = getTotalSurfaceArea(geometries);
 
   return (
@@ -78,42 +78,22 @@ export default function JohtoselvitysAreaSummary({
         )}
         {(areasChanged.length > 0 || areasRemoved.length > 0) && (
           <>
-            {areasChanged.length > 0 && (
-              <>
-                <SectionItemTitle>{t('form:labels:kokonaisAla')}</SectionItemTitle>
-                <SectionItemContent>
-                  <p>{totalSurfaceArea} m²</p>
-                </SectionItemContent>
-              </>
-            )}
+            <SectionItemTitle>{t('form:labels:kokonaisAla')}</SectionItemTitle>
+            <SectionItemContent>
+              <p>{totalSurfaceArea} m²</p>
+            </SectionItemContent>
             <SectionItemTitle>{t('form:labels:areas')}</SectionItemTitle>
             <SectionItemContent>
-              {taydennysAreas.map((area, index) => {
-                if (!muutokset.includes(`areas[${index}]`)) {
-                  return null;
-                }
-                return (
-                  <AreaInformation
-                    area={area}
-                    areaName={getAreaDefaultName(t, index, originalData.areas.length)}
-                    key={index}
-                  />
-                );
-              })}
-              {areasRemoved.length === originalData.areas.length && (
+              {areasChanged.length > 0 &&
+                areasChanged.map((area, index) => {
+                  const name = getAreaDefaultName(t, index, areasChanged.length);
+                  return <AreaInformation area={area} areaName={name} key={index} />;
+                })}
+              {areasRemoved.length > 0 && (
                 <SectionItemContentRemoved>
                   {areasRemoved.map((area, index) => {
-                    return (
-                      <AreaInformation
-                        area={area}
-                        areaName={getAreaDefaultName(
-                          t,
-                          originalData.areas.indexOf(area),
-                          originalData.areas.length,
-                        )}
-                        key={index}
-                      />
-                    );
+                    const name = getAreaDefaultName(t, index, areasRemoved.length);
+                    return <AreaInformation area={area} areaName={name} key={index} />;
                   })}
                 </SectionItemContentRemoved>
               )}

--- a/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.tsx
+++ b/src/domain/application/taydennys/components/summary/JohtoselvitysAreaSummary.tsx
@@ -87,13 +87,13 @@ export default function JohtoselvitysAreaSummary({
               {areasChanged.length > 0 &&
                 areasChanged.map((area, index) => {
                   const name = getAreaDefaultName(t, index, areasChanged.length);
-                  return <AreaInformation area={area} areaName={name} key={index} />;
+                  return <AreaInformation area={area} areaName={name} key={name} />;
                 })}
               {areasRemoved.length > 0 && (
                 <SectionItemContentRemoved>
                   {areasRemoved.map((area, index) => {
                     const name = getAreaDefaultName(t, index, areasRemoved.length);
-                    return <AreaInformation area={area} areaName={name} key={index} />;
+                    return <AreaInformation area={area} areaName={name} key={name} />;
                   })}
                 </SectionItemContentRemoved>
               )}

--- a/src/domain/application/taydennysAndMuutosilmoitusCommon/components/summary/KaivuilmoitusAreaSummary.test.tsx
+++ b/src/domain/application/taydennysAndMuutosilmoitusCommon/components/summary/KaivuilmoitusAreaSummary.test.tsx
@@ -62,6 +62,15 @@ describe('Kaivuilmoitus taydennys AreaSummary', () => {
               kaistahaittojenPituus: 'PITUUS_ALLE_10_METRIA',
               lisatiedot: 'Lorem ipsum',
             },
+            {
+              ...mockData.areas[0], // a "new" area
+              name: 'Hankealue 2',
+              tyoalueet: [
+                {
+                  ...mockData.areas[0].tyoalueet[0],
+                },
+              ],
+            },
           ],
         }}
         originalData={mockData}
@@ -77,14 +86,16 @@ describe('Kaivuilmoitus taydennys AreaSummary', () => {
           'areas[0].kaistahaitta',
           'areas[0].kaistahaittojenPituus',
           'areas[0].lisatiedot',
+          'areas[1]',
         ]}
       />,
     );
 
+    // changed area
     expect(
       screen.getByText(
         (_, element) =>
-          element?.tagName === 'P' && element?.textContent === 'Työalueet (Hankealue 2)',
+          element?.tagName === 'P' && element?.textContent === 'Työalueet (Hankealue 1)',
       ),
     ).toBeInTheDocument();
     expect(screen.getByText('Työalue 1 (159 m²)')).toBeInTheDocument();
@@ -102,6 +113,27 @@ describe('Kaivuilmoitus taydennys AreaSummary', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Kaistahaittojen pituus: Alle 10 m')).toBeInTheDocument();
     expect(screen.getByText('Lisätietoja alueesta: Lorem ipsum')).toBeInTheDocument();
+
+    // new area
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.tagName === 'P' && element?.textContent === 'Työalueet (Hankealue 2)',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Työalue (159 m²)')).toBeInTheDocument();
+    expect(screen.getByText('Pinta-ala: 159 m²')).toBeInTheDocument();
+    expect(screen.getByText('Katuosoite: Aidasmäentie 5')).toBeInTheDocument();
+    expect(screen.getByText('Työn tarkoitus: Vesi')).toBeInTheDocument();
+    expect(screen.getByText('Meluhaitta: Toistuva meluhaitta')).toBeInTheDocument();
+    expect(screen.getByText('Pölyhaitta: Jatkuva pölyhaitta')).toBeInTheDocument();
+    expect(screen.getByText('Tärinähaitta: Satunnainen tärinähaitta')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Autoliikenteen kaistahaitta: Yksi autokaista vähenee - ajosuunta vielä käytössä',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Kaistahaittojen pituus: 10-99 m')).toBeInTheDocument();
   });
 
   test('renders removed areas', () => {

--- a/src/domain/application/taydennysAndMuutosilmoitusCommon/components/summary/KaivuilmoitusAreaSummary.tsx
+++ b/src/domain/application/taydennysAndMuutosilmoitusCommon/components/summary/KaivuilmoitusAreaSummary.tsx
@@ -17,6 +17,47 @@ import { formatSurfaceArea, getTotalSurfaceArea } from '../../../../map/utils';
 import { getAreaDefaultName } from '../../../utils';
 import { isNewArea } from '../../utils';
 
+function getKaivuilmoitusAlueChanges(
+  kaivuilmoitusAlue: KaivuilmoitusAlue,
+  muutokset: string[],
+  index: number,
+) {
+  return {
+    ...kaivuilmoitusAlue,
+    katuosoite: muutokset.includes(`areas[${index}].katuosoite`)
+      ? kaivuilmoitusAlue.katuosoite
+      : undefined,
+    tyonTarkoitukset: muutokset.includes(`areas[${index}].tyonTarkoitukset`)
+      ? kaivuilmoitusAlue.tyonTarkoitukset
+      : undefined,
+    meluhaitta: muutokset.includes(`areas[${index}].meluhaitta`)
+      ? kaivuilmoitusAlue.meluhaitta
+      : undefined,
+    polyhaitta: muutokset.includes(`areas[${index}].polyhaitta`)
+      ? kaivuilmoitusAlue.polyhaitta
+      : undefined,
+    tarinahaitta: muutokset.includes(`areas[${index}].tarinahaitta`)
+      ? kaivuilmoitusAlue.tarinahaitta
+      : undefined,
+    kaistahaitta: muutokset.includes(`areas[${index}].kaistahaitta`)
+      ? kaivuilmoitusAlue.kaistahaitta
+      : undefined,
+    kaistahaittojenPituus: muutokset.includes(`areas[${index}].kaistahaittojenPituus`)
+      ? kaivuilmoitusAlue.kaistahaittojenPituus
+      : undefined,
+    lisatiedot: muutokset.includes(`areas[${index}].lisatiedot`)
+      ? kaivuilmoitusAlue.lisatiedot
+      : undefined,
+    // If there are changes to any work areas, include all work areas
+    tyoalueet:
+      kaivuilmoitusAlue.tyoalueet.filter((_, tyoalueIndex) => {
+        return muutokset.includes(`areas[${index}].tyoalueet[${tyoalueIndex}]`);
+      }).length > 0
+        ? kaivuilmoitusAlue.tyoalueet
+        : [],
+  };
+}
+
 function AreaDetail({ area }: Readonly<{ area: PartialExcept<KaivuilmoitusAlue, 'tyoalueet'> }>) {
   const { t } = useTranslation();
 
@@ -116,40 +157,7 @@ export default function KaivuilmoitusAreaSummary({
       if (isNewArea(index, muutokset)) {
         return kaivuilmoitusAlue;
       } else {
-        return {
-          ...kaivuilmoitusAlue,
-          katuosoite: muutokset.includes(`areas[${index}].katuosoite`)
-            ? kaivuilmoitusAlue.katuosoite
-            : undefined,
-          tyonTarkoitukset: muutokset.includes(`areas[${index}].tyonTarkoitukset`)
-            ? kaivuilmoitusAlue.tyonTarkoitukset
-            : undefined,
-          meluhaitta: muutokset.includes(`areas[${index}].meluhaitta`)
-            ? kaivuilmoitusAlue.meluhaitta
-            : undefined,
-          polyhaitta: muutokset.includes(`areas[${index}].polyhaitta`)
-            ? kaivuilmoitusAlue.polyhaitta
-            : undefined,
-          tarinahaitta: muutokset.includes(`areas[${index}].tarinahaitta`)
-            ? kaivuilmoitusAlue.tarinahaitta
-            : undefined,
-          kaistahaitta: muutokset.includes(`areas[${index}].kaistahaitta`)
-            ? kaivuilmoitusAlue.kaistahaitta
-            : undefined,
-          kaistahaittojenPituus: muutokset.includes(`areas[${index}].kaistahaittojenPituus`)
-            ? kaivuilmoitusAlue.kaistahaittojenPituus
-            : undefined,
-          lisatiedot: muutokset.includes(`areas[${index}].lisatiedot`)
-            ? kaivuilmoitusAlue.lisatiedot
-            : undefined,
-          // If there are changes to any work areas, include all work areas
-          tyoalueet:
-            kaivuilmoitusAlue.tyoalueet.filter((_, tyoalueIndex) => {
-              return muutokset.includes(`areas[${index}].tyoalueet[${tyoalueIndex}]`);
-            }).length > 0
-              ? kaivuilmoitusAlue.tyoalueet
-              : [],
-        };
+        return getKaivuilmoitusAlueChanges(kaivuilmoitusAlue, muutokset, index);
       }
     })
     .filter((_, index) => {

--- a/src/domain/application/taydennysAndMuutosilmoitusCommon/components/summary/KaivuilmoitusAreaSummary.tsx
+++ b/src/domain/application/taydennysAndMuutosilmoitusCommon/components/summary/KaivuilmoitusAreaSummary.tsx
@@ -15,6 +15,7 @@ import { formatToFinnishDate } from '../../../../../common/utils/date';
 import { getAreaGeometry } from '../../../../johtoselvitys/utils';
 import { formatSurfaceArea, getTotalSurfaceArea } from '../../../../map/utils';
 import { getAreaDefaultName } from '../../../utils';
+import { isNewArea } from '../../utils';
 
 function AreaDetail({ area }: Readonly<{ area: PartialExcept<KaivuilmoitusAlue, 'tyoalueet'> }>) {
   const { t } = useTranslation();
@@ -112,47 +113,49 @@ export default function KaivuilmoitusAreaSummary({
   const endTimeChanged = muutokset.includes('endTime');
   const changedAreas: PartialExcept<KaivuilmoitusAlue, 'tyoalueet'>[] = taydennysAreas
     .map((kaivuilmoitusAlue, index) => {
-      return {
-        ...kaivuilmoitusAlue,
-        katuosoite: muutokset.includes(`areas[${index}].katuosoite`)
-          ? kaivuilmoitusAlue.katuosoite
-          : undefined,
-        tyonTarkoitukset: muutokset.includes(`areas[${index}].tyonTarkoitukset`)
-          ? kaivuilmoitusAlue.tyonTarkoitukset
-          : undefined,
-        meluhaitta: muutokset.includes(`areas[${index}].meluhaitta`)
-          ? kaivuilmoitusAlue.meluhaitta
-          : undefined,
-        polyhaitta: muutokset.includes(`areas[${index}].polyhaitta`)
-          ? kaivuilmoitusAlue.polyhaitta
-          : undefined,
-        tarinahaitta: muutokset.includes(`areas[${index}].tarinahaitta`)
-          ? kaivuilmoitusAlue.tarinahaitta
-          : undefined,
-        kaistahaitta: muutokset.includes(`areas[${index}].kaistahaitta`)
-          ? kaivuilmoitusAlue.kaistahaitta
-          : undefined,
-        kaistahaittojenPituus: muutokset.includes(`areas[${index}].kaistahaittojenPituus`)
-          ? kaivuilmoitusAlue.kaistahaittojenPituus
-          : undefined,
-        lisatiedot: muutokset.includes(`areas[${index}].lisatiedot`)
-          ? kaivuilmoitusAlue.lisatiedot
-          : undefined,
-        // If there are changes to any work areas, include all work areas
-        tyoalueet:
-          kaivuilmoitusAlue.tyoalueet.filter((_, tyoalueIndex) => {
-            return muutokset.includes(`areas[${index}].tyoalueet[${tyoalueIndex}]`);
-          }).length > 0
-            ? kaivuilmoitusAlue.tyoalueet
-            : [],
-      };
+      if (isNewArea(index, muutokset)) {
+        return kaivuilmoitusAlue;
+      } else {
+        return {
+          ...kaivuilmoitusAlue,
+          katuosoite: muutokset.includes(`areas[${index}].katuosoite`)
+            ? kaivuilmoitusAlue.katuosoite
+            : undefined,
+          tyonTarkoitukset: muutokset.includes(`areas[${index}].tyonTarkoitukset`)
+            ? kaivuilmoitusAlue.tyonTarkoitukset
+            : undefined,
+          meluhaitta: muutokset.includes(`areas[${index}].meluhaitta`)
+            ? kaivuilmoitusAlue.meluhaitta
+            : undefined,
+          polyhaitta: muutokset.includes(`areas[${index}].polyhaitta`)
+            ? kaivuilmoitusAlue.polyhaitta
+            : undefined,
+          tarinahaitta: muutokset.includes(`areas[${index}].tarinahaitta`)
+            ? kaivuilmoitusAlue.tarinahaitta
+            : undefined,
+          kaistahaitta: muutokset.includes(`areas[${index}].kaistahaitta`)
+            ? kaivuilmoitusAlue.kaistahaitta
+            : undefined,
+          kaistahaittojenPituus: muutokset.includes(`areas[${index}].kaistahaittojenPituus`)
+            ? kaivuilmoitusAlue.kaistahaittojenPituus
+            : undefined,
+          lisatiedot: muutokset.includes(`areas[${index}].lisatiedot`)
+            ? kaivuilmoitusAlue.lisatiedot
+            : undefined,
+          // If there are changes to any work areas, include all work areas
+          tyoalueet:
+            kaivuilmoitusAlue.tyoalueet.filter((_, tyoalueIndex) => {
+              return muutokset.includes(`areas[${index}].tyoalueet[${tyoalueIndex}]`);
+            }).length > 0
+              ? kaivuilmoitusAlue.tyoalueet
+              : [],
+        };
+      }
     })
     .filter((_, index) => {
       return muutokset.includes(`areas[${index}]`);
     });
-
   const removedAreas = differenceBy(originalData.areas, taydennysAreas, 'hankealueId');
-
   if (
     changedAreas.length === 0 &&
     removedAreas.length === 0 &&
@@ -162,7 +165,7 @@ export default function KaivuilmoitusAreaSummary({
     return null;
   }
 
-  const geometries: Geometry[] = changedAreas
+  const geometries: Geometry[] = taydennysAreas
     .flatMap((area) => area.tyoalueet)
     .map((alue) => getAreaGeometry(alue));
   const totalSurfaceArea = getTotalSurfaceArea(geometries);

--- a/src/domain/application/taydennysAndMuutosilmoitusCommon/components/summary/KaivuilmoitusHaittojenhallintaSummary.test.tsx
+++ b/src/domain/application/taydennysAndMuutosilmoitusCommon/components/summary/KaivuilmoitusHaittojenhallintaSummary.test.tsx
@@ -17,7 +17,8 @@ describe('Kaivuilmoitus taydennys HaittojenhallintaSummary', () => {
     const { container } = render(
       <KaivuilmoitusHaittojenhallintaSummary
         hankealueet={testHanke.alueet!}
-        kaivuilmoitusAlueet={mockData.areas}
+        data={mockData}
+        originalData={mockData}
         muutokset={[]}
       />,
     );
@@ -29,15 +30,19 @@ describe('Kaivuilmoitus taydennys HaittojenhallintaSummary', () => {
     render(
       <KaivuilmoitusHaittojenhallintaSummary
         hankealueet={testHanke.alueet!}
-        kaivuilmoitusAlueet={[
-          {
-            ...mockData.areas[0],
-            haittojenhallintasuunnitelma: {
-              PYORALIIKENNE: 'Pyöräliikenteen haitat',
-              MUUT: 'Muut haitat',
+        data={{
+          ...mockData,
+          areas: [
+            {
+              ...mockData.areas[0],
+              haittojenhallintasuunnitelma: {
+                PYORALIIKENNE: 'Pyöräliikenteen haitat',
+                MUUT: 'Muut haitat',
+              },
             },
-          },
-        ]}
+          ],
+        }}
+        originalData={mockData}
         muutokset={[
           'areas[0].haittojenhallintasuunnitelma[PYORALIIKENNE]',
           'areas[0].haittojenhallintasuunnitelma[MUUT]',
@@ -45,7 +50,7 @@ describe('Kaivuilmoitus taydennys HaittojenhallintaSummary', () => {
       />,
     );
 
-    expect(screen.getByText('Työalueet (Hankealue 2)')).toBeInTheDocument();
+    expect(screen.getByText('Työalueet (Hankealue 1)')).toBeInTheDocument();
     expect(screen.getByText('Pyöräliikenteen merkittävyys')).toBeInTheDocument();
     expect(screen.getByText('Pyöräliikenteen haitat')).toBeInTheDocument();
     expect(screen.getByText('Muut haittojenhallintatoimet')).toBeInTheDocument();

--- a/src/domain/application/taydennysAndMuutosilmoitusCommon/utils.ts
+++ b/src/domain/application/taydennysAndMuutosilmoitusCommon/utils.ts
@@ -19,3 +19,16 @@ export function modifyHakemusAfterReceive(
     applicationData: kaivuilmoitusData,
   };
 }
+
+/**
+ * Function to check if the area is new i.e. if changes include `areas[${index}]` but not any subfields
+ *
+ * @param index - The index of the area
+ * @param muutokset - The list of changes
+ */
+export function isNewArea(index: number, muutokset: string[]) {
+  return (
+    muutokset.includes(`areas[${index}]`) &&
+    !muutokset.some((item) => item.startsWith(`areas[${index}].`))
+  );
+}

--- a/src/domain/johtoselvitys/components/AreaSummary.tsx
+++ b/src/domain/johtoselvitys/components/AreaSummary.tsx
@@ -41,7 +41,7 @@ const AreaSummary: React.FC<Props> = ({ formData }) => {
       <SectionItemContent>
         {areas.map((area, index) => {
           const name = getAreaDefaultName(t, index, areas.length);
-          return <AreaInformation area={area} areaName={name} key={index} />;
+          return <AreaInformation area={area} areaName={name} key={name} />;
         })}
       </SectionItemContent>
     </FormSummarySection>

--- a/src/domain/johtoselvitys/components/AreaSummary.tsx
+++ b/src/domain/johtoselvitys/components/AreaSummary.tsx
@@ -40,13 +40,8 @@ const AreaSummary: React.FC<Props> = ({ formData }) => {
       <SectionItemTitle>{t('form:labels:areas')}</SectionItemTitle>
       <SectionItemContent>
         {areas.map((area, index) => {
-          return (
-            <AreaInformation
-              area={area}
-              areaName={getAreaDefaultName(t, index, areas.length)}
-              key={index}
-            />
-          );
+          const name = getAreaDefaultName(t, index, areas.length);
+          return <AreaInformation area={area} areaName={name} key={index} />;
         })}
       </SectionItemContent>
     </FormSummarySection>

--- a/src/domain/johtoselvitys/utils.ts
+++ b/src/domain/johtoselvitys/utils.ts
@@ -12,12 +12,6 @@ import {
 } from '../application/types/application';
 import { JohtoselvitysArea, JohtoselvitysFormValues } from './types';
 import { JohtoselvitysTaydennysFormValues } from '../johtoselvitysTaydennys/types';
-import { HankeAlue } from '../types/hanke';
-import {
-  featureContainsApplicationGeometry,
-  getFeatureFromHankeGeometry,
-  olFeatureToGeoJSON,
-} from '../map/utils';
 
 export function getAreaGeometry(area: JohtoselvitysArea): Geometry {
   if (area.feature) {
@@ -98,44 +92,3 @@ export function convertApplicationDataToFormState(
 
   return data;
 }
-
-function getHankealueContainingJohtoselvitysArea(
-  johtoselvitysArea: JohtoselvitysArea,
-  hankeAreas: HankeAlue[],
-): HankeAlue | undefined {
-  return hankeAreas.find((area) => {
-    const olFeature = area.geometriat && getFeatureFromHankeGeometry(area.geometriat);
-    const geoJsonFeature = olFeatureToGeoJSON(olFeature);
-    return (
-      geoJsonFeature &&
-      featureContainsApplicationGeometry(geoJsonFeature, johtoselvitysArea.geometry)
-    );
-  });
-}
-
-/**
- * Get johtoselvitys areas grouped by hanke area. This can be used in places where johtoselvitys areas need to be grouped by the hanke area where they are located.
- *
- * @param applicationAreas
- * @param hankeAreas
- */
-export function getAreasGroupedByHankeArea(
-  applicationAreas: JohtoselvitysArea[],
-  hankeAreas: HankeAlue[],
-): Record<string, JohtoselvitysArea[]> {
-  const areasByHanke = {} as Record<string, JohtoselvitysArea[]>;
-  applicationAreas.forEach((area) => {
-    const hankeArea = getHankealueContainingJohtoselvitysArea(area, hankeAreas);
-    const id = hankeArea?.id?.toString();
-    if (id) {
-      if (!areasByHanke[id]) {
-        areasByHanke[id] = [];
-      }
-      areasByHanke[id].push(area);
-    }
-  });
-  return areasByHanke;
-}
-
-export const length = (rec: Record<string, ApplicationArea[]>) => Object.keys(rec).length;
-export const isEmpty = (rec: Record<string, ApplicationArea[]>) => length(rec) === 0;

--- a/src/domain/johtoselvitys/utils.ts
+++ b/src/domain/johtoselvitys/utils.ts
@@ -126,7 +126,7 @@ export function getAreasGroupedByHankeArea(
   const areasByHanke = {} as Record<string, JohtoselvitysArea[]>;
   applicationAreas.forEach((area) => {
     const hankeArea = getHankealueContainingJohtoselvitysArea(area, hankeAreas);
-    const id = hankeArea && hankeArea.id?.toString();
+    const id = hankeArea?.id?.toString();
     if (id) {
       if (!areasByHanke[id]) {
         areasByHanke[id] = [];

--- a/src/domain/kaivuilmoitusMuutosilmoitus/ReviewAndSend.tsx
+++ b/src/domain/kaivuilmoitusMuutosilmoitus/ReviewAndSend.tsx
@@ -66,7 +66,8 @@ export default function ReviewAndSend({
           />
           <HaittojenhallintaSummary
             hankealueet={hankealueet}
-            kaivuilmoitusAlueet={muutosilmoitus.applicationData.areas}
+            data={muutosilmoitus.applicationData}
+            originalData={originalApplication.applicationData}
             muutokset={muutosilmoitus.muutokset}
           />
           <ContactsSummary

--- a/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennys.test.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/KaivuilmoitusTaydennys.test.tsx
@@ -486,10 +486,10 @@ describe('Error notification', () => {
     expect(screen.getByRole('link', { name: /Työn alkupäivämäärä/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Työn loppupäivämäärä/i })).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: 'Työalueet (Hankealue 2): Katuosoite' }),
+      screen.getByRole('link', { name: 'Työalueet (Hankealue 1): Katuosoite' }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: 'Työalueet (Hankealue 2): Työn tarkoitus' }),
+      screen.getByRole('link', { name: 'Työalueet (Hankealue 1): Työn tarkoitus' }),
     ).toBeInTheDocument();
   });
 
@@ -521,12 +521,12 @@ describe('Error notification', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', {
-        name: 'Työalueet (Hankealue 2): Yleiset toimet työalueiden haittojen hallintaan',
+        name: 'Työalueet (Hankealue 1): Yleiset toimet työalueiden haittojen hallintaan',
       }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', {
-        name: 'Työalueet (Hankealue 2) Pyöräliikenteen merkittävyys: Toimet työalueiden haittojen hallintaan',
+        name: 'Työalueet (Hankealue 1) Pyöräliikenteen merkittävyys: Toimet työalueiden haittojen hallintaan',
       }),
     ).toBeInTheDocument();
   });

--- a/src/domain/kaivuilmoitusTaydennys/ReviewAndSend.tsx
+++ b/src/domain/kaivuilmoitusTaydennys/ReviewAndSend.tsx
@@ -68,7 +68,8 @@ export default function ReviewAndSend({
           />
           <TaydennysHaittojenhallintaSummary
             hankealueet={hankealueet}
-            kaivuilmoitusAlueet={taydennys.applicationData.areas}
+            data={taydennys.applicationData}
+            originalData={originalApplication.applicationData}
             muutokset={muutokset}
           />
           <TaydennysContactsSummary

--- a/src/domain/mocks/data/hakemukset-data.ts
+++ b/src/domain/mocks/data/hakemukset-data.ts
@@ -1667,8 +1667,8 @@ const hakemukset: Application[] = [
       placementContracts: ['SL1234567'],
       areas: [
         {
-          name: 'Hankealue 2',
-          hankealueId: 2,
+          name: 'Hankealue 1',
+          hankealueId: 1,
           tyoalueet: [
             {
               geometry: {


### PR DESCRIPTION
# Description

Show changes in kaivuilmoitus areas and haittojenhallintasuunnitelma in summary form page for täydennys and muutosilmoitus. Show changes in areas also in johtoselvitys täydennys.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3470

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Create first a täydennys for kaivuilmoitus and johtoselvityshakemus
2. Change areas (remove all from some hanke area and add new ones in hanke areas that didn't have any application areas) (and haittojenhallintasuunnitelma for kaivuilmoitus)
3. Check summary page
4. Create päätös and then muutosilmoitus for kaivuilmoitus
5. Again, make some changes in areas and haittojenhallintasuunnitelma
6. Check summary page

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
