### PR TITLE
HAI-3541 Log out when the backend has logged out

### DIFF
--- a/TESTING_SESSION_TERMINATION.md
+++ b/TESTING_SESSION_TERMINATION.md
@@ -14,10 +14,11 @@ npm test api.test.ts
 These tests cover:
 
 - SessionTerminationHandler component behavior
-- API interceptor error detection
+- API interceptor error detection using MSW
 - Logout handler setup and cleanup
-- Notification display
-- Error code detection (HAI0006, HAI4008)
+- Notification display and timing (4-second delay)
+- Error code detection (HAI0006, HAI4008) using Set-based lookup
+- Proper error handling in catch blocks
 
 ## Manual Testing Approaches
 
@@ -159,4 +160,8 @@ When testing, you should observe:
 - **Notification doesn't appear**: Check that SessionTerminationHandler is properly mounted within GlobalNotificationProvider
 - **Logout doesn't occur**: Verify that the OIDC client is available and logout handler is set
 - **Wrong language**: Check the i18n configuration and language setting
-- **Tests fail**: Ensure all mocks are properly set up and timing is handled correctly with fake timers
+- **Tests fail**:
+  - Ensure all mocks are properly set up and timing is handled correctly with fake timers
+  - Verify MSW server uses the global test-server setup (not a separate server instance)
+  - Check that error codes are being detected using the Set-based lookup
+  - Ensure catch blocks properly validate expected errors with assertions

