### PR TITLE
HAI-3567 Fix translations and error->alert on out of area alert

### DIFF
--- a/src/common/components/map/modules/draw/DrawInteraction.tsx
+++ b/src/common/components/map/modules/draw/DrawInteraction.tsx
@@ -156,7 +156,7 @@ export default function DrawInteraction({
                 autoCloseDuration: 5000,
                 label: t('map:notifications:drawingOutsideHankeAreaLabel'),
                 message: t('map:notifications:drawingOutsideHankeAreaText'),
-                type: 'error',
+                type: 'alert',
                 closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
               });
               return;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1898,8 +1898,8 @@
     "drawPolygonButtonAria": "Draw a polygon on the map",
     "notifications": {
       "selfIntersectingLabel": "Invalid Geometry",
-      "selfIntersectingText": "The polygon cannot intersect with itself. Changes have been reverted.",
-      "drawingOutsideHankeAreaLabel": "Drawing Prevented",
+      "selfIntersectingText": "The polygon cannot intersect with itself. Changes have been cancelled.",
+      "drawingOutsideHankeAreaLabel": "Drawing Blocked",
       "drawingOutsideHankeAreaText": "Drawing outside the project area is not allowed."
     }
   },

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -1898,8 +1898,8 @@
     "drawPolygonButtonAria": "Rita en polygon på kartan",
     "notifications": {
       "selfIntersectingLabel": "Felaktig geometri",
-      "selfIntersectingText": "Monopolyt kan inte skära sig själv. Ändringarna har återkallats.",
-      "drawingOutsideHankeAreaLabel": "Ritning förhindrad",
+      "selfIntersectingText": "Polygonen kan inte skära sig själv. Ändringarna har dragits tillbaka.",
+      "drawingOutsideHankeAreaLabel": "Ritning blockerad",
       "drawingOutsideHankeAreaText": "Ritning utanför projektområdet är inte tillåten."
     }
   },


### PR DESCRIPTION
# Description

Fix translations
Use alert instead of error in intersection

### Jira Issue:
HAI-3567

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
