### PR TITLE
nuisance end date removed

### DIFF
--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -199,6 +199,18 @@ export default function Areas({ hankeData, hankkeenHakemukset, originalHakemus }
           ta: Tyoalue,
           tyoalueIndex: number,
         ) => {
+          const startDate = applicationData.startTime;
+          const endDate = applicationData.endTime;
+
+          // prevent calculation if dates are empty
+          if (
+            !startDate ||
+            !endDate ||
+            isNaN(new Date(startDate).getTime()) ||
+            isNaN(new Date(endDate).getTime())
+          ) {
+            return;
+          }
           const request = {
             geometriat: {
               featureCollection: formatFeaturesToHankeGeoJSON([ta.openlayersFeature!]),


### PR DESCRIPTION
If end date of the nuisance is removed do not call calculateHaittaIndexesForTyoalue

# Description

calculateHaittaIndexesForTyoalue added prevent calculation if dates are empty

### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-3578
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