--- a/TESTING_SESSION_TERMINATION.md
+++ b/TESTING_SESSION_TERMINATION.md
@@ -1,0 +1,162 @@
+# Testing Session Termination Functionality
+
+This document describes how to test the automatic logout functionality for session termination errors.
+
+## Unit Tests
+
+Run the unit tests to verify the functionality:
+
+```bash
+npm test SessionTerminationHandler.test.tsx
+npm test api.test.ts
+```
+
+These tests cover:
+
+- SessionTerminationHandler component behavior
+- API interceptor error detection
+- Logout handler setup and cleanup
+- Notification display
+- Error code detection (HAI0006, HAI4008)
+
+## Manual Testing Approaches
+
+### 1. Browser DevTools Method (Recommended)
+
+1. **Open the application** and log in
+2. **Open DevTools** (F12) → Go to **Network** tab
+3. **Find any API request** to `/api/*` endpoint
+4. **Right-click** on the request → **Copy as curl**
+5. **Modify the curl command** to return a 401 with session termination error:
+
+```bash
+# For HAI0006 (Session terminated)
+curl -X GET 'http://localhost:3000/api/some-endpoint' \
+  -H 'Authorization: Bearer your-token' \
+  --fail-with-body \
+  && echo '{"errorCode":"HAI0006","errorMessage":"Session terminated"}' \
+  | curl -X POST 'http://localhost:3000/api/mock-session-termination' \
+       -H 'Content-Type: application/json' \
+       -d @- \
+       --fail-with-body
+
+# For HAI4008 (Verified name call was unauthorized)
+curl -X GET 'http://localhost:3000/api/profiili/verified-name' \
+  -H 'Authorization: Bearer your-token' \
+  --fail-with-body \
+  && echo '{"errorCode":"HAI4008","errorMessage":"Verified name call was unauthorized"}' \
+  | curl -X POST 'http://localhost:3000/api/mock-session-termination' \
+       -H 'Content-Type: application/json' \
+       -d @- \
+       --fail-with-body
+```
+
+### 2. Mock Service Worker (MSW) Method
+
+Add a temporary mock in your development environment:
+
+```typescript
+// In your MSW handlers or test setup
+import { http, HttpResponse } from 'msw';
+
+const handlers = [
+  // Mock session termination for testing
+  http.get('/api/test-session-termination', () => {
+    return HttpResponse.json(
+      {
+        errorCode: 'HAI0006',
+        errorMessage: 'Session terminated',
+      },
+      { status: 401 },
+    );
+  }),
+
+  http.get('/api/test-verified-name-error', () => {
+    return HttpResponse.json(
+      {
+        errorCode: 'HAI4008',
+        errorMessage: 'Verified name call was unauthorized',
+      },
+      { status: 401 },
+    );
+  }),
+];
+```
+
+Then make requests to these endpoints in the browser console:
+
+```javascript
+// Test HAI0006
+fetch('/api/test-session-termination').catch(console.log);
+
+// Test HAI4008
+fetch('/api/test-verified-name-error').catch(console.log);
+```
+
+### 3. Backend Modification Method
+
+**Temporarily modify the backend** to return session termination errors:
+
+1. Find any endpoint handler in the backend
+2. Add a temporary condition to return 401 with the error codes:
+
+```java
+// Java/Spring example
+@GetMapping("/test-session-termination")
+public ResponseEntity<?> testSessionTermination() {
+    Map<String, String> error = new HashMap<>();
+    error.put("errorCode", "HAI0006");
+    error.put("errorMessage", "Session terminated");
+    return ResponseEntity.status(401).body(error);
+}
+```
+
+3. Call this endpoint from the UI
+4. **Remove the test endpoint** after testing
+
+### 4. Proxy/Network Intercept Method
+
+Use a tool like **Fiddler**, **Charles Proxy**, or **mitmproxy**:
+
+1. Configure your browser to use the proxy
+2. Set up a rule to intercept API requests
+3. Modify responses to return 401 with session termination error codes
+4. Test the UI behavior
+
+## Expected Behavior
+
+When testing, you should observe:
+
+1. **Notification appears** in the top-right corner with the message:
+   - Finnish: "Istunto on päättynyt. Sinut kirjataan automaattisesti ulos."
+   - English: "Your session has ended. You will be automatically logged out."
+   - Swedish: "Din session har avslutats. Du kommer att loggas ut automatiskt."
+
+2. **Notification characteristics**:
+   - Type: Info (blue)
+   - Auto-close: 5 seconds
+   - Not dismissible by user
+   - Appears in top-right position
+
+3. **Automatic logout**:
+   - Occurs 4 seconds after notification appears
+   - User is redirected to Helsinki Profiili logout page
+   - Session is properly cleared
+
+4. **Console logging**:
+   - Warning message: "Session terminated with error code: [code]. Logging out..."
+
+## Testing Different Scenarios
+
+1. **Test both error codes**: HAI0006 and HAI4008
+2. **Test with different languages**: Switch UI language and verify notification text
+3. **Test logout flow**: Verify user is properly logged out and redirected
+4. **Test other 401 errors**: Verify that other 401 responses don't trigger logout
+5. **Test non-401 errors**: Verify that non-401 responses with session error codes don't trigger logout
+
+## Troubleshooting
+
+- **Notification doesn't appear**: Check that SessionTerminationHandler is properly mounted within GlobalNotificationProvider
+- **Logout doesn't occur**: Verify that the OIDC client is available and logout handler is set
+- **Wrong language**: Check the i18n configuration and language setting
+- **Tests fail**: Ensure all mocks are properly set up and timing is handled correctly with fake timers

--- a/src/common/components/app/App.tsx
+++ b/src/common/components/app/App.tsx
@@ -17,6 +17,7 @@ import '../../../assets/styles/variables.css';
 import MaintenancePage from '../../../pages/staticPages/MaintenancePage';
 import AccessibleNavigationAnnouncer from '../NavigationAnnouncer';
 import { loginProviderProps } from '../../../domain/auth/loginProviderProps';
+import SessionTerminationHandler from '../../../domain/auth/components/SessionTerminationHandler';
 import siteSettings from './sitesettings.json';
 import { useTranslation } from 'react-i18next';
 import { useEffect, useState } from 'react';
