### PR TITLE
HAI-3590 Fix default zoom level in public hanke map

### DIFF
--- a/src/domain/map/components/Layers/SimpleHankeLayer.tsx
+++ b/src/domain/map/components/Layers/SimpleHankeLayer.tsx
@@ -94,6 +94,7 @@ const performDataLoad = async (
   startDate: string,
   endDate: string,
   source: React.MutableRefObject<VectorSource>,
+  setFeatureCount: (count: number) => void,
 ) => {
   try {
     // Get grid cells for current viewport (increased limit for full coverage)
@@ -102,6 +103,7 @@ const performDataLoad = async (
     if (cells.length === 0) {
       console.warn('No grid cells generated - clearing map');
       source.current.clear();
+      setFeatureCount(0);
       return;
     }
 
@@ -118,15 +120,18 @@ const performDataLoad = async (
     // Update source with new features
     source.current.clear();
     source.current.addFeatures(allFeatures);
+    setFeatureCount(allFeatures.length);
   } catch (error) {
     console.error('Failed to load hanke data:', error);
     source.current.clear();
+    setFeatureCount(0);
   }
 };
 
 function SimpleHankeLayer({ startDate, endDate }: Props) {
   const source = useRef(new VectorSource());
   const [metadata, setMetadata] = useState<GridMetadata | null>(null);
+  const [featureCount, setFeatureCount] = useState(0);
   const bounds = useMapViewportBounds();
   const loadTimer = useRef<NodeJS.Timeout | null>(null);
 
@@ -157,7 +162,7 @@ function SimpleHankeLayer({ startDate, endDate }: Props) {
 
     // Debounce the loading
     loadTimer.current = setTimeout(async () => {
-      await performDataLoad(bounds, metadata, startDate, endDate, source);
+      await performDataLoad(bounds, metadata, startDate, endDate, source, setFeatureCount);
     }, 300); // 300ms debounce
   }, [metadata, startDate, endDate, bounds]);
 
@@ -177,6 +182,9 @@ function SimpleHankeLayer({ startDate, endDate }: Props) {
 
   return (
     <>
+      <div style={{ display: 'none' }} data-testid="countOfFilteredHankeAlueet">
+        {featureCount}
+      </div>
       <VectorLayer
         source={source.current}
         zIndex={1}


### PR DESCRIPTION
# Description

Use initial zoom level 8 for public hanke map. Also., removed unnecessary filtered hanke printout.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3590

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Open public hanke map and check that the Helsinki base map looks like this:
<img width="875" height="477" alt="image" src="https://github.com/user-attachments/assets/83487067-dd62-4250-9128-89e31bb30020" />
