### PR TITLE
HAI-3472 Do not show link to full page map in hanke view and list

### DIFF
--- a/src/domain/application/applicationView/Sidebar.tsx
+++ b/src/domain/application/applicationView/Sidebar.tsx
@@ -158,7 +158,7 @@ function AreaTabs({
       <TabPanel>
         <Box mt="var(--spacing-s)">
           <Box mb="var(--spacing-s)">
-            <OwnHankeMapHeader hankeTunnus={hanke.hankeTunnus} showLink={false} />
+            <OwnHankeMapHeader hankeTunnus={hanke.hankeTunnus} />
             <OwnHankeMap hanke={hanke} tyoalueet={tyoalueet} />
           </Box>
           {applicationType === 'CABLE_REPORT' && (
@@ -239,7 +239,7 @@ export default function Sidebar({ hanke, application }: Readonly<SidebarProps>) 
   const hakemusContent = (
     <>
       <Box mb="var(--spacing-s)">
-        <OwnHankeMapHeader hankeTunnus={hanke.hankeTunnus} showLink={false} />
+        <OwnHankeMapHeader hankeTunnus={hanke.hankeTunnus} />
         <OwnHankeMap hanke={getHankeWithAlueetFilteredByDates(hanke)} tyoalueet={tyoalueet} />
       </Box>
       {applicationType === 'CABLE_REPORT' && (

--- a/src/domain/hanke/hankeView/HankeView.tsx
+++ b/src/domain/hanke/hankeView/HankeView.tsx
@@ -541,7 +541,7 @@ const HankeView: React.FC<Props> = ({
           </Tabs>
         </InformationViewMainContent>
         <InformationViewSidebar testId="hanke-map">
-          <OwnHankeMapHeader hankeTunnus={hankeData.hankeTunnus} showLink={alueet.length > 0} />
+          <OwnHankeMapHeader hankeTunnus={hankeData.hankeTunnus} />
           {alueet?.length > 0 ? (
             <>
               <OwnHankeMap hanke={hankeData} />

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -249,10 +249,7 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke, signedInUser, 
           </div>
           <div>
             <FeatureFlags flags={['hanke']}>
-              <OwnHankeMapHeader
-                hankeTunnus={hanke.hankeTunnus}
-                showLink={hanke.alueet?.length > 0}
-              />
+              <OwnHankeMapHeader hankeTunnus={hanke.hankeTunnus} />
               {hanke.alueet?.length > 0 && isOpen ? (
                 <div data-testid="hanke-map">
                   <OwnHankeMap hanke={hanke} />

--- a/src/domain/map/components/OwnHankeMap/OwnHankeMapHeader.tsx
+++ b/src/domain/map/components/OwnHankeMap/OwnHankeMapHeader.tsx
@@ -8,7 +8,7 @@ import styles from './OwnHankeMapHeader.module.scss';
 
 const OwnHankeMapHeader: React.FC<{ hankeTunnus: string; showLink?: boolean }> = ({
   hankeTunnus,
-  showLink = true,
+  showLink = false,
 }) => {
   const { t } = useTranslation();
   const getFullPageMapPath = useLinkPath(ROUTES.FULL_PAGE_MAP);


### PR DESCRIPTION
# Description

Do not show link to full page map in hanke view and list. The functionality still is in place but everywhere its use is set to `false`.

Other thing in Jira issue was to remove "Päätä hanke" button from hanke view. That is already implemented in https://github.com/City-of-Helsinki/haitaton-ui/pull/1149

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3472

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

# Instructions for testing

1. Check that there is no "Avaa kartta uuteen ikkunaan" links in hanke list or hanke view.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
