### PR TITLE
HAI-3557 Prevent editing hanke from list

### DIFF
--- a/src/domain/hanke/portfolio/HankePortfolio.test.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolio.test.tsx
@@ -158,13 +158,29 @@ describe('HankePortfolioComponent', () => {
     });
   });
 
+  test('Should not show edit link for completed hanke', async () => {
+    const completedHankkeet = hankeList.filter((hanke) => hanke.status == 'COMPLETED');
+    const hankeTunnusList = completedHankkeet.map((hanke) => hanke.hankeTunnus);
+    const signedUserData: SignedInUserByHanke = {
+      ...userDataByHanke(hankeTunnusList, AccessRightLevel.HANKEMUOKKAUS),
+    };
+
+    render(
+      <HankePortfolioComponent hankkeet={completedHankkeet} signedInUserByHanke={signedUserData} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('hankeEditLink')).toHaveLength(0);
+    });
+  });
+
   test('Should show draft state notification for hankkeet that are in draft state', async () => {
     render(<HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />);
 
     expect(screen.getAllByText('Luonnos')).toHaveLength(1);
   });
 
-  test('Should show completed state notification for hankkeet that are in draft state', async () => {
+  test('Should show completed state notification for hankkeet that are in completed state', async () => {
     render(<HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={{}} />);
 
     expect(screen.getAllByText('Valmis')).toHaveLength(1);

--- a/src/domain/hanke/portfolio/HankePortfolio.test.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolio.test.tsx
@@ -144,7 +144,7 @@ describe('HankePortfolioComponent', () => {
     window._env_ = OLD_ENV;
   });
 
-  test('Should render edit hanke links for hankkeet that user has edit rights', async () => {
+  test('Should show edit links for uncompleted hankkeet that user has edit rights', async () => {
     const hankeTunnusList = hankeList.map((hanke) => hanke.hankeTunnus);
     const signedUserData: SignedInUserByHanke = {
       ...userDataByHanke(hankeTunnusList),
@@ -154,7 +154,7 @@ describe('HankePortfolioComponent', () => {
     render(<HankePortfolioComponent hankkeet={hankeList} signedInUserByHanke={signedUserData} />);
 
     await waitFor(() => {
-      expect(screen.queryAllByTestId('hankeEditLink')).toHaveLength(2);
+      expect(screen.queryAllByTestId('hankeEditLink')).toHaveLength(1);
     });
   });
 

--- a/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
+++ b/src/domain/hanke/portfolio/HankePortfolioComponent.tsx
@@ -144,17 +144,19 @@ const CustomAccordion: React.FC<CustomAccordionProps> = ({ hanke, signedInUser, 
             </Link>
             <FeatureFlags flags={['hanke']}>
               <CheckRightsByUser requiredRight="EDIT" signedInUser={signedInUser}>
-                <Link
-                  to={getEditHankePath({ hankeTunnus: hanke.hankeTunnus })}
-                  aria-label={
-                    // eslint-disable-next-line
-                    t(`routes:${ROUTES.EDIT_HANKE}.meta.title`) +
-                    ` ${hanke.nimi} - ${hanke.hankeTunnus} `
-                  }
-                  data-testid="hankeEditLink"
-                >
-                  <IconPen aria-hidden />
-                </Link>
+                {hanke.status !== 'COMPLETED' ? (
+                  <Link
+                    to={getEditHankePath({ hankeTunnus: hanke.hankeTunnus })}
+                    aria-label={
+                      // eslint-disable-next-line
+                      t(`routes:${ROUTES.EDIT_HANKE}.meta.title`) +
+                      ` ${hanke.nimi} - ${hanke.hankeTunnus} `
+                    }
+                    data-testid="hankeEditLink"
+                  >
+                    <IconPen aria-hidden />
+                  </Link>
+                ) : null}
               </CheckRightsByUser>
             </FeatureFlags>
           </div>

--- a/src/pages/EditJohtoselvitysPage.test.tsx
+++ b/src/pages/EditJohtoselvitysPage.test.tsx
@@ -11,7 +11,8 @@ test('Should show dialog with button to navigate to application view when naviga
     '/fi/johtoselvityshakemus/2/muokkaa',
   );
 
-  await screen.findByText(/hakemus lähetetty/i);
+  expect(await screen.findByText(/hakemus lähetetty/i, {}, { timeout: 10000 })).toBeInTheDocument();
+
   await user.click(screen.getByText('Siirry hakemussivulle'));
 
   expect(window.location.pathname).toBe('/fi/hakemus/2');


### PR DESCRIPTION
# Description

Do not show hanke edit link in hanke list if hanke is completed.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3557

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

1. Have some completed hanke
2. Check that there is no edit link (pen) in hanke list for that hanke

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
