### PR TITLE
Support HTML content in banner notifications

### DIFF
--- a/src/common/components/serviceNotifications/ServiceNotifications.tsx
+++ b/src/common/components/serviceNotifications/ServiceNotifications.tsx
@@ -89,7 +89,7 @@ function ServiceNotifications() {
           closeButtonLabelText={`${t('common:components:notification:closeButtonLabelText')}`}
           onClose={() => closeNotification(NotificationType.INFO)}
         >
-          {infoText}
+          <div dangerouslySetInnerHTML={{ __html: infoText }} />
         </Notification>
       )}
 
@@ -103,7 +103,7 @@ function ServiceNotifications() {
           closeButtonLabelText={`${t('common:components:notification:closeButtonLabelText')}`}
           onClose={() => closeNotification(NotificationType.WARNING)}
         >
-          {warningText}
+          <div dangerouslySetInnerHTML={{ __html: warningText }} />
         </Notification>
       )}
 
@@ -117,7 +117,7 @@ function ServiceNotifications() {
           closeButtonLabelText={`${t('common:components:notification:closeButtonLabelText')}`}
           onClose={() => closeNotification(NotificationType.ERROR)}
         >
-          {errorText}
+          <div dangerouslySetInnerHTML={{ __html: errorText }} />
         </Notification>
       )}
     </>


### PR DESCRIPTION
# Description

allow html formatting in banner text
for example putting a link in the banner.

dangerouslySetInnerHTML is used safely since the content comes from a trusted source.

### Jira Issue:

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ X] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