@@ -86,6 +87,7 @@ function App({ matomoEnabled }: Readonly<{ matomoEnabled: boolean }>) {
                     <AccessibleNavigationAnnouncer />
                     <Layout>
                       <GlobalNotificationProvider>
+                        <SessionTerminationHandler />
                         <AppRoutes />
                         <GlobalNotification />
                         <CookieBanner />

--- a/src/common/components/datePicker/DatePicker.tsx
+++ b/src/common/components/datePicker/DatePicker.tsx
@@ -6,7 +6,7 @@ import { TooltipProps } from '../../types/tooltip';
 import { getInputErrorText } from '../../utils/form';
 import styles from './DatePicker.module.scss';
 import { convertFinnishDate, formatToFinnishDate, toEndOfDayUTCISO } from '../../utils/date';
-import { useGlobalNotification } from "../globalNotification/GlobalNotificationContext";
+import { useGlobalNotification } from '../globalNotification/GlobalNotificationContext';
 
 type PropTypes = {
   name: string;
@@ -38,7 +38,7 @@ const DatePicker: React.FC<React.PropsWithChildren<PropTypes>> = ({
   locale,
   onValueChange,
   hankeStartDate,
-  hankeEndDate
+  hankeEndDate,
 }) => {
   const { t } = useTranslation(['form', 'hakemus', 'common', 'validations']);
   const { control, setError, clearErrors, trigger, setValue } = useFormContext();
@@ -56,10 +56,12 @@ const DatePicker: React.FC<React.PropsWithChildren<PropTypes>> = ({
             if (isNaN(date.getTime())) return t('form:validations:invalidDate');
             if (minDate && date < minDate) return t('form:errors:dateTooEarly');
             if (maxDate && date > maxDate) return t('form:errors:dateTooLate');
-            if (hankeStartDate && date < hankeStartDate) return t('form:validations:dateBeforeProjectDate');
-            if (hankeEndDate && date > hankeEndDate) return t('form:validations:dateFutureProjectDate');
+            if (hankeStartDate && date < hankeStartDate)
+              return t('form:validations:dateBeforeProjectDate');
+            if (hankeEndDate && date > hankeEndDate)
+              return t('form:validations:dateFutureProjectDate');
             return true;
-          }
+          },
         }}
         render={({ field: { onChange, onBlur, value, ref }, fieldState: { error } }) => (
           <div className={styles.datePicker}>
@@ -106,9 +108,13 @@ const DatePicker: React.FC<React.PropsWithChildren<PropTypes>> = ({
                       autoClose: true,
                       autoCloseDuration: 5000,
                       label: t('hakemus:notifications:dateBeforeProjectDateLabel'),
-                      message: t('hakemus:notifications:dateBeforeProjectDateText', { date: formatToFinnishDate(hankeStartDate)}),
+                      message: t('hakemus:notifications:dateBeforeProjectDateText', {
+                        date: formatToFinnishDate(hankeStartDate),
+                      }),
                       type: 'error',
-                      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+                      closeButtonLabelText: t(
+                        'common:components:notification:closeButtonLabelText',
+                      ),
                     });
                     return;
                   }
@@ -125,9 +131,13 @@ const DatePicker: React.FC<React.PropsWithChildren<PropTypes>> = ({
                       autoClose: true,
                       autoCloseDuration: 5000,
                       label: t('hakemus:notifications:dateFutureProjectDateLabel'),
-                      message: t('hakemus:notifications:dateFutureProjectDateText', { date: formatToFinnishDate(hankeEndDate)}),
+                      message: t('hakemus:notifications:dateFutureProjectDateText', {
+                        date: formatToFinnishDate(hankeEndDate),
+                      }),
                       type: 'error',
-                      closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
+                      closeButtonLabelText: t(
+                        'common:components:notification:closeButtonLabelText',
+                      ),
                     });
                     return;
                   }

--- a/src/domain/api/api.test.ts
+++ b/src/domain/api/api.test.ts
@@ -1,0 +1,195 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import api, { setLogoutHandler } from './api';
+
+describe('API Session Termination', () => {
+  let mockLogoutHandler: jest.MockedFunction<() => void>;
+  const server = setupServer();
+
+  beforeAll(() => {
+    server.listen();
+  });
+
+  beforeEach(() => {
+    mockLogoutHandler = jest.fn();
+    setLogoutHandler(mockLogoutHandler);
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    setLogoutHandler(null);
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should call logout handler for HAI0006 error code', async () => {
+    const errorResponse = {
+      errorCode: 'HAI0006',
+      errorMessage: 'Session terminated',
+    };
+
+    server.use(
+      http.get('/api/test', () => {
+        return HttpResponse.json(errorResponse, { status: 401 });
+      }),
+    );
+
+    try {
+      await api.get('/test');
+    } catch (error) {
+      // Expected to throw
+    }
+
+    expect(mockLogoutHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call logout handler for HAI4008 error code', async () => {
+    const errorResponse = {
+      errorCode: 'HAI4008',
+      errorMessage: 'Verified name call was unauthorized',
+    };
+
+    server.use(
+      http.get('/api/test', () => {
+        return HttpResponse.json(errorResponse, { status: 401 });
+      }),
+    );
+
+    try {
+      await api.get('/test');
+    } catch (error) {
+      // Expected to throw
+    }
+
+    expect(mockLogoutHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call logout handler for other 401 errors', async () => {
+    const errorResponse = {
+      errorCode: 'OTHER_ERROR',
+      errorMessage: 'Some other unauthorized error',
+    };
+
+    server.use(
+      http.get('/api/test', () => {
+        return HttpResponse.json(errorResponse, { status: 401 });
+      }),
+    );
+
+    try {
+      await api.get('/test');
+    } catch (error) {
+      // Expected to throw
+    }
+
+    expect(mockLogoutHandler).not.toHaveBeenCalled();
+  });
+
+  it('should not call logout handler for 401 without error code', async () => {
+    server.use(
+      http.get('/api/test', () => {
+        return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+      }),
+    );
+
+    try {
+      await api.get('/test');
+    } catch (error) {
+      // Expected to throw
+    }
+
+    expect(mockLogoutHandler).not.toHaveBeenCalled();
+  });
+
+  it('should not call logout handler for non-401 errors', async () => {
+    const errorResponse = {
+      errorCode: 'HAI0006',
+      errorMessage: 'Session terminated',
+    };
+
+    server.use(
+      http.get('/api/test', () => {
+        return HttpResponse.json(errorResponse, { status: 500 });
+      }),
+    );
+
+    try {
+      await api.get('/test');
+    } catch (error) {
+      // Expected to throw
+    }
+
+    expect(mockLogoutHandler).not.toHaveBeenCalled();
+  });
+
+  it('should handle the case when no logout handler is set', async () => {
+    setLogoutHandler(null);
+
+    const errorResponse = {
+      errorCode: 'HAI0006',
+      errorMessage: 'Session terminated',
+    };
+
+    server.use(
+      http.get('/api/test', () => {
+        return HttpResponse.json(errorResponse, { status: 401 });
+      }),
+    );
+
+    // Should not throw an error even when logout handler is null
+    try {
+      await api.get('/test');
+    } catch (error) {
+      // Expected to throw the original error
+      expect(error).toBeDefined();
+    }
+
+    // No logout handler to call, so this should not throw
+  });
+
+  it('should still reject the promise after calling logout handler', async () => {
+    const errorResponse = {
+      errorCode: 'HAI0006',
+      errorMessage: 'Session terminated',
+    };
+
+    server.use(
+      http.get('/api/test', () => {
+        return HttpResponse.json(errorResponse, { status: 401 });
+      }),
+    );
+
+    await expect(api.get('/test')).rejects.toThrow();
+    expect(mockLogoutHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('should log warning message when session termination is detected', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const errorResponse = {
+      errorCode: 'HAI0006',
+      errorMessage: 'Session terminated',
+    };
+
+    server.use(
+      http.get('/api/test', () => {
+        return HttpResponse.json(errorResponse, { status: 401 });
+      }),
+    );
+
+    try {
+      await api.get('/test');
+    } catch (error) {
+      // Expected to throw
+    }
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Session terminated with error code: HAI0006. Logging out...',
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/domain/api/api.test.ts
+++ b/src/domain/api/api.test.ts
@@ -29,8 +29,11 @@ describe('API Session Termination', () => {
 
     try {
       await api.get('/test');
+      // Should not reach here
+      expect(true).toBe(false);
     } catch (error) {
-      // Expected to throw
+      // Expected to throw due to 401 error
+      expect(error).toBeDefined();
     }
 
     expect(mockLogoutHandler).toHaveBeenCalledTimes(1);
@@ -50,8 +53,11 @@ describe('API Session Termination', () => {
 
     try {
       await api.get('/test');
+      // Should not reach here
+      expect(true).toBe(false);
     } catch (error) {
-      // Expected to throw
+      // Expected to throw due to 401 error
+      expect(error).toBeDefined();
     }
 
     expect(mockLogoutHandler).toHaveBeenCalledTimes(1);
@@ -71,8 +77,11 @@ describe('API Session Termination', () => {
 
     try {
       await api.get('/test');
+      // Should not reach here
+      expect(true).toBe(false);
     } catch (error) {
-      // Expected to throw
+      // Expected to throw due to 401 error
+      expect(error).toBeDefined();
     }
 
     expect(mockLogoutHandler).not.toHaveBeenCalled();
@@ -87,8 +96,11 @@ describe('API Session Termination', () => {
 
     try {
       await api.get('/test');
+      // Should not reach here
+      expect(true).toBe(false);
     } catch (error) {
-      // Expected to throw
+      // Expected to throw due to 401 error
+      expect(error).toBeDefined();
     }
 
     expect(mockLogoutHandler).not.toHaveBeenCalled();
@@ -108,8 +120,11 @@ describe('API Session Termination', () => {
 
     try {
       await api.get('/test');
+      // Should not reach here
+      expect(true).toBe(false);
     } catch (error) {
-      // Expected to throw
+      // Expected to throw due to 401 error
+      expect(error).toBeDefined();
     }
 
     expect(mockLogoutHandler).not.toHaveBeenCalled();
@@ -132,6 +147,8 @@ describe('API Session Termination', () => {
     // Should not throw an error even when logout handler is null
     try {
       await api.get('/test');
+      // Should not reach here
+      expect(true).toBe(false);
     } catch (error) {
       // Expected to throw the original error
       expect(error).toBeDefined();
@@ -172,8 +189,11 @@ describe('API Session Termination', () => {
 
     try {
       await api.get('/test');
+      // Should not reach here
+      expect(true).toBe(false);
     } catch (error) {
-      // Expected to throw
+      // Expected to throw due to 401 error
+      expect(error).toBeDefined();
     }
 
     expect(consoleSpy).toHaveBeenCalledWith(

--- a/src/domain/api/api.test.ts
+++ b/src/domain/api/api.test.ts
@@ -7,7 +7,7 @@ describe('API Session Termination', () => {
   const server = setupServer();
 
   beforeAll(() => {
-    server.listen();
+    server.listen({ onUnhandledRequest: 'bypass' });
   });
 
   beforeEach(() => {

--- a/src/domain/api/api.test.ts
+++ b/src/domain/api/api.test.ts
@@ -1,14 +1,9 @@
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
+import { server } from '../mocks/test-server';
 import api, { setLogoutHandler } from './api';
 
 describe('API Session Termination', () => {
   let mockLogoutHandler: jest.MockedFunction<() => void>;
-  const server = setupServer();
-
-  beforeAll(() => {
-    server.listen({ onUnhandledRequest: 'bypass' });
-  });
 
   beforeEach(() => {
     mockLogoutHandler = jest.fn();
@@ -16,13 +11,8 @@ describe('API Session Termination', () => {
   });
 
   afterEach(() => {
-    server.resetHandlers();
     setLogoutHandler(null);
     jest.clearAllMocks();
-  });
-
-  afterAll(() => {
-    server.close();
   });
 
   it('should call logout handler for HAI0006 error code', async () => {

--- a/src/domain/api/api.ts
+++ b/src/domain/api/api.ts
@@ -3,7 +3,7 @@ import { getApiTokenFromStorage } from 'hds-react';
 import { publicEndpoints } from './publicEndpoints';
 
 // Session termination error codes that should trigger logout
-const SESSION_TERMINATION_ERROR_CODES = ['HAI0006', 'HAI4008'];
+const SESSION_TERMINATION_ERROR_CODES = new Set(['HAI0006', 'HAI4008']);
 
 // Global logout handler that can be set by the app
 let logoutHandler: (() => void) | null = null;
@@ -17,9 +17,9 @@ export function setLogoutHandler(handler: (() => void) | null) {
 function handleSessionTermination() {
   if (logoutHandler) {
     logoutHandler();
-  } else if (typeof window !== 'undefined') {
+  } else if (typeof globalThis.window !== 'undefined') {
     // Fallback: redirect to log out path
-    window.location.href = '/logout';
+    globalThis.window.location.href = '/logout';
   }
 }
 
@@ -68,7 +68,7 @@ api.interceptors.response.use(
       // Check for session termination error codes
       if (response.status === 401 && response.data?.errorCode) {
         const errorCode = response.data.errorCode;
-        if (SESSION_TERMINATION_ERROR_CODES.includes(errorCode)) {
+        if (SESSION_TERMINATION_ERROR_CODES.has(errorCode)) {
           // eslint-disable-next-line
           console.warn(`Session terminated with error code: ${errorCode}. Logging out...`);
           handleSessionTermination();

--- a/src/domain/api/api.ts
+++ b/src/domain/api/api.ts
@@ -2,6 +2,27 @@ import axios, { AxiosInstance, AxiosResponse, AxiosError, InternalAxiosRequestCo
 import { getApiTokenFromStorage } from 'hds-react';
 import { publicEndpoints } from './publicEndpoints';
 
+// Session termination error codes that should trigger logout
+const SESSION_TERMINATION_ERROR_CODES = ['HAI0006', 'HAI4008'];
+
+// Global logout handler that can be set by the app
+let logoutHandler: (() => void) | null = null;
+
+// Function to set the logout handler
+export function setLogoutHandler(handler: (() => void) | null) {
+  logoutHandler = handler;
+}
+
+// Function to handle session termination
+function handleSessionTermination() {
+  if (logoutHandler) {
+    logoutHandler();
+  } else if (typeof window !== 'undefined') {
+    // Fallback: redirect to log out path
+    window.location.href = '/logout';
+  }
+}
+
 const api: AxiosInstance = axios.create({
   baseURL: '/api',
 });
@@ -44,6 +65,17 @@ api.interceptors.response.use(
       request?: XMLHttpRequest;
     } = error;
     if (response) {
+      // Check for session termination error codes
+      if (response.status === 401 && response.data?.errorCode) {
+        const errorCode = response.data.errorCode;
+        if (SESSION_TERMINATION_ERROR_CODES.includes(errorCode)) {
+          // eslint-disable-next-line
+          console.warn(`Session terminated with error code: ${errorCode}. Logging out...`);
+          handleSessionTermination();
+          return Promise.reject(error);
+        }
+      }
+
       if (response.status >= 400 && response.status < 500) {
         // eslint-disable-next-line
         console.error(response.data?.data?.message);

--- a/src/domain/api/api.ts
+++ b/src/domain/api/api.ts
@@ -17,7 +17,7 @@ export function setLogoutHandler(handler: (() => void) | null) {
 function handleSessionTermination() {
   if (logoutHandler) {
     logoutHandler();
-  } else if (typeof globalThis.window !== 'undefined') {
+  } else if (globalThis.window !== undefined) {
     // Fallback: redirect to log out path
     globalThis.window.location.href = '/logout';
   }

--- a/src/domain/auth/components/SessionTerminationHandler.test.tsx
+++ b/src/domain/auth/components/SessionTerminationHandler.test.tsx
@@ -8,7 +8,7 @@ jest.mock('hds-react', () => ({
 }));
 
 jest.mock('react-i18next', () => ({
-  useTranslation: jest.fn(),
+  useTranslation: () => ({ t: (key: string) => key }),
 }));
 
 jest.mock('../../../common/components/globalNotification/GlobalNotificationContext', () => ({
@@ -20,18 +20,15 @@ jest.mock('../../api/api', () => ({
 }));
 
 import { useOidcClient } from 'hds-react';
-import { useTranslation } from 'react-i18next';
 import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
 
 const mockUseOidcClient = jest.mocked(useOidcClient);
-const mockUseTranslation = jest.mocked(useTranslation);
 const mockUseGlobalNotification = jest.mocked(useGlobalNotification);
 const mockSetLogoutHandler = jest.mocked(setLogoutHandler);
 
 describe('SessionTerminationHandler', () => {
   const mockLogout = jest.fn();
   const mockSetNotification = jest.fn();
-  const mockT = jest.fn((key: string) => key);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -39,10 +36,6 @@ describe('SessionTerminationHandler', () => {
     mockUseOidcClient.mockReturnValue({
       logout: mockLogout,
     } as unknown as ReturnType<typeof useOidcClient>);
-
-    mockUseTranslation.mockReturnValue({
-      t: mockT,
-    } as unknown as ReturnType<typeof useTranslation>);
 
     mockUseGlobalNotification.mockReturnValue({
       setNotification: mockSetNotification,

--- a/src/domain/auth/components/SessionTerminationHandler.test.tsx
+++ b/src/domain/auth/components/SessionTerminationHandler.test.tsx
@@ -1,0 +1,126 @@
+import { render } from '@testing-library/react';
+import SessionTerminationHandler from './SessionTerminationHandler';
+import { setLogoutHandler } from '../../api/api';
+
+// Mock the dependencies
+jest.mock('hds-react', () => ({
+  useOidcClient: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(),
+}));
+
+jest.mock('../../../common/components/globalNotification/GlobalNotificationContext', () => ({
+  useGlobalNotification: jest.fn(),
+}));
+
+jest.mock('../../api/api', () => ({
+  setLogoutHandler: jest.fn(),
+}));
+
+import { useOidcClient } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
+
+const mockUseOidcClient = jest.mocked(useOidcClient);
+const mockUseTranslation = jest.mocked(useTranslation);
+const mockUseGlobalNotification = jest.mocked(useGlobalNotification);
+const mockSetLogoutHandler = jest.mocked(setLogoutHandler);
+
+describe('SessionTerminationHandler', () => {
+  const mockLogout = jest.fn();
+  const mockSetNotification = jest.fn();
+  const mockT = jest.fn((key: string) => key);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseOidcClient.mockReturnValue({
+      logout: mockLogout,
+    } as unknown as ReturnType<typeof useOidcClient>);
+
+    mockUseTranslation.mockReturnValue({
+      t: mockT,
+    } as unknown as ReturnType<typeof useTranslation>);
+
+    mockUseGlobalNotification.mockReturnValue({
+      setNotification: mockSetNotification,
+      isOpen: false,
+      options: undefined,
+    });
+
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should set up logout handler on mount', () => {
+    render(<SessionTerminationHandler />);
+
+    expect(mockSetLogoutHandler).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('should clean up logout handler on unmount', () => {
+    const { unmount } = render(<SessionTerminationHandler />);
+
+    // Clear the initial call
+    mockSetLogoutHandler.mockClear();
+
+    unmount();
+
+    expect(mockSetLogoutHandler).toHaveBeenCalledWith(null);
+  });
+
+  it('should show notification and logout when handler is called', () => {
+    render(<SessionTerminationHandler />);
+
+    // Get the handler that was set
+    const logoutHandler = mockSetLogoutHandler.mock.calls[0][0] as () => void;
+
+    // Call the handler
+    logoutHandler();
+
+    // Should show notification
+    expect(mockSetNotification).toHaveBeenCalledWith(true, {
+      message: 'authentication:sessionTerminated',
+      type: 'info',
+      autoClose: true,
+      autoCloseDuration: 5000,
+      dismissible: false,
+    });
+
+    // Should not have called logout yet
+    expect(mockLogout).not.toHaveBeenCalled();
+
+    // Fast-forward time by 4 seconds
+    jest.advanceTimersByTime(4000);
+
+    // Now logout should be called
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call logout if oidcClient is not available', () => {
+    mockUseOidcClient.mockReturnValue(undefined as unknown as ReturnType<typeof useOidcClient>);
+
+    render(<SessionTerminationHandler />);
+
+    // Get the handler that was set
+    const logoutHandler = mockSetLogoutHandler.mock.calls[0][0] as () => void;
+
+    // Call the handler
+    logoutHandler();
+
+    // Should not show notification or call logout
+    expect(mockSetNotification).not.toHaveBeenCalled();
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it('should render nothing', () => {
+    const { container } = render(<SessionTerminationHandler />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/domain/auth/components/SessionTerminationHandler.tsx
+++ b/src/domain/auth/components/SessionTerminationHandler.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { useOidcClient } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+import { setLogoutHandler } from '../../api/api';
+import { useGlobalNotification } from '../../../common/components/globalNotification/GlobalNotificationContext';
+
+/**
+ * Component that sets up automatic logout handling for session termination errors.
+ * Must be rendered inside LoginProvider to access the OIDC client.
+ */
+export default function SessionTerminationHandler() {
+  const oidcClient = useOidcClient();
+  const { setNotification } = useGlobalNotification();
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    // Set up the logout handler that the API interceptor can use
+    const handleLogout = () => {
+      if (oidcClient) {
+        // Show notification to user before logout
+        setNotification(true, {
+          message: t('authentication:sessionTerminated'),
+          type: 'info',
+          autoClose: true,
+          autoCloseDuration: 5000,
+          dismissible: false,
+        });
+
+        // Give user time to read the notification before logout
+        setTimeout(() => {
+          oidcClient.logout();
+        }, 4000);
+      }
+    };
+
+    setLogoutHandler(handleLogout);
+
+    // Cleanup on unmount
+    return () => {
+      setLogoutHandler(null);
+    };
+  }, [oidcClient, setNotification, t]);
+
+  // This component doesn't render anything
+  return null;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,6 +11,7 @@
     "loggingOut": "Logging out...",
     "loggingInErrorLabel": "Error during log-in",
     "logoutError": "Error during log-out",
+    "sessionTerminated": "Your session has ended. You will be automatically logged out.",
     "noADPermissionHeading": "No access rights to Haitaton service",
     "noADPermissionText": "AD identification to Haitaton is only possible for the employees of Stara and the Urban Environment Division. <a>Log out</a> of Haitaton and attempt to login again via Suomi.fi authentication.",
     "noADUserNameHeading": "Login failed",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -11,6 +11,7 @@
     "loggingOut": "Kirjaudutaan ulos...",
     "loggingInErrorLabel": "Kirjautumisessa tapahtui virhe",
     "logoutError": "Uloskirjautumisessa tapahtui virhe",
+    "sessionTerminated": "Istunto on päättynyt. Sinut kirjataan automaattisesti ulos.",
     "noADPermissionHeading": "Ei käyttöoikeutta Haitaton-asiointiin",
     "noADPermissionText": "AD-tunnistautuminen Haitattomaan on mahdollista ainoastaan Kaupunkiympäristön ja Staran työntekijöille. <a>Kirjaudu ulos</a> Haitattomasta ja yritä uudelleen Suomi.fi-tunnistautumisen kautta.",
     "noADUserNameHeading": "Kirjautuminen epäonnistui",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -11,6 +11,7 @@
     "loggingOut": "Loggar ut...",
     "loggingInErrorLabel": "Ett fel uppstod vid inloggningen",
     "logoutError": "Ett fel uppstod vid utloggningen",
+    "sessionTerminated": "Din session har avslutats. Du kommer att loggas ut automatiskt.",
     "noADPermissionHeading": "Ingen användarrätt till Haitaton ärenden",
     "noADPermissionText": "AD-autentisering i Haitaton är möjlig endast för arbetstagare inom Stadsmiljön och Stara. <a>Logga ut</a> ur Haitaton och försök igen med Suomi.fi-identifieringen.",
     "noADUserNameHeading": "Inloggningen misslyckades",


### PR DESCRIPTION
# Description

Log out when the backend has logged out (via backchannel-logout call from Helsinki Profiili).
The logic of logging out this way is explained in TESTING_SESSION_TERMINATION.md

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3541

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

# Instructions for testing

See the backend PR: https://github.com/City-of-Helsinki/haitaton-backend/pull/1128

# Checklist:

- [x] I have written new tests (if applicable)
- [x] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

