### PR TITLE
HAI-3500 Prevent moving away from areas page in kaivuilmoitus form when there is self-intersecting work area

### DIFF
--- a/src/common/components/dropdown/DropdownMultiselect.tsx
+++ b/src/common/components/dropdown/DropdownMultiselect.tsx
@@ -38,6 +38,7 @@ function DropdownMultiselect<T>({
       name={name}
       control={control}
       rules={rules}
+      defaultValue={[]}
       render={({ field: { onChange, onBlur, value, ref }, fieldState: { error } }) => {
         return (
           <Select

--- a/src/common/components/map/controls/FullscreenControl.scss
+++ b/src/common/components/map/controls/FullscreenControl.scss
@@ -16,3 +16,8 @@
     outline: none;
   }
 }
+
+.full-screen-icon {
+  width: 20px !important;
+  height: 20px !important;
+}

--- a/src/common/components/map/controls/FullscreenControl.tsx
+++ b/src/common/components/map/controls/FullscreenControl.tsx
@@ -5,10 +5,10 @@ import MapContext from '../MapContext';
 import './FullscreenControl.scss';
 
 const labelElement = document.createElement('div');
-labelElement.className = 'hds-icon hds-icon--link-external';
+labelElement.className = 'hds-icon hds-icon--link-external full-screen-icon';
 
 const labelActiveElement = document.createElement('div');
-labelActiveElement.className = 'hds-icon hds-icon--collapse';
+labelActiveElement.className = 'hds-icon hds-icon--collapse full-screen-icon';
 
 const FullScreenControl = () => {
   const { map } = useContext(MapContext);

--- a/src/domain/forms/utils.ts
+++ b/src/domain/forms/utils.ts
@@ -25,7 +25,13 @@ export function changeFormStep<T extends FieldValues>(
       : fieldsToValidate.every((field) => {
           const message = get(errors, field)?.message as unknown as { key: string } | undefined;
           const errorKey = message?.key;
-          return !errorKey || errorsToIgnore.includes(errorKey);
+          if (!message) {
+            return true;
+          }
+          if (!errorKey) {
+            return false;
+          }
+          return errorsToIgnore.includes(errorKey);
         });
 
   if (ignoreErrors) {

--- a/src/domain/hanke/hooks/useHaittaIndexes.ts
+++ b/src/domain/hanke/hooks/useHaittaIndexes.ts
@@ -1,4 +1,5 @@
 import { useMutation } from 'react-query';
+import { Polygon } from 'ol/geom';
 import api from '../../api/api';
 import {
   HANKE_KAISTAHAITTA_KEY,
@@ -6,6 +7,7 @@ import {
   HankeGeometria,
 } from '../../types/hanke';
 import { HaittaIndexData } from '../../common/haittaIndexes/types';
+import { isPolygonSelfIntersecting } from '../../../common/components/map/utils';
 
 type HankeAlueData = {
   geometriat: HankeGeometria;
@@ -19,6 +21,12 @@ type HankeAlueData = {
  * Request haittaindeksit for hanke area
  */
 async function calculateHaittaIndexes(data: HankeAlueData) {
+  const polygonToCheck = new Polygon(
+    data.geometriat.featureCollection.features[0].geometry.coordinates,
+  );
+  if (isPolygonSelfIntersecting(polygonToCheck)) {
+    throw new Error('Self-intersecting polygon');
+  }
   const { data: response } = await api.post<HaittaIndexData>('/haittaindeksit', data);
   return response;
 }


### PR DESCRIPTION
# Description

Also do not request haitta indexes when there is self-intersecting area.

Fixed also icon not showing in fullscreen control in map.

### Jira Issue:

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Draw a self-intersecting work area in kaivuilmoitus form
2. Check that moving to another page in the form is prevented

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
