### PR TITLE
Fix flaky language_change_remove_area E2E test

### DIFF
--- a/e2e/language_change_remove_area.spec.ts
+++ b/e2e/language_change_remove_area.spec.ts
@@ -27,16 +27,16 @@ test('area removal persists across language change', async ({ page }) => {
   // The stepper button has an aria-label like: "Alueiden piirto. Vaihe 2/6. Valmis." — target it directly
   await page.locator('button[aria-label^="Alueiden piirto"]').first().click();
 
-  // Ensure the work area button exists
-  await expect(page.getByTestId('work-area-button')).toBeVisible();
+  // Ensure the work area tab exists
+  await expect(page.getByRole('tab').first()).toBeVisible();
 
   // Change language (Suomi -> English) via header language selector
   // Open language selector and pick English
   await page.getByRole('button', { name: 'Suomi' }).click();
   await page.getByText('English').click();
 
-  // After language change the work area button should still be present
-  await expect(page.getByTestId('work-area-button')).toBeVisible();
+  // After language change the work area tab should still be present
+  await expect(page.getByRole('tab').first()).toBeVisible();
 
   // Remove the work area using the table delete button (localized label)
   // Scope search to the tyoalueet table to target the correct delete button
@@ -53,13 +53,13 @@ test('area removal persists across language change', async ({ page }) => {
     .getByRole('button', { name: /Vahvista|Confirm|Remove/i })
     .click();
 
-  // Wait for the UI to reflect removal: no work-area buttons should remain
-  await expect(page.locator('[data-testid="work-area-button"]')).toHaveCount(0);
+  // Wait for the UI to reflect removal: no work-area tabs should remain
+  await expect(page.getByRole('tab')).toHaveCount(0);
 
   // Change language again (English -> Suomi)
   await page.getByRole('button', { name: 'English' }).click();
   await page.getByText('Suomi').click();
 
   // Verify the removal persisted after language change
-  await expect(page.locator('[data-testid="work-area-button"]')).toHaveCount(0);
+  await expect(page.getByRole('tab')).toHaveCount(0);
 });

--- a/src/domain/kaivuilmoitus/Areas.tsx
+++ b/src/domain/kaivuilmoitus/Areas.tsx
@@ -247,7 +247,7 @@ export default function Areas({ hankeData, hankkeenHakemukset, originalHakemus }
     selectedJohtoselvitysTunnukset?.includes(hakemus.applicationIdentifier!),
   );
 
-  const { tabRefs, setSelectedTabIndex, selectedTabIndex } = useSelectableTabs(applicationAreas, {
+  const { tabRefs, setSelectedTabIndex } = useSelectableTabs(applicationAreas, {
     selectLastTabOnChange: true,
   });
 
@@ -614,33 +614,6 @@ export default function Areas({ hankeData, hankkeenHakemukset, originalHakemus }
           </Box>
         )}
 
-        {/* Work area selection buttons (mirror tab selection) */}
-        {watchApplicationAreas.length > 0 && (
-          <Flex gap="var(--spacing-xs)" flexWrap="wrap" marginBottom="var(--spacing-s)">
-            {watchApplicationAreas.map((alue, index) => (
-              <button
-                key={`work-area-btn-${alue.hankealueId ?? index}`}
-                type="button"
-                data-testid="work-area-button"
-                data-selected={selectedTabIndex === index ? 'true' : 'false'}
-                aria-pressed={selectedTabIndex === index}
-                onClick={() => {
-                  setSelectedTabIndex(index);
-                }}
-                style={{
-                  border: '1px solid var(--color-black-40)',
-                  background:
-                    selectedTabIndex === index ? 'var(--color-bus-light)' : 'var(--color-black-5)',
-                  padding: '0.25rem 0.5rem',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                }}
-              >
-                {alue.name}
-              </button>
-            ))}
-          </Flex>
-        )}
         <Tabs>
           <TabList>
             {applicationAreas.map((alue, index) => {

--- a/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
+++ b/src/domain/kaivuilmoitus/KaivuilmoitusForm.test.tsx
@@ -1061,11 +1061,6 @@ test('Should be able to remove work areas', async () => {
   expect(screen.queryByText('Hankealue 2')).not.toBeInTheDocument();
 });
 
-// Skipped: No stable DOM attribute/class change currently exposed that reflects a work area button selection
-// interaction distinct from tab/stepper logic. Original assertion relied on internal class mutations that do not
-// occur; alternative tab selection check also not triggered by clicking the raw work area button in current
-// implementation. Once UI exposes a deterministic indicator (e.g. data-selected, aria-pressed, or tab change),
-// re-enable and adjust.
 test('Should highlight selected work area', async () => {
   const hankeData = hankkeet[1] as HankeData;
   const application = cloneDeep(applications[4] as Application<KaivuilmoitusData>);
@@ -1092,19 +1087,19 @@ test('Should highlight selected work area', async () => {
     <KaivuilmoitusContainer hankeData={hankeData} application={application} />,
   );
   await user.click(await screen.findByRole('button', { name: /alueiden/i }));
-  const workAreaButtons = await screen.findAllByTestId('work-area-button');
-  expect(workAreaButtons.length).toBeGreaterThan(1);
-  // Establish baseline: ensure first button becomes selected (hook effect may not have fired yet)
-  if (workAreaButtons[0].getAttribute('data-selected') !== 'true') {
-    await user.click(workAreaButtons[0]);
+  const tabs = await screen.findAllByRole('tab');
+  expect(tabs.length).toBeGreaterThan(1);
+  // Establish baseline: ensure first tab becomes selected (hook effect may not have fired yet)
+  if (tabs[0].getAttribute('aria-selected') !== 'true') {
+    await user.click(tabs[0]);
   }
-  await waitFor(() => expect(workAreaButtons[0].getAttribute('data-selected')).toBe('true'));
+  await waitFor(() => expect(tabs[0]).toHaveAttribute('aria-selected', 'true'));
   // Now select the second area and assert toggle
-  await user.click(workAreaButtons[1]);
+  await user.click(tabs[1]);
   await waitFor(() => {
-    const refreshed = screen.getAllByTestId('work-area-button');
-    expect(refreshed[1].getAttribute('data-selected')).toBe('true');
-    expect(refreshed[0].getAttribute('data-selected')).toBe('false');
+    const refreshed = screen.getAllByRole('tab');
+    expect(refreshed[1]).toHaveAttribute('aria-selected', 'true');
+    expect(refreshed[0]).toHaveAttribute('aria-selected', 'false');
   });
 });
 


### PR DESCRIPTION
## Summary
- `Areas.tsx` rendered two parallel UIs for the same work-area list: the real `Tab` (backed by react-hook-form's `useFieldArray`, reliable across step remounts) and a redundant custom `work-area-button` that existed solely to give `language_change_remove_area.spec.ts` a `data-testid` (backed by `watch()`, which doesn't reliably reflect state after the Areas step unmounts/remounts during wizard navigation).
- Removes the duplicate button and points both the E2E test and the `KaivuilmoitusForm` unit test at the already-accessible `Tab` element instead.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on touched files
- [x] Full unit suite passes (`yarn testCI`: 111 files, 917 tests)
- [x] `language_change_remove_area.spec.ts` E2E test verified passing manually (`yarn run playwright test --retries=0 --project=chromium --workers=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)