### PR TITLE
HAI-3522 Fix problems with y-tunnus validation in hanke form

### DIFF
--- a/src/domain/hanke/edit/HankeForm.test.tsx
+++ b/src/domain/hanke/edit/HankeForm.test.tsx
@@ -1066,3 +1066,56 @@ describe('Selecting user in user name search input', () => {
     expect(screen.getByTestId('muut.0.puhelinnumero')).toHaveValue('0401234567');
   });
 });
+
+describe('Yhteystieto ytunnus validation', () => {
+  describe('Draft hanke', () => {
+    test('Should be able to move to next page if ytunnus field is empty', async () => {
+      const { user } = await setupYhteystiedotPage(<HankeFormContainer hankeTunnus="HAI22-1" />);
+      fireEvent.change(screen.getByLabelText(/y-tunnus/i), {
+        target: { value: '' },
+      });
+      await user.tab();
+      await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+      expect(await screen.findByText('Vaihe 5/6: Liitteet')).toBeInTheDocument();
+    });
+
+    test('Should not be able to move to next page if ytunnus is invalid', async () => {
+      const { user } = await setupYhteystiedotPage(<HankeFormContainer hankeTunnus="HAI22-1" />);
+      fireEvent.change(screen.getByLabelText(/y-tunnus/i), {
+        target: { value: '1234567-8' },
+      });
+      await user.tab();
+      await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+      expect(screen.getByText('Vaihe 4/6: Yhteystiedot')).toBeInTheDocument();
+      expect(screen.getByLabelText(/y-tunnus/i)).toHaveFocus();
+      expect(screen.getByText('Kentän arvo on virheellinen')).toBeInTheDocument();
+    });
+  });
+
+  describe('Public hanke', () => {
+    test('Should not be able to move to next page if ytunnus is empty or invalid', async () => {
+      const { user } = await setupYhteystiedotPage(<HankeFormContainer hankeTunnus="HAI22-3" />);
+      fireEvent.change(screen.getByLabelText(/y-tunnus/i), {
+        target: { value: '' },
+      });
+      await user.tab();
+      await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+      expect(screen.getByText('Vaihe 4/6: Yhteystiedot')).toBeInTheDocument();
+      expect(screen.getByLabelText(/y-tunnus/i)).toHaveFocus();
+      expect(screen.getByText('Kenttä on pakollinen')).toBeInTheDocument();
+
+      fireEvent.change(screen.getByLabelText(/y-tunnus/i), {
+        target: { value: '1234567-8' },
+      });
+      await user.tab();
+      await user.click(screen.getByRole('button', { name: /seuraava/i }));
+
+      expect(screen.getByText('Vaihe 4/6: Yhteystiedot')).toBeInTheDocument();
+      expect(screen.getByLabelText(/y-tunnus/i)).toHaveFocus();
+      expect(screen.getByText('Kentän arvo on virheellinen')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
+++ b/src/domain/hanke/edit/HankeFormYhteystiedot.tsx
@@ -63,6 +63,7 @@ const ContactFields: React.FC<
   const { t } = useTranslation();
   const { watch, setValue } = useFormContext();
   const selectedContactType = watch(`${contactType}.${index}.tyyppi`);
+  const registryKey = watch(`${contactType}.${index}.ytunnus`);
   const isPrivatePerson = selectedContactType === CONTACT_TYYPPI.YKSITYISHENKILO;
   const registryKeyInputDisabled = isPrivatePerson;
 
@@ -73,6 +74,13 @@ const ContactFields: React.FC<
       });
     }
   }, [registryKeyInputDisabled, contactType, index, setValue]);
+
+  useEffect(() => {
+    if (registryKey === '') {
+      // set the registry key to null when it is empty
+      setValue(`${contactType}.${index}.ytunnus`, null);
+    }
+  }, [contactType, index, registryKey, setValue]);
 
   function handleUserSelect(user: HankeUser) {
     setValue(`${contactType}.${index}.${CONTACT_FORMFIELD.EMAIL}`, user.sahkoposti, {


### PR DESCRIPTION
# Description

There was a problem that hanke in draft state could not be saved if y-tunnus was missing for yhteystieto. Also if y-tunnus was invalid it was not clear for the user what was wrong when trying to go to another form page as focus was not moved to invalid field and there was no error notification.

Fix this by triggering the validation through react-hook-form.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3522

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Have hanke that's in Draft state 
2. Go to hanke form "Yhteystiedot" page and leave "Y-tunnus" field empty for example for "Omistaja"
3. It should be possible to move forward (or backward) in the form
4. Go and edit "Y-tunnus" to be invalid value
5. Now it should not be possible to navigate to other pages of the form
6. For Public hanke it should not be possible to navigate to other pages from "Yhteystiedot" page if "Y-tunnus" is invalid or missing

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
