### PR TITLE
change project save error in haittojenhallinta

### DIFF
--- a/src/domain/hanke/edit/HankeForm.tsx
+++ b/src/domain/hanke/edit/HankeForm.tsx
@@ -82,6 +82,7 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
     setValue,
     trigger,
     watch,
+    setFocus,
   } = formContext;
 
   const formValues = getValues();
@@ -254,6 +255,17 @@ const HankeForm: React.FC<React.PropsWithChildren<Props>> = ({
         closeButtonLabelText: t('common:components:notification:closeButtonLabelText'),
       });
       setActiveStepIndex(2);
+      return;
+    }
+// If hanke is public and there are missing fields dont save, focus on the first missing field
+    if (isHankePublic && haittojenHallintaErrors.length > 0) {
+      const firstErrorField = haittojenHallintaErrors[0]?.path;
+      setActiveStepIndex(3);
+      if (typeof firstErrorField === 'string') {
+        setTimeout(() => {
+          setFocus(firstErrorField as FieldPath<HankeDataFormState>);
+        }, 100);
+      }
       return;
     }
 


### PR DESCRIPTION
# Description

When editing a public-state project and trying to save, if there are empty fields in the haittojenhallinta, the focus will move to the first empty field and doesnt save.

### Jira Issue: https://helsinkisolutionoffice.atlassian.net/browse/HAI-3594

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X ] Other

# Instructions for testing

Please describe tests how this change or new feature can be tested.

# Checklist:

- [ ] I have written new tests (if applicable)
- [ ] I have ran the tests myself (if applicable)
- [ ] I have made necessary changes to the documentation, link to confluence
      or other location:

# Other relevant info

Please describe here if there is e.g. some requirements for this change or
other info that the tester/user needs to know.
