### PR TITLE
Preventing false dates on workarea

### DIFF
--- a/src/common/components/datePicker/DatePicker.tsx
+++ b/src/common/components/datePicker/DatePicker.tsx
@@ -6,6 +6,7 @@ import { TooltipProps } from '../../types/tooltip';
 import { getInputErrorText } from '../../utils/form';
 import styles from './DatePicker.module.scss';
 import { convertFinnishDate, formatToFinnishDate, toEndOfDayUTCISO } from '../../utils/date';
+import { useGlobalNotification } from "../globalNotification/GlobalNotificationContext";
 
 type PropTypes = {
   name: string;
@@ -20,6 +21,8 @@ type PropTypes = {
   initialMonth?: Date;
   helperText?: string;
   onValueChange?: (value: string) => void;
+  hankeStartDate?: Date;
+  hankeEndDate?: Date;
 };
 
 const DatePicker: React.FC<React.PropsWithChildren<PropTypes>> = ({
@@ -34,15 +37,30 @@ const DatePicker: React.FC<React.PropsWithChildren<PropTypes>> = ({
   helperText,
   locale,
   onValueChange,
+  hankeStartDate,
+  hankeEndDate
 }) => {
-  const { t } = useTranslation();
-  const { control } = useFormContext();
+  const { t } = useTranslation(['form', 'hakemus', 'common', 'validations']);
+  const { control, setError, clearErrors, trigger, setValue } = useFormContext();
+  const { setNotification } = useGlobalNotification();
 
   return (
     <>
       <Controller
         name={name}
         control={control}
+        rules={{
+          required: required ? t('form:errors:required') : false,
+          validate: (value) => {
+            const date = new Date(value);
+            if (isNaN(date.getTime())) return t('form:validations:invalidDate');
+            if (minDate && date < minDate) return t('form:errors:dateTooEarly');
+            if (maxDate && date > maxDate) return t('form:errors:dateTooLate');
+            if (hankeStartDate && date < hankeStartDate) return t('form:validations:dateBeforeProjectDate');
+            if (hankeEndDate && date > hankeEndDate) return t('form:validations:dateFutureProjectDate');
+            return true;
+          }
+        }}
         render={({ field: { onChange, onBlur, value, ref }, fieldState: { error } }) => (
           <div className={styles.datePicker}>
             <div className={styles.tooltip}>
@@ -68,10 +86,59 @@ const DatePicker: React.FC<React.PropsWithChildren<PropTypes>> = ({
                 helperText={helperText}
                 errorText={getInputErrorText(t, error)}
                 ref={ref}
-                onBlur={onBlur}
+                onBlur={(e) => {
+                  const rawValue = e.target.value;
+                  const [day, month, year] = rawValue.split('.');
+                  const parsedDate = new Date(`${year}-${month}-${day}`);
+                  if (isNaN(parsedDate.getTime())) {
+                    setError(name, { type: 'manual', message: 'invalidDate' });
+                    return;
+                  }
+                  if (hankeStartDate && parsedDate < hankeStartDate) {
+                    setError(name, {
+                      type: 'manual',
+                      message: t('dateBeforeProjectDate'),
+                    });
+                    setValue(name, '');
+                    setNotification(true, {
+                      position: 'top-right',
+                      dismissible: true,
+                      autoClose: true,
+                      autoCloseDuration: 5000,
+                      label: t('hakemus:notifications:dateBeforeProjectDateLabel'),
+                      message: t('hakemus:notifications:dateBeforeProjectDateText', { date: formatToFinnishDate(hankeStartDate)}),
+                      type: 'error',
+                      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+                    });
+                    return;
+                  }
+
+                  if (hankeEndDate && parsedDate > hankeEndDate) {
+                    setError(name, {
+                      type: 'manual',
+                      message: t('dateFutureProjectDate'),
+                    });
+                    setValue(name, '');
+                    setNotification(true, {
+                      position: 'top-right',
+                      dismissible: true,
+                      autoClose: true,
+                      autoCloseDuration: 5000,
+                      label: t('hakemus:notifications:dateFutureProjectDateLabel'),
+                      message: t('hakemus:notifications:dateFutureProjectDateText', { date: formatToFinnishDate(hankeEndDate)}),
+                      type: 'error',
+                      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+                    });
+                    return;
+                  }
+                  clearErrors(name);
+                  trigger(name);
+                  onBlur();
+                }}
                 onChange={(date) => {
                   const convertedDateString = convertFinnishDate(date);
                   onChange(toEndOfDayUTCISO(new Date(convertedDateString)));
+                  clearErrors(name);
                   onValueChange && onValueChange(date);
                 }}
                 crossOrigin=""

--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -377,14 +377,14 @@ export default function Areas({ hankeData, hankkeenHakemukset, originalHakemus }
   function handleStartTimeChange() {
     // Trigger validation for startTime field
     trigger('applicationData.startTime').then(() => {
-      refreshHaittaIndexes();
+        refreshHaittaIndexes();
     });
   }
 
   function handleEndTimeChange() {
     // Trigger validation for endTime field
     trigger('applicationData.endTime').then(() => {
-      refreshHaittaIndexes();
+        refreshHaittaIndexes();
     });
   }
 
@@ -432,25 +432,29 @@ export default function Areas({ hankeData, hankkeenHakemukset, originalHakemus }
           <ResponsiveGrid>
             <DatePicker
               name="applicationData.startTime"
-              label={t('kaivuilmoitusForm:alueet:startDate')}
-              locale={locale}
-              required
+                  label={t('kaivuilmoitusForm:alueet:startDate')}
+                  locale={locale}
+                  required
               minDate={minStartDate}
               maxDate={maxDate}
-              initialMonth={minStartDate}
+                  initialMonth={minStartDate}
               helperText={t('form:helperTexts:dateInForm')}
               onValueChange={handleStartTimeChange}
+              hankeStartDate={hankeData.alkuPvm ? new Date(hankeData.alkuPvm) : undefined}
+              hankeEndDate={hankeData.loppuPvm ? new Date(hankeData.loppuPvm) : undefined}
             />
             <DatePicker
               name="applicationData.endTime"
-              label={t('kaivuilmoitusForm:alueet:endDate')}
-              locale={locale}
-              required
+                  label={t('kaivuilmoitusForm:alueet:endDate')}
+                  locale={locale}
+                  required
               minDate={minEndDate}
               maxDate={maxDate}
-              initialMonth={minEndDate}
+                  initialMonth={minEndDate}
               helperText={t('form:helperTexts:dateInForm')}
               onValueChange={handleEndTimeChange}
+              hankeStartDate={hankeData.alkuPvm ? new Date(hankeData.alkuPvm) : undefined}
+              hankeEndDate={hankeData.loppuPvm ? new Date(hankeData.loppuPvm) : undefined}
             />
           </ResponsiveGrid>
         </Fieldset>

--- a/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusContainer.tsx
@@ -242,7 +242,11 @@ export default function KaivuilmoitusContainer({ hankeData, application }: Reado
     // Basic information page
     ['applicationData.name'],
     // Areas page
-    ['selfIntersectingPolygon'],
+    [
+      'applicationData.startTime',
+      'applicationData.endTime',
+      'selfIntersectingPolygon'
+    ],
     // Haittojenhallinta page
     [],
     // Contacts page

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -123,7 +123,10 @@
       "emailAlreadyUsedInUserManagement": "Valitsemasi sähköpostiosoite löytyy jo toiselta käyttäjältä.",
       "dateBeforeStart": "Päivämäärä ei voi olla ennen hakemuksen töiden alkamispäivää ({{startDate}})",
       "dateInFuture": "Päivämäärä ei voi olla tulevaisuudessa",
-      "dateConflictWithWorkAreas": "Tällä hankealueella on jo hakemusten kautta lisättyjä työalueita. Et voi lyhentää hankealueen ajankohtaa lyhyemmäksi kuin työalueiden ajankohdat."
+      "dateConflictWithWorkAreas": "Tällä hankealueella on jo hakemusten kautta lisättyjä työalueita. Et voi lyhentää hankealueen ajankohtaa lyhyemmäksi kuin työalueiden ajankohdat.",
+      "invalidDate": "Virheellinen päivämäärä.",
+      "dateBeforeProjectDate": "Päivämäärä ei voi olla ennen hankkeen alkamista.",
+      "dateFutureProjectDate": "Päivämäärä ei voi olla hankkeen loppumisen jälkeen."
     },
     "errors": {
       "areaRequired": "Vähintään yksi alue vaaditaan",
@@ -1321,7 +1324,11 @@
       "reportOperationalConditionSuccessText": "Ilmoitus toiminnallisesta kunnosta on lähetetty hyväksyttäväksi.",
       "reportWorkFinishedSuccessText": "Ilmoitus valmistumisesta on lähetetty hyväksyttäväksi.",
       "reportCompletionDateErrorLabel": "Ilmoituksen lähettäminen epäonnistui",
-      "reportCompletionDateErrorText": "<0>Lähettämisessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>"
+      "reportCompletionDateErrorText": "<0>Lähettämisessä tapahtui virhe. Yritä myöhemmin uudelleen tai ota yhteyttä Haitattoman tekniseen tukeen sähköpostiosoitteessa <1>haitatontuki@hel.fi</1>.</0>",
+      "dateBeforeProjectDateLabel": "Virheellinen päivämäärä",
+      "dateBeforeProjectDateText": "Päivämäärä ei voi olla ennen hankkeen alkamista {{date}}",
+      "dateFutureProjectDateLabel": "Virheellinen päivämäärä",
+      "dateFutureProjectDateText": "Päivämäärä ei voi olla hankkeen loppumisen jälkeen {{date}}"
     },
     "sendDialog": {
       "title": "Lähetä hakemus?",


### PR DESCRIPTION
# Description

If you enter a date that is too early in the start date field, the field will be cleared and an error message will tell what the earliest possible date is.

The same function is used for the end date.

When the date field is cleared, you will not be able to proceed on the page, meaning the excavation report will not be saved.

### Jira Issue:

## Type of change

- [X ] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
