### PR TITLE
HAI-1688 Fix matomo script loading and cookie consent banner

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -31,6 +31,9 @@ http {
         set $DEFAULT_SRC "default-src 'self'";
         set $STYLE_SRC "style-src 'self'";
         set $STYLE_SRC "${STYLE_SRC} 'unsafe-inline'";
+        set $SCRIPT_SRC "script-src 'self'";
+        set $SCRIPT_SRC "${SCRIPT_SRC} https://matomo.hel.fi";
+        set $SCRIPT_SRC "${SCRIPT_SRC} 'unsafe-inline'";
         set $IMG_SRC "img-src 'self'";
         set $IMG_SRC "${IMG_SRC} https://kartta.hel.fi";
         set $IMG_SRC "${IMG_SRC} data:";
@@ -39,7 +42,7 @@ http {
         set $CONNECT_SRC "${CONNECT_SRC} ${LOGIN_SERVER}";
         set $CONNECT_SRC "${CONNECT_SRC} https://kartta.hel.fi";
         set $CONNECT_SRC "${CONNECT_SRC} https://matomo.hel.fi";
-        add_header Content-Security-Policy "${DEFAULT_SRC}; ${STYLE_SRC}; ${IMG_SRC}; ${CONNECT_SRC};" always;
+        add_header Content-Security-Policy "${DEFAULT_SRC}; ${STYLE_SRC}; ${SCRIPT_SRC}; ${IMG_SRC}; ${CONNECT_SRC};" always;
 
         location / {
             root        /usr/share/nginx/html;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -38,6 +38,7 @@ http {
         set $CONNECT_SRC "${CONNECT_SRC} https://o394401.ingest.sentry.io";
         set $CONNECT_SRC "${CONNECT_SRC} ${LOGIN_SERVER}";
         set $CONNECT_SRC "${CONNECT_SRC} https://kartta.hel.fi";
+        set $CONNECT_SRC "${CONNECT_SRC} https://matomo.hel.fi";
         add_header Content-Security-Policy "${DEFAULT_SRC}; ${STYLE_SRC}; ${IMG_SRC}; ${CONNECT_SRC};" always;
 
         location / {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -31,6 +31,7 @@ http {
         set $DEFAULT_SRC "default-src 'self'";
         set $STYLE_SRC "style-src 'self'";
         set $STYLE_SRC "${STYLE_SRC} 'unsafe-inline'";
+;       # script-src is needed for Matomo site traffic tracking and HDS 4 cookie consent component
         set $SCRIPT_SRC "script-src 'self'";
         set $SCRIPT_SRC "${SCRIPT_SRC} https://matomo.hel.fi";
         set $SCRIPT_SRC "${SCRIPT_SRC} 'unsafe-inline'";

--- a/public/scripts/init-matomo.js
+++ b/public/scripts/init-matomo.js
@@ -4,7 +4,7 @@ _paq.push(['setExcludedQueryParams', ['state', 'session_state', 'iss', 'code']])
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
 (function () {
-  var u = '//matomo.hel.fi/';
+  var u = 'https://matomo.hel.fi/';
   _paq.push(['setTrackerUrl', u + 'matomo.php']);
   _paq.push(['setSiteId', '78']);
   var d = document,

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,4 +1,0 @@
-interface Window {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _paq: [string, ...any[]][];
-}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,6 +62,8 @@ declare global {
   interface Window {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     _env_: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _paq: [string, ...any[]][];
   }
 }
 


### PR DESCRIPTION
# Description

Add into nginx Content-Security-Policy header hel.fi Matomo access.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-1688

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Run both the backend and the frontend with Docker Compose
2. Check that Cookie Consent banner works okay and there are no Content-Security-Policy errors in console.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
