### PR TITLE
HAI-3504: Add missing breadcrumb

### DIFF
--- a/src/pages/staticPages/workInstructions/cards/Cards.tsx
+++ b/src/pages/staticPages/workInstructions/cards/Cards.tsx
@@ -1810,9 +1810,14 @@ const Card: React.FC = () => {
 
     const updateBreadcrumbs = () => {
       if (type === t('routes:CARD:additionalLevel')) {
-        setBreadcrumbs([BREADCRUMBS.cardsIndex, breadcrumb, BREADCRUMBS.additionalLevel]);
+        setBreadcrumbs([
+          BREADCRUMBS.tyoOhjeet,
+          BREADCRUMBS.cardsIndex,
+          breadcrumb,
+          BREADCRUMBS.additionalLevel,
+        ]);
       } else {
-        setBreadcrumbs([BREADCRUMBS.cardsIndex, breadcrumb]);
+        setBreadcrumbs([BREADCRUMBS.tyoOhjeet, BREADCRUMBS.cardsIndex, breadcrumb]);
       }
     };
 


### PR DESCRIPTION
# Description

Add missing breadcrumb from work instruction sub pages.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3503

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Work instructions breadcrumb visible in card pages.

# Checklist:

- [ ] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:
